### PR TITLE
includesへのリンクがなかったので修正

### DIFF
--- a/reference/algorithm.md
+++ b/reference/algorithm.md
@@ -208,6 +208,7 @@ return distance(a, b);
 | [`set_intersection`](algorithm/set_intersection.md) | 2つのソート済み範囲の積集合を得る | |
 | [`set_difference`](algorithm/set_difference.md)     | 2つのソート済み範囲の差集合を得る | |
 | [`set_symmetric_difference`](algorithm/set_symmetric_difference.md) | 2つのソート済み範囲の互いに素な集合を得る | |
+| [`includes`](algorithm/includes.md) | 2つのソート済み範囲において、一方の範囲の要素がもう一方の範囲に全て含まれているかを判定する | |
 
 
 ###ヒープ


### PR DESCRIPTION
algorithm.mdにincludes.mdへのリンクがなかったため追加しました。
追加する位置が集合演算のテーブルで良いのか不安なためPRにさせていただきました。

参考: cppreference.comやcplusplus.comではmerge, inplace_merge, includes, set_* が1つのテーブルにまとまっているようでした