### PR TITLE
std::asyncのサンプルコードの増補

### DIFF
--- a/reference/future/async.md
+++ b/reference/future/async.md
@@ -48,38 +48,53 @@ namespace std {
 ```cpp
 #include <iostream>
 #include <future>
+#include <thread>
 
-int foo() { return 3; }
+int foo() { std::cout << "executes foo()\n"; return 3; }
 
 int main()
 {
   // 新たなスレッドで関数foo()を非同期実行
   {
+    std::cout << "invokes std::async(std::launch::async, foo)" << std::endl;
     std::future<int> f = std::async(std::launch::async, foo);
-
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::cout << "main thread: slept for 10 msec\n";
     // 非同期実行の結果を取得
     int result = f.get();
-    std::cout << result << std::endl;
+    std::cout << "foo() = " << result << std::endl;
   }
+
+  std::cout << std::endl;
 
   // 関数fを遅延状態で非同期実行
   {
     // この段階では関数foo()を実行しない
+    std::cout << "invokes std::async(std::launch::deferred, foo)" << std::endl;
     std::future<int> f = std::async(std::launch::deferred, foo);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::cout << "main thread: slept for 10 msec\n";
 
     // 非同期実行の結果を取得
     // この段階で関数foo()を実行
     int result = f.get();
-    std::cout << result << std::endl;
+    std::cout << "foo() = " << result << std::endl;
   }
+  return 0;
 }
 ```
-* async[color ff0000]
 
 ###出力
 ```
-3
-3
+invokes std::async(std::launch::async, foo)
+executes foo()
+main thread: slept for 10 msec
+foo() = 3
+
+invokes std::async(std::launch::deferred, foo)
+main thread: slept for 10 msec
+executes foo()
+foo() = 3
 ```
 
 ##バージョン
@@ -92,7 +107,7 @@ int main()
 - [GCC](/implementation#gcc.md): 
 - [GCC, C++0x mode](/implementation#gcc.md): 4.7.0
 - [ICC](/implementation#icc.md): ??
-- [Visual C++](/implementation#visual_cpp.md) ??
+- [Visual C++](/implementation#visual_cpp.md) 11.0
 
 
 ##参照


### PR DESCRIPTION
std::launch::asyncとstd::launch::deferredの違いをsleep_forを用いて実行結果から理解できるように変更しました。
