### PR TITLE
constexpr を追加

### DIFF
--- a/reference/random/discard_block_engine.md
+++ b/reference/random/discard_block_engine.md
@@ -95,8 +95,8 @@ public:
   sequence_generator(result_type = 0) {}
   void seed(result_type) {}
 
-  static result_type min() { return 0; }
-  static result_type max() { return 65537; }
+  constexpr static result_type min() { return 0; }
+  constexpr static result_type max() { return 65537; }
 
   result_type operator()()
   {


### PR DESCRIPTION
26.5.1.3/2 によると compile-time な値じゃないといけないらしい（元のコードは libc++ だとコンパイルエラーになる）。

のですが、compile-time というのが constexpr を付けるということでいいのかどうかいまいち自信が持てないのでチェックをお願いします。
