### PR TITLE
typedef を using に置換 (コードのみ)

### DIFF
--- a/article/lib/at_thread_exit.md
+++ b/article/lib/at_thread_exit.md
@@ -51,7 +51,7 @@ namespace std {
 
 template<class F>
 std::future<typename std::result_of<F()>::type> spawn_task(F f) {
-  typedef typename std::result_of<F()>::type result_type;
+  using result_type = typename std::result_of<F()>::type;
   std::packaged_task<result_type ()> task(std::move(f));
   std::future<result_type> future(task.get_future());
   std::thread th(std::move(task));
@@ -104,7 +104,7 @@ struct task_executor
 
 template<class F>
 std::future<typename std::result_of<F()>::type> spawn_task(F f) {
-  typedef typename std::result_of<F()>::type result_type;
+  using result_type = typename std::result_of<F()>::type;
   std::packaged_task<result_type ()> task(std::move(f));
   std::future<result_type> future(task.get_future());
   std::thread th(task_executor{}, std::move(task));

--- a/lang/cpp11/alias_templates.md
+++ b/lang/cpp11/alias_templates.md
@@ -61,7 +61,7 @@ void f(const std::vector<T>&) {} // コンパイルエラー！再定義と見�
 ```cpp
 template <class T>
 struct Vec {
-  using type = std::vector<T>;
+  typedef std::vector<T> type;
 };
 
 Vec<int>::type v;
@@ -75,13 +75,13 @@ v.push_back(3);
 template <class T>
 struct allocator {
   template <class U>
-  struct rebind { using other = allocator<U>; };
+  struct rebind { typedef allocator<U> other; };
 };
 
-using void_alloc = allocator<void>;
+typedef allocator<void> void_alloc;
 
 // int型をアロケートするallocator型を取得
-using int_alloc = void_alloc::rebind<int>::other;
+typedef void_alloc::rebind<int>::other int_alloc;
 ```
 
 前述した例での`::type`や、アロケータの例での`other`は冗長であり、必要とされることが多いこの機能には言語サポートが求められた。こういった経緯から、パラメータ化した型の別名付けが、言語機能としてサポートされることとなった。

--- a/lang/cpp11/alias_templates.md
+++ b/lang/cpp11/alias_templates.md
@@ -61,7 +61,7 @@ void f(const std::vector<T>&) {} // コンパイルエラー！再定義と見�
 ```cpp
 template <class T>
 struct Vec {
-  typedef std::vector<T> type;
+  using type = std::vector<T>;
 };
 
 Vec<int>::type v;
@@ -75,13 +75,13 @@ v.push_back(3);
 template <class T>
 struct allocator {
   template <class U>
-  struct rebind { typedef allocator<U> other; };
+  struct rebind { using other = allocator<U>; };
 };
 
-typedef allocator<void> void_alloc;
+using void_alloc = allocator<void>;
 
 // int型をアロケートするallocator型を取得
-typedef void_alloc::rebind<int>::other int_alloc;
+using int_alloc = void_alloc::rebind<int>::other;
 ```
 
 前述した例での`::type`や、アロケータの例での`other`は冗長であり、必要とされることが多いこの機能には言語サポートが求められた。こういった経緯から、パラメータ化した型の別名付けが、言語機能としてサポートされることとなった。

--- a/lang/cpp11/override_final.md
+++ b/lang/cpp11/override_final.md
@@ -327,7 +327,7 @@ struct X
 struct C {};
 struct A
 {
-  typedef int C;
+  using C = int;
 };
 
 struct B : A

--- a/lang/cpp11/right_angle_brackets.md
+++ b/lang/cpp11/right_angle_brackets.md
@@ -38,7 +38,7 @@ template<int I> struct X {
   static int const c = 2;
 };
 template<> struct X<0> {
-  typedef int c;
+  using c = int;
 };
 template<typename T> struct Y {
   static int const c = 3;

--- a/lang/cpp11/sfinae_expressions.md
+++ b/lang/cpp11/sfinae_expressions.md
@@ -97,10 +97,10 @@ template <class T> void h(Z<T::template TT>*){}
 struct A {};
 struct B { int Y; };
 struct C {
-  typedef int N;
+  using N = int;
 };
 struct D {
-  typedef int TT;
+  using TT = int;
 };
 
 int main() {

--- a/reference/algorithm/is_heap_until.md
+++ b/reference/algorithm/is_heap_until.md
@@ -64,7 +64,7 @@ before: is heap? false
 template<class RandomAccessIterator>
 RandomAccessIterator is_heap_until(RandomAccessIterator first, RandomAccessIterator last)
 {
-  typedef typename std::iterator_traits<RandomAccessIterator>::difference_type diff;
+  using diff = typename std::iterator_traits<RandomAccessIterator>::difference_type;
   for (diff len = last - first, p = 0, c = 1; c < len; ++c) {
     if (first[c] < first[p])
       return first + c;
@@ -78,7 +78,7 @@ template<class RandomAccessIterator, class Compare>
 RandomAccessIterator is_heap_until(RandomAccessIterator first, RandomAccessIterator last,
                                    Compare comp)
 {
-  typedef typename std::iterator_traits<RandomAccessIterator>::difference_type diff;
+  using diff = typename std::iterator_traits<RandomAccessIterator>::difference_type;
   for (diff len = last - first, p = 0, c = 1; c < len; ++c) {
     if (comp(first[c], first[p]))
       return first + c;

--- a/reference/algorithm/is_permutation.md
+++ b/reference/algorithm/is_permutation.md
@@ -104,7 +104,7 @@ bool is_permutation(ForwardIterator1 first1, ForwardIterator1 last1,
     return true;
   auto last2 = std::next(first2, std::distance(first1, last1));
 
-  typedef typename std::iterator_traits<ForwardIterator1>::value_type value_type;
+  using value_type = typename std::iterator_traits<ForwardIterator1>::value_type;
   auto upred = [&pred, &first1](const value_type& x) { return pred(*first1, x); };
   for (; first1 != last1; ++first1) {
     auto count2 = std::count_if(first2, last2, upred);

--- a/reference/algorithm/lower_bound.md
+++ b/reference/algorithm/lower_bound.md
@@ -85,7 +85,7 @@ template<class ForwardIterator, class T, class Compare>
 ForwardIterator
 lower_bound(ForwardIterator first, ForwardIterator last, const T& value, Compare comp)
 {
-  typedef typename std::iterator_traits<ForwardIterator>::difference_type diff;
+  using diff = typename std::iterator_traits<ForwardIterator>::difference_type;
   for (diff len = std::distance(first, last); len != 0; ) {
     diff half = len / 2;
     ForwardIterator mid = first;

--- a/reference/algorithm/make_heap.md
+++ b/reference/algorithm/make_heap.md
@@ -66,8 +66,8 @@ int main()
 template <class RandomAccessIterator>
 void make_heap(RandomAccessIterator first, RandomAccessIterator last)
 {
-  typedef typename std::iterator_traits<RandomAccessIterator>::difference_type difference_type;
-  typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
+  using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+  using value_type      = typename std::iterator_traits<RandomAccessIterator>::value_type;
 
   const difference_type len = last - first;
   for (difference_type top = len / 2 - 1; top >= 0; --top) {
@@ -88,8 +88,8 @@ void make_heap(RandomAccessIterator first, RandomAccessIterator last)
 template <class RandomAccessIterator, class Compare>
 void make_heap(RandomAccessIterator first, RandomAccessIterator last, Compare comp)
 {
-  typedef typename std::iterator_traits<RandomAccessIterator>::difference_type difference_type;
-  typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
+  using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+  using value_type      = typename std::iterator_traits<RandomAccessIterator>::value_type;
 
   const difference_type len = last - first;
   for (difference_type top = len / 2 - 1; top >= 0; --top) {

--- a/reference/algorithm/pop_heap.md
+++ b/reference/algorithm/pop_heap.md
@@ -76,8 +76,8 @@ int main()
 template <class RandomAccessIterator>
 void pop_heap(RandomAccessIterator first, RandomAccessIterator last)
 {
-  typedef typename std::iterator_traits<RandomAccessIterator>::difference_type difference_type;
-  typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
+  using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+  using value_type      = typename std::iterator_traits<RandomAccessIterator>::value_type;
   --last;
   difference_type len = last - first;
   if (len > 0) {
@@ -99,8 +99,8 @@ void pop_heap(RandomAccessIterator first, RandomAccessIterator last)
 template <class RandomAccessIterator, class Compare>
 void pop_heap(RandomAccessIterator first, RandomAccessIterator last, Compare comp)
 {
-  typedef typename std::iterator_traits<RandomAccessIterator>::difference_type difference_type;
-  typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
+  using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+  using value_type      = typename std::iterator_traits<RandomAccessIterator>::value_type;
   --last;
   difference_type len = last - first;
   if (len > 0) {

--- a/reference/algorithm/push_heap.md
+++ b/reference/algorithm/push_heap.md
@@ -77,8 +77,8 @@ int main()
 template <class RandomAccessIterator>
 void push_heap(RandomAccessIterator first, RandomAccessIterator last)
 {
-  typedef typename std::iterator_traits<RandomAccessIterator>::difference_type difference_type;
-  typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
+  using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+  using value_type      = typename std::iterator_traits<RandomAccessIterator>::value_type;
   difference_type c = last - first - 1;
   value_type v = std::move(first[c]);
   while (c > 0) {
@@ -94,8 +94,8 @@ void push_heap(RandomAccessIterator first, RandomAccessIterator last)
 template <class RandomAccessIterator, class Compare>
 void push_heap(RandomAccessIterator first, RandomAccessIterator last, Compare comp)
 {
-  typedef typename std::iterator_traits<RandomAccessIterator>::difference_type difference_type;
-  typedef typename std::iterator_traits<RandomAccessIterator>::value_type value_type;
+  using difference_type = typename std::iterator_traits<RandomAccessIterator>::difference_type;
+  using value_type      = typename std::iterator_traits<RandomAccessIterator>::value_type;
 
   difference_type c = last - first - 1;
   value_type v = std::move(first[c]);

--- a/reference/algorithm/shuffle.md
+++ b/reference/algorithm/shuffle.md
@@ -74,10 +74,10 @@ template <class RandomAccessIterator, class UniformRandomNumberGenerator>
 void shuffle(RandomAccessIterator first, RandomAccessIterator last, UniformRandomNumberGenerator&& g) {
   if (first == last) return;
 
-  typedef typename iterator_traits<RandomAccessIterator>::difference_type distance_type;
-  typedef typename make_unsigned<distance_type>::type                     unsigned_type;
-  typedef typename uniform_int_distribution<unsigned_type>                distribute_type;
-  typedef typename distribute_type::param_type                            param_type;
+  using distance_type   = typename iterator_traits<RandomAccessIterator>::difference_type;
+  using unsigned_type   = typename make_unsigned<distance_type>::type;
+  using distribute_type = typename uniform_int_distribution<unsigned_type>;
+  using param_type      = typename distribute_type::param_type;
 
   distribute_type d;
   for (auto it = first + 1; it != last; ++it)

--- a/reference/algorithm/upper_bound.md
+++ b/reference/algorithm/upper_bound.md
@@ -85,7 +85,7 @@ template<class ForwardIterator, class T, class Compare>
 ForwardIterator
 upper_bound(ForwardIterator first, ForwardIterator last, const T& value, Compare comp)
 {
-  typedef typename std::iterator_traits<ForwardIterator>::difference_type diff;
+  using diff = typename std::iterator_traits<ForwardIterator>::difference_type;
   for (diff len = std::distance(first, last); len != 0; ) {
     diff half = len / 2;
     ForwardIterator mid = first;

--- a/reference/array/tuple_element.md
+++ b/reference/array/tuple_element.md
@@ -11,7 +11,7 @@ namespace std {
   template <size_t I, class T, size_t N>
   struct tuple_element<I, array<T, N>> {
     static_assert(I < N, implementation-defined);
-    typedef T type;
+    using type = T;
   }
 }
 ```

--- a/reference/cfenv/fexcept_t.md
+++ b/reference/cfenv/fexcept_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef implementation-defined fexcept_t;
+  using fexcept_t = implementation-defined;
 }
 ```
 

--- a/reference/chrono/duration/max.md
+++ b/reference/chrono/duration/max.md
@@ -26,7 +26,7 @@ using std::micro;
 
 int main()
 {
-  typedef duration<int, micro> microseconds;
+  using microseconds = duration<int, micro>;
 
   microseconds m = microseconds::max();
   std::cout << m.count() << std::endl;

--- a/reference/chrono/duration/min.md
+++ b/reference/chrono/duration/min.md
@@ -26,7 +26,7 @@ using std::micro;
 
 int main()
 {
-  typedef duration<int, micro> microseconds;
+  using microseconds = duration<int, micro>;
 
   microseconds m = microseconds::min();
   std::cout << m.count() << std::endl;

--- a/reference/chrono/duration/op_divide.md
+++ b/reference/chrono/duration/op_divide.md
@@ -35,7 +35,7 @@ namespace chrono {
 - (1)
 
 ```cpp
-typedef duration<typename common_type<Rep1, Rep2>::type, Period> cd;
+using cd = duration<typename common_type<Rep1, Rep2>::type, Period>;
 return cd(cd(d).count() / s);
 ```
 * duration[link /reference/chrono/duration.md]
@@ -45,7 +45,7 @@ return cd(cd(d).count() / s);
 - (2)
 
 ```cpp
-typedef typename common_type<Rep1, Rep2>::type cd;
+using cd = typename common_type<Rep1, Rep2>::type;
 return cd(lhs).count() / cd(rhs).count();
 ```
 * common_type[link /reference/type_traits/common_type.md]

--- a/reference/chrono/duration/op_equal.md
+++ b/reference/chrono/duration/op_equal.md
@@ -22,7 +22,7 @@ namespace chrono {
 2つの[`duration`](/reference/chrono/duration.md)の単位を合わせた上で、[`count()`](/reference/chrono/duration/count.md)の等値比較を行う。
 
 ```cpp
-typedef common_type<decltype(lhs), decltype(rhs)>::type ct;
+using ct = common_type<decltype(lhs), decltype(rhs)>::type;
 return ct(lhs).count() == ct(rhs).count();
 ```
 * common_type[link /reference/type_traits/common_type.md]

--- a/reference/chrono/duration/op_greater.md
+++ b/reference/chrono/duration/op_greater.md
@@ -22,7 +22,7 @@ namespace chrono {
 2つの[`duration`](/reference/chrono/duration.md)の単位を合わせた上で、[`count()`](/reference/chrono/duration/count.md)の比較を行う。
 
 ```cpp
-typedef common_type<decltype(lhs), decltype(rhs)>::type ct;
+using ct = common_type<decltype(lhs), decltype(rhs)>::type;
 return ct(lhs).count() > ct(rhs).count();
 ```
 * common_type[link /reference/type_traits/common_type.md]

--- a/reference/chrono/duration/op_greater_equal.md
+++ b/reference/chrono/duration/op_greater_equal.md
@@ -22,7 +22,7 @@ namespace chrono {
 2つの[`duration`](/reference/chrono/duration.md)の単位を合わせた上で[`count()`](/reference/chrono/duration/count.md)の比較を行う。
 
 ```cpp
-typedef common_type<decltype(lhs), decltype(rhs)>::type ct;
+using ct = common_type<decltype(lhs), decltype(rhs)>::type;
 return ct(lhs).count() < ct(rhs).count();
 ```
 * common_type[link /reference/type_traits/common_type.md]

--- a/reference/chrono/duration/op_less.md
+++ b/reference/chrono/duration/op_less.md
@@ -22,7 +22,7 @@ namespace chrono {
 2つの[`duration`](/reference/chrono/duration.md)の単位を合わせた上で、[`count()`](/reference/chrono/duration/count.md)の比較を行う。
 
 ```cpp
-typedef common_type<decltype(lhs), decltype(rhs)>::type ct;
+using ct = common_type<decltype(lhs), decltype(rhs)>::type;
 return ct(lhs).count() < ct(rhs).count();
 ```
 * common_type[link /reference/type_traits/common_type.md]

--- a/reference/chrono/duration/op_less_equal.md
+++ b/reference/chrono/duration/op_less_equal.md
@@ -22,7 +22,7 @@ namespace chrono {
 2つの[`duration`](/reference/chrono/duration.md)の単位を合わせた上で、[`count()`](/reference/chrono/duration/count.md)の比較を行う。
 
 ```cpp
-typedef common_type<decltype(lhs), decltype(rhs)>::type ct;
+using ct = common_type<decltype(lhs), decltype(rhs)>::type;
 return ct(lhs).count() <= ct(rhs).count();
 ```
 * common_type[link /reference/type_traits/common_type.md]

--- a/reference/chrono/duration/op_modulo.md
+++ b/reference/chrono/duration/op_modulo.md
@@ -34,7 +34,7 @@ durationの剰余演算を行う
 - (1)
 
 ```cpp
-typedef duration<typename common_type<Rep1, Rep2>::type, Period> cd;
+using cd = duration<typename common_type<Rep1, Rep2>::type, Period>;
 return cd(cd(d).count() % s);
 ```
 * duration[link /reference/chrono/duration.md]
@@ -44,7 +44,7 @@ return cd(cd(d).count() % s);
 - (2)
 
 ```cpp
-typedef duration<typename common_type<Rep1, Rep2>::type, Period> cd;
+using cd = duration<typename common_type<Rep1, Rep2>::type, Period>;
 return cd(cd(lhs).count() % cd(rhs).count());
 ```
 * duration[link /reference/chrono/duration.md]

--- a/reference/chrono/duration/op_multiply.md
+++ b/reference/chrono/duration/op_multiply.md
@@ -33,7 +33,7 @@ durationの乗算を行う
 
 ##戻り値
 ```cpp
-typedef duration<typename common_type<Rep1, Rep2>::type, Period> cd;
+using cd = duration<typename common_type<Rep1, Rep2>::type, Period>;
 return cd(cd(d).count() * s);
 ```
 * duration[link /reference/chrono/duration.md]

--- a/reference/chrono/duration/zero.md
+++ b/reference/chrono/duration/zero.md
@@ -26,7 +26,7 @@ using std::micro;
 
 int main()
 {
-  typedef duration<int, micro> microseconds;
+  using microseconds = duration<int, micro>;
 
   microseconds m = microseconds::zero();
   std::cout << m.count() << std::endl;

--- a/reference/chrono/hours.md
+++ b/reference/chrono/hours.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
 namespace chrono {
-  typedef duration<最低でも23ビットを持つ符号付き整数型, ratio<3600>> hours;
+  using hours = duration<最低でも23ビットを持つ符号付き整数型, ratio<3600>>;
 }}
 ```
 * duration[link /reference/chrono/duration.md]

--- a/reference/chrono/microseconds.md
+++ b/reference/chrono/microseconds.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
 namespace chrono {
-  typedef duration<最低でも55ビットを持つ符号付き整数型, micro> microseconds;
+  using microseconds = duration<最低でも55ビットを持つ符号付き整数型, micro>;
 }}
 ```
 * duration[link /reference/chrono/duration.md]

--- a/reference/chrono/milliseconds.md
+++ b/reference/chrono/milliseconds.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
 namespace chrono {
-  typedef duration<最低でも45ビットを持つ符号付き整数型, milli> milliseconds;
+  using milliseconds = duration<最低でも45ビットを持つ符号付き整数型, milli>;
 }}
 ```
 * duration[link /reference/chrono/duration.md]

--- a/reference/chrono/minutes.md
+++ b/reference/chrono/minutes.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
 namespace chrono {
-  typedef duration<最低でも29ビットを持つ符号付き整数型, ratio<60>> minutes;
+  using minutes = duration<最低でも29ビットを持つ符号付き整数型, ratio<60>>;
 }}
 ```
 * duration[link /reference/chrono/duration.md]

--- a/reference/chrono/nanoseconds.md
+++ b/reference/chrono/nanoseconds.md
@@ -8,7 +8,7 @@
 namespace std {
 
 namespace chrono {
-  typedef duration<最低でも64ビットを持つ符号付き整数型, nano> nanoseconds;
+  using nanoseconds = duration<最低でも64ビットを持つ符号付き整数型, nano>;
 }}
 ```
 * duration[link /reference/chrono/duration.md]

--- a/reference/chrono/op_minus.md
+++ b/reference/chrono/op_minus.md
@@ -50,7 +50,7 @@ namespace chrono {
 - (1)
 
 ```cpp
-typedef common_type<decltype(lhs), decltype(rhs)> cd;
+using cd = common_type<decltype(lhs), decltype(rhs)>;
 return cd(cd(lhs).count() - cd(rhs).count());
 ```
 * common_type[link /reference/type_traits/common_type.md]

--- a/reference/chrono/op_plus.md
+++ b/reference/chrono/op_plus.md
@@ -50,7 +50,7 @@ namespace chrono {
 - (1)
 
 ```cpp
-typedef common_type<decltype(lhs), decltype(rhs)> cd;
+using cd = common_type<decltype(lhs), decltype(rhs)>;
 return cd(cd(lhs).count() + cd(rhs).count());
 ```
 * common_type[link /reference/type_traits/common_type.md]
@@ -59,7 +59,7 @@ return cd(cd(lhs).count() + cd(rhs).count());
 - (2)
 
 ```cpp
-typedef time_point<Clock, common_type<decltype(lhs), decltype(rhs)>> ct;
+using ct = time_point<Clock, common_type<decltype(lhs), decltype(rhs)>>;
 return ct(lhs) += rhs;
 ```
 * time_point[link time_point.md]

--- a/reference/chrono/seconds.md
+++ b/reference/chrono/seconds.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
 namespace chrono {
-  typedef duration<最低でも35ビットを持つ符号付き整数型> seconds;
+  using seconds = duration<最低でも35ビットを持つ符号付き整数型>;
 }}
 ```
 * duration[link /reference/chrono/duration.md]

--- a/reference/chrono/time_point_cast.md
+++ b/reference/chrono/time_point_cast.md
@@ -39,8 +39,8 @@ using namespace std::chrono;
 
 int main()
 {
-  typedef time_point<system_clock, milliseconds> MTimePoint;
-  typedef time_point<system_clock, seconds>      STimePoint;
+  using MTimePoint = time_point<system_clock, milliseconds>;
+  using STimePoint = time_point<system_clock, seconds>;
 
   MTimePoint mp(milliseconds(1100));
 

--- a/reference/cmath/double_t.md
+++ b/reference/cmath/double_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef implementation-defined double_t;
+  using double_t = implementation-defined;
 }
 ```
 

--- a/reference/cmath/float_t.md
+++ b/reference/cmath/float_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef implementation-defined float_t;
+  using float_t = implementation-defined;
 }
 ```
 

--- a/reference/cstddef/max_align_t.md
+++ b/reference/cstddef/max_align_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef implementation-defined max_align_t;
+  using max_align_t = implementation-defined;
 }
 ```
 

--- a/reference/cstddef/nullptr_t.md
+++ b/reference/cstddef/nullptr_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef decltype(nullptr) nullptr_t;
+  using nullptr_t = decltype(nullptr);
 }
 ```
 

--- a/reference/cstddef/ptrdiff_t.md
+++ b/reference/cstddef/ptrdiff_t.md
@@ -5,7 +5,7 @@
 
 ```cpp
 namespace std {
-  typedef implementation-defined ptrdiff_t;
+  using ptrdiff_t = implementation-defined;
 }
 ```
 

--- a/reference/cstddef/size_t.md
+++ b/reference/cstddef/size_t.md
@@ -5,7 +5,7 @@
 
 ```cpp
 namespace std {
-  typedef implementation-defined size_t;
+  using size_t = implementation-defined;
 }
 ```
 

--- a/reference/cstdint/int16_t.md
+++ b/reference/cstdint/int16_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int16_t;
+  using int16_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int32_t.md
+++ b/reference/cstdint/int32_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int32_t;
+  using int32_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int64_t.md
+++ b/reference/cstdint/int64_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int64_t;
+  using int64_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int8_t.md
+++ b/reference/cstdint/int8_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int8_t;
+  using int8_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int_fast16_t.md
+++ b/reference/cstdint/int_fast16_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int_fast16_t;
+  using int_fast16_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int_fast32_t.md
+++ b/reference/cstdint/int_fast32_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int_fast32_t;
+  using int_fast32_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int_fast64_t.md
+++ b/reference/cstdint/int_fast64_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int_fast64_t;
+  using int_fast64_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int_fast8_t.md
+++ b/reference/cstdint/int_fast8_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int_fast8_t;
+  using int_fast8_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int_least16_t.md
+++ b/reference/cstdint/int_least16_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int_least16_t;
+  using int_least16_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int_least32_t.md
+++ b/reference/cstdint/int_least32_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int_least32_t;
+  using int_least32_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int_least64_t.md
+++ b/reference/cstdint/int_least64_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int_least64_t;
+  using int_least64_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/int_least8_t.md
+++ b/reference/cstdint/int_least8_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type int_least8_t;
+  using int_least8_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/intmax_t.md
+++ b/reference/cstdint/intmax_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type intmax_t;
+  using intmax_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/intptr_t.md
+++ b/reference/cstdint/intptr_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef signed-integer-type intptr_t;
+  using intptr_t = signed-integer-type;
 }
 ```
 * signed-integer-type[italic]

--- a/reference/cstdint/uint16_t.md
+++ b/reference/cstdint/uint16_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint16_t;
+  using uint16_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint32_t.md
+++ b/reference/cstdint/uint32_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint32_t;
+  using uint32_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint64_t.md
+++ b/reference/cstdint/uint64_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint64_t;
+  using uint64_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint8_t.md
+++ b/reference/cstdint/uint8_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint8_t;
+  using uint8_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint_fast16_t.md
+++ b/reference/cstdint/uint_fast16_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint_fast16_t;
+  using uint_fast16_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint_fast32_t.md
+++ b/reference/cstdint/uint_fast32_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint_fast32_t;
+  using uint_fast32_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint_fast64_t.md
+++ b/reference/cstdint/uint_fast64_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint_fast64_t;
+  using uint_fast64_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint_fast8_t.md
+++ b/reference/cstdint/uint_fast8_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint_fast8_t;
+  using uint_fast8_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint_least16_t.md
+++ b/reference/cstdint/uint_least16_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint_least16_t;
+  using uint_least16_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint_least32_t.md
+++ b/reference/cstdint/uint_least32_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint_least32_t;
+  using uint_least32_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint_least64_t.md
+++ b/reference/cstdint/uint_least64_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint_least64_t;
+  using uint_least64_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uint_least8_t.md
+++ b/reference/cstdint/uint_least8_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uint_least8_t;
+  using uint_least8_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uintmax_t.md
+++ b/reference/cstdint/uintmax_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uintmax_t;
+  using uintmax_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/cstdint/uintptr_t.md
+++ b/reference/cstdint/uintptr_t.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unsigned-integer-type uintptr_t;
+  using uintptr_t = unsigned-integer-type;
 }
 ```
 * unsigned-integer-type[italic]

--- a/reference/exception/exception_ptr.md
+++ b/reference/exception/exception_ptr.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef unspecified exception_ptr;
+  using exception_ptr = unspecified;
 }
 ```
 * unspecified[italic]

--- a/reference/exception/get_terminate.md
+++ b/reference/exception/get_terminate.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef void (*terminate_handler)();
+  using terminate_handler = void(*)();
   terminate_handler get_terminate() noexcept;
 }
 ```

--- a/reference/exception/get_unexpected.md
+++ b/reference/exception/get_unexpected.md
@@ -7,7 +7,7 @@
 
 ```cpp
 namespace std {
-  typedef void (*unexpected_handler)();
+  using unexpected_handler = void(*)();
   unexpected_handler get_unexpected() noexcept;
 }
 ```

--- a/reference/exception/set_terminate.md
+++ b/reference/exception/set_terminate.md
@@ -5,7 +5,7 @@
 
 ```cpp
 namespace std {
-  typedef void (*terminate_handler)();
+  using terminate_handler = void(*)();
   terminate_handler set_terminate(terminate_handler f) noexcept;
 }
 ```

--- a/reference/exception/set_unexpected.md
+++ b/reference/exception/set_unexpected.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef void (*unexpected_handler)();
+  using unexpected_handler = void(*)();
   unexpected_handler set_unexpected (unexpected_handler f) throw();
 }
 ```

--- a/reference/fstream/basic_filebuf.md
+++ b/reference/fstream/basic_filebuf.md
@@ -8,8 +8,8 @@ namespace std {
   template<class CharT, class Traits = char_traits<CharT>>
   class basic_filebuf : public basic_streambuf<CharT, Traits> { …… };
 
-  typedef basic_filebuf<char> filebuf;
-  typedef basic_filebuf<wchar_t> wfilebuf;
+  using filebuf  = basic_filebuf<char>;
+  using wfilebuf = basic_filebuf<wchar_t>;
 }
 ```
 * char_traits[link ../string/char_traits.md]

--- a/reference/fstream/basic_fstream.md
+++ b/reference/fstream/basic_fstream.md
@@ -8,8 +8,8 @@ namespace std {
   template <class CharT, class Traits = char_traits<CharT>>
   class basic_fstream : public basic_iostream<CharT, Traits>;
 
-  typedef basic_fstream<char>    fstream;
-  typedef basic_fstream<wchar_t> wfstream;
+  using fstream  = basic_fstream<char>;
+  using wfstream = basic_fstream<wchar_t>;
 }
 ```
 * char_traits[link /reference/string/char_traits.md]

--- a/reference/functional/bind.md
+++ b/reference/functional/bind.md
@@ -26,7 +26,7 @@ namespace std {
 引数を部分束縛された [<i>Callable</i>](callable.md) オブジェクト。このオブジェクトは、次のような関数オブジェクトとして扱うことができる：
 ```cpp
 struct bound_function_type {
-  typedef unspecified result_type;
+  using result_type = unspecified;
   template <class... UnBoundArgs>
   unspecified operator ()(UnBoundArgs&&... unbound_args) const;
 };

--- a/reference/functional/bit_and.md
+++ b/reference/functional/bit_and.md
@@ -10,18 +10,18 @@ namespace std {
   template <typename T>
   struct bit_and {
     T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // C++14 から（operator() が constexpr、テンプレート引数にデフォルトが指定された）
   template <typename T = void>
   struct bit_and {
     constexpr T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // テンプレート引数が void（デフォルト）の場合の特殊化（operator() が関数テンプレート）
@@ -30,7 +30,7 @@ namespace std {
     template <typename T, typename U>
     constexpr auto operator()(const T& t, const U& u) const
       -> decltype(forward<T>(t) & forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/bit_not.md
+++ b/reference/functional/bit_not.md
@@ -9,8 +9,8 @@ namespace std {
   template <typename T = void>
   struct bit_not {
     constexpr T operator()(const T& x) const;
-    typedef T argument_type;
-    typedef T result_type;
+    using argument_type = T;
+    using result_type   = T;
   };
 
   template <>
@@ -18,7 +18,7 @@ namespace std {
     template <typename T>
     constexpr auto operator()(T&& t) const
       -> decltype(~forward<T>(t));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/bit_or.md
+++ b/reference/functional/bit_or.md
@@ -10,18 +10,18 @@ namespace std {
   template <typename T>
   struct bit_or {
     T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // C++14 から（operator() が constexpr、テンプレート引数にデフォルトが指定された）
   template <typename T = void>
   struct bit_or {
     constexpr T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // テンプレート引数が void（デフォルト）の場合の特殊化（operator() が関数テンプレート）
@@ -30,7 +30,7 @@ namespace std {
     template <typename T, typename U>
     constexpr auto operator()(const T& t, const U& u) const
       -> decltype(forward<T>(t) | forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/bit_xor.md
+++ b/reference/functional/bit_xor.md
@@ -10,18 +10,18 @@ namespace std {
   template <typename T>
   struct bit_xor {
     T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // C++14 から（operator() が constexpr、テンプレート引数にデフォルトが指定された）
   template <typename T = void>
   struct bit_xor {
     constexpr T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // テンプレート引数が void（デフォルト）の場合の特殊化（operator() が関数テンプレート）
@@ -30,7 +30,7 @@ namespace std {
     template <typename T, typename U>
     constexpr auto operator()(const T& t, const U& u) const
       -> decltype(forward<T>(t) | forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/divides.md
+++ b/reference/functional/divides.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct divides {
     T operator ()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // C++14
   template <typename T = void>
   struct divides {
     constexpr T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <>
   struct divides<void> {
     template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) / std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/equal_to.md
+++ b/reference/functional/equal_to.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct equal_to {
     bool operator ()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   // C++14
   template <class T = void>
   struct equal_to {
     constexpr bool operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <>
   struct equal_to<void> {
     template <class T, class U> auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) == std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/greater.md
+++ b/reference/functional/greater.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct greater {
     bool operator ()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   // C++14
   template <class T = void>
   struct greater {
     constexpr bool operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <>
   struct greater<void> {
     template <class T, class U> auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) > std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/greater_equal.md
+++ b/reference/functional/greater_equal.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct greater_equal {
     bool operator ()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   // C++14
   template <class T = void>
   struct greater_equal {
     constexpr bool operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <>
   struct greater_equal<void> {
     template <class T, class U> auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) >= std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/less.md
+++ b/reference/functional/less.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct less {
     bool operator ()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   // C++14
   template <class T = void>
   struct less {
     constexpr bool operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <>
   struct less<void> {
     template <class T, class U> auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) < std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/less_equal.md
+++ b/reference/functional/less_equal.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct less_equal {
     bool operator ()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   // C++14
   template <class T = void>
   struct less_equal {
     constexpr bool operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <>
   struct less_equal<void> {
     template <class T, class U> auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) <= std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/logical_and.md
+++ b/reference/functional/logical_and.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct logical_and {
     bool operator ()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   // C++14
   template <class T = void>
   struct logical_and {
     bool constexpr operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <>
   struct logical_and<void> {
     template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) && std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/logical_not.md
+++ b/reference/functional/logical_not.md
@@ -9,23 +9,23 @@ namespace std {
   template <typename T>
   struct logical_not {
     bool operator ()(const T& x) const;
-    typedef T argument_type;
-    typedef bool result_type;
+    using argument_type = T;
+    using result_type   = bool;
   };
 
   // C++14
   template <class T = void>
   struct logical_not {
     bool constexpr operator()(const T& x) const;
-    typedef T argument_type;
-    typedef bool result_type;
+    using argument_type = T;
+    using result_type   = bool;
   };
 
   template <>
   struct logical_not<void> {
     template <class T> constexpr auto operator()(T&& t) const
       -> decltype(!std::forward<T>(t));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/logical_or.md
+++ b/reference/functional/logical_or.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct logical_or {
     bool operator ()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   // C++14
   template <class T = void>
   struct logical_or {
     bool constexpr operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <>
   struct logical_or<void> {
     template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) || std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/minus.md
+++ b/reference/functional/minus.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct minus {
     T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // C++14
   template <typename T = void>
   struct minus {
     constexpr T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <>
   struct minus<void> {
     template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) - std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/modulus.md
+++ b/reference/functional/modulus.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct modulus {
     T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // C++14
   template <typename T = void>
   struct modulus {
     constexpr T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <>
   struct modulus<void> {
     template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) / std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/multiplies.md
+++ b/reference/functional/multiplies.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct multiplies {
     T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // C++14
   template <typename T = void>
   struct multiplies {
     constexpr T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <>
   struct multiplies<void> {
     template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) * std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/negate.md
+++ b/reference/functional/negate.md
@@ -10,23 +10,23 @@ namespace std {
   struct negate {
     T operator()(const T& x) const;
     constexpr T operator ()(const T& x) const;
-    typedef T argument_type;
-    typedef T result_type;
+    using argument_type = T;
+    using result_type   = T;
   };
 
   // C++14
   template <typename T = void>
   struct negate {
     constexpr T operator()(const T& x) const;
-    typedef T argument_type;
-    typedef T result_type;
+    using argument_type = T;
+    using result_type   = T;
   };
 
   template <>
   struct negate<void> {
     template <class T> constexpr auto operator()(T&& t) const
       -> decltype(-std::forward<T>(t));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/negators.md
+++ b/reference/functional/negators.md
@@ -11,8 +11,8 @@ namespace std {
     explicit constexpr unary_negate(const Pred& pred); // C++14
     bool operator()(const typename Pred::argument_type& x) const;           // C++98
     constexpr bool operator()(const typename Pred::argument_type& x) const; // C++14
-    typedef typename Pred::argument_type argument_type;
-    typedef bool result_type;
+    using argument_type = typename Pred::argument_type;
+    using result_type   = bool;
   };
 
   template <typename Pred>
@@ -32,9 +32,9 @@ namespace std {
              const typename Pred::first_argument_type& x,
              const typename Pred::second_argument_type& y) const; // C++14
 
-    typedef typename Pred::first_argument_type first_argument_type;
-    typedef typename Pred::second_argument_type second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = typename Pred::first_argument_type;
+    using second_argument_type = typename Pred::second_argument_type;
+    using result_type          = bool;
   };
 
   template <typename Pred>

--- a/reference/functional/not_equal_to.md
+++ b/reference/functional/not_equal_to.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct not_equal_to {
     bool operator ()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   // C++14
   template <class T = void>
   struct not_equal_to {
     constexpr bool operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef bool result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = bool;
   };
 
   template <>
   struct not_equal_to<void> {
     template <class T, class U> auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) != std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/functional/plus.md
+++ b/reference/functional/plus.md
@@ -9,25 +9,25 @@ namespace std {
   template <typename T>
   struct plus {
     T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   // C++14
   template <typename T = void>
   struct plus {
     constexpr T operator()(const T& x, const T& y) const;
-    typedef T first_argument_type;
-    typedef T second_argument_type;
-    typedef T result_type;
+    using first_argument_type  = T;
+    using second_argument_type = T;
+    using result_type          = T;
   };
 
   template <>
   struct plus<void> {
     template <class T, class U> constexpr auto operator()(T&& t, U&& u) const
       -> decltype(std::forward<T>(t) + std::forward<U>(u));
-    typedef unspecified is_transparent;
+    using is_transparent = unspecified;
   };
 }
 ```

--- a/reference/iomanip/put_time.md
+++ b/reference/iomanip/put_time.md
@@ -26,8 +26,8 @@ unspecified put_time(const struct tm* tmb, const CharT* fmt);
 template <class CharT, class Traits>
 void f(basic_ios<CharT, Traits>& out, const struct tm* tmb, const CharT* fmt)
 {
-  typedef ostreambuf_iterator<CharT, Traits> Iter;
-  typedef time_put<CharT, Iter> TimePut;
+  using Iter    = ostreambuf_iterator<CharT, Traits>;
+  using TimePut = time_put<CharT, Iter>;
   const TimePut& tp = use_facet<TimePut>(out.getloc());
   const Iter end = tp.put(Iter(out.rdbuf()), out, out.fill(), tmb,
                           fmt, fmt + Traits::length(fmt));

--- a/reference/ios/basic_ios.md
+++ b/reference/ios/basic_ios.md
@@ -8,8 +8,8 @@ namespace std {
   template<class CharT, class Traits = char_traits<CharT> >
   class basic_ios : public ios_base { …… };
 
-  typedef basic_ios<char> ios;                                  // <iosfwd> で定義
-  typedef basic_ios<wchar_t> wios;                              // <iosfwd> で定義
+  using ios  = basic_ios<char>;                                  // <iosfwd> で定義
+  using wios = basic_ios<wchar_t>;                              // <iosfwd> で定義
 }
 ```
 * ios_base[link ios_base.md]

--- a/reference/ios/ios_base/type-event_callback.md
+++ b/reference/ios/ios_base/type-event_callback.md
@@ -5,7 +5,7 @@
 * ios_base[meta class]
 
 ```cpp
-typedef void (*event_callback)(event ev, ios_base& str, int index);
+using event_callback = void(*)(event ev, ios_base& str, int index);
 ```
 * event[link type-event.md]
 * ios_base[link ../ios_base.md]

--- a/reference/ios/ios_base/type-fmtflags.md
+++ b/reference/ios/ios_base/type-fmtflags.md
@@ -5,7 +5,7 @@
 * ios_base[meta class]
 
 ```cpp
-typedef T1 fmtflags;
+using fmtflags = T1;
 ```
 * T1[italic]
 

--- a/reference/ios/ios_base/type-iostate.md
+++ b/reference/ios/ios_base/type-iostate.md
@@ -5,7 +5,7 @@
 * ios_base[meta class]
 
 ```cpp
-typedef T2 iostate;
+using iostate = T2;
 ```
 * T2[italic]
 

--- a/reference/ios/ios_base/type-openmode.md
+++ b/reference/ios/ios_base/type-openmode.md
@@ -5,7 +5,7 @@
 * ios_base[meta class]
 
 ```cpp
-typedef T3 openmode;
+using openmode = T3;
 ```
 * T3[italic]
 

--- a/reference/ios/ios_base/type-seekdir.md
+++ b/reference/ios/ios_base/type-seekdir.md
@@ -5,7 +5,7 @@
 * ios_base[meta class]
 
 ```cpp
-typedef T4 seekdir;
+using seekdir = T4;
 ```
 * T4[italic]
 

--- a/reference/ios/type-streamoff.md
+++ b/reference/ios/type-streamoff.md
@@ -5,7 +5,7 @@
 
 ```cpp
 namespace std {
-  typedef implementation-defined streamoff;
+  using streamoff = implementation-defined;
 }
 ```
 

--- a/reference/ios/type-streamsize.md
+++ b/reference/ios/type-streamsize.md
@@ -5,7 +5,7 @@
 
 ```cpp
 namespace std {
-  typedef implementation-defined streamsize;
+  using streamsize = implementation-defined;
 }
 ```
 

--- a/reference/istream/basic_iostream.md
+++ b/reference/istream/basic_iostream.md
@@ -10,8 +10,8 @@ namespace std {
     public basic_istream<CharT, Traits>,
     public basic_ostream<CharT, Traits> { …… };
 
-  typedef basic_iostream<char> iostream;
-  typedef basic_iostream<wchar_t> wiostream;
+  using iostream  = basic_iostream<char>;
+  using wiostream = basic_iostream<wchar_t>;
 }
 ```
 * basic_istream[link basic_istream.md]

--- a/reference/istream/basic_istream.md
+++ b/reference/istream/basic_istream.md
@@ -8,8 +8,8 @@ namespace std {
   template<class CharT, class Traits = char_traits<CharT>>
   class basic_istream : virtual public basic_ios<CharT, Traits> { …… };
 
-  typedef basic_istream<char> istream;
-  typedef basic_istream<wchar_t> wistream;
+  using istream  = basic_istream<char>;
+  using wistream = basic_istream<wchar_t>;
 }
 ```
 * basic_ios[link ../ios/basic_ios.md]

--- a/reference/iterator/iterator.md
+++ b/reference/iterator/iterator.md
@@ -11,11 +11,11 @@ namespace std {
            class Pointer = T*,
            class Reference = T&>
   struct iterator {
-    typedef T value_type;
-    typedef Distance difference_type;
-    typedef Pointer pointer;
-    typedef Reference reference;
-    typedef Category iterator_category;
+    using value_type        = T;
+    using difference_type   = Distance;
+    using pointer           = Pointer;
+    using reference         = Reference;
+    using iterator_category = Category;
   };
 }
 ```

--- a/reference/iterator/iterator_traits.md
+++ b/reference/iterator/iterator_traits.md
@@ -7,30 +7,30 @@
 namespace std {
   template <class Iterator>
   struct iterator_traits {
-    typedef typename Iterator::difference_type difference_type;
-    typedef typename Iterator::value_type value_type;
-    typedef typename Iterator::pointer pointer;
-    typedef typename Iterator::reference reference;
-    typedef typename Iterator::iterator_category iterator_category;
+    using difference_type   = typename Iterator::difference_type;
+    using value_type        = typename Iterator::value_type;
+    using pointer           = typename Iterator::pointer;
+    using reference         = typename Iterator::reference;
+    using iterator_category = typename Iterator::iterator_category;
   };
 
   // ポインタに対する特殊化
   template <class T>
   struct iterator_traits<T*> {
-    typedef ptrdiff_t difference_type;
-    typedef T value_type;
-    typedef T* pointer;
-    typedef T& reference;
-    typedef random_access_iterator_tag iterator_category;
+    using difference_type   = ptrdiff_t;
+    using value_type        = T;
+    using pointer           = T*;
+    using reference         = T&;
+    using iterator_category = random_access_iterator_tag;
   };
 
   template<class T>
   struct iterator_traits<const T*> {
-    typedef ptrdiff_t difference_type;
-    typedef T value_type;
-    typedef const T* pointer;
-    typedef const T& reference;
-    typedef random_access_iterator_tag iterator_category;
+    using difference_type   = ptrdiff_t;
+    using value_type        = T;
+    using pointer           = const T*;
+    using reference         = const T&;
+    using iterator_category = random_access_iterator_tag;
   };
 }
 ```

--- a/reference/memory/allocator.md
+++ b/reference/memory/allocator.md
@@ -10,10 +10,10 @@ namespace std {
 
   template<>
   class allocator<void> {
-    typedef void* pointer;
-    typedef const void* const_pointer;
-    typedef void value_type;
-    template <class U> struct rebind { typedef allocator<U> other; };
+    using pointer       = void*;
+    using const_pointer = const void*;
+    using value_type    = void;
+    template <class U> struct rebind { using other = allocator<U>; };
   };
 }
 ```

--- a/reference/memory/allocator/construct.md
+++ b/reference/memory/allocator/construct.md
@@ -34,7 +34,7 @@ void construct(U* p, Args&&... args);
 
 int main()
 {
-  typedef std::pair<int, char> value_type;
+  using value_type = std::pair<int, char>;
   std::allocator<value_type> alloc;
 
   std::size_t n = 1;

--- a/reference/memory/allocator/destroy.md
+++ b/reference/memory/allocator/destroy.md
@@ -34,7 +34,7 @@ void destroy(U* p);
 
 int main()
 {
-  typedef std::pair<int, char> value_type;
+  using value_type = std::pair<int, char>;
   std::allocator<value_type> alloc;
 
   std::size_t n = 1;

--- a/reference/new/new_handler.md
+++ b/reference/new/new_handler.md
@@ -5,7 +5,7 @@
 
 ```cpp
 namespace std {
-  typedef void (*new_handler)();
+  using new_handler = void(*)();
 }
 ```
 

--- a/reference/ostream/basic_ostream.md
+++ b/reference/ostream/basic_ostream.md
@@ -8,8 +8,8 @@ namespace std {
   template<class CharT, class Traits = char_traits<CharT>>
   class basic_ostream : virtual public basic_ios<CharT, Traits> { …… };
 
-  typedef basic_ostream<char> ostream;
-  typedef basic_ostream<wchar_t> wostream;
+  using ostream  = basic_ostream<char>;
+  using wostream = basic_ostream<wchar_t>;
 }
 ```
 * basic_ios[link ../ios/basic_ios.md]

--- a/reference/random/bernoulli_distribution/op_call.md
+++ b/reference/random/bernoulli_distribution/op_call.md
@@ -52,7 +52,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::bernoulli_distribution dist_type;
+    using dist_type = std::bernoulli_distribution;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/bernoulli_distribution/op_constructor.md
+++ b/reference/random/bernoulli_distribution/op_constructor.md
@@ -44,7 +44,7 @@ int main()
 
   // パラメータを通して範囲指定する
   {
-    typedef std::bernoulli_distribution dist_type;
+    using dist_type = std::bernoulli_distribution;
 
     // 確率0.7でtrueを生成し、確率0.3(1.0 - 0.7)でfalseを生成する
     dist_type::param_type param(0.7);

--- a/reference/random/bernoulli_distribution/param.md
+++ b/reference/random/bernoulli_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::bernoulli_distribution dist_type;
+  using dist_type = std::bernoulli_distribution;
 
   dist_type dist(0.5);
 

--- a/reference/random/binomial_distribution/op_call.md
+++ b/reference/random/binomial_distribution/op_call.md
@@ -48,7 +48,7 @@ int main()
 
   // (2) パラメータを渡すバージョン
   {
-    typedef std::binomial_distribution<> dist_type;
+    using dist_type = std::binomial_distribution<>;
     dist_type dist;
 
     // 確率0.5で成功する事象を3回施行する

--- a/reference/random/binomial_distribution/op_constructor.md
+++ b/reference/random/binomial_distribution/op_constructor.md
@@ -41,7 +41,7 @@ int main()
 
   // パラメータを通して範囲指定する
   {
-    typedef std::binomial_distribution<> dist_type;
+    using dist_type = std::binomial_distribution<>;
 
     // 確率0.5で成功する事象を、3回施行する
     dist_type::param_type param(3, 0.5);

--- a/reference/random/binomial_distribution/param.md
+++ b/reference/random/binomial_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::binomial_distribution<> dist_type;
+  using dist_type = std::binomial_distribution<>;
 
   dist_type dist(3, 0.5);
 

--- a/reference/random/cauchy_distribution/op_call.md
+++ b/reference/random/cauchy_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::cauchy_distribution<> dist_type;
+    using dist_type = std::cauchy_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/cauchy_distribution/op_constructor.md
+++ b/reference/random/cauchy_distribution/op_constructor.md
@@ -43,7 +43,7 @@ int main()
 
   // パラメータを通して範囲指定する
   {
-    typedef std::cauchy_distribution<> dist_type;
+    using dist_type = std::cauchy_distribution<>;
 
     // 位置母数0.0、尺度母数1.0で分布させる
     dist_type::param_type param(0.0, 1.0);

--- a/reference/random/cauchy_distribution/param.md
+++ b/reference/random/cauchy_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::cauchy_distribution<> dist_type;
+  using dist_type = std::cauchy_distribution<>;
 
   dist_type dist(0.0, 1.0);
 

--- a/reference/random/chi_squared_distribution/op_call.md
+++ b/reference/random/chi_squared_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::chi_squared_distribution<> dist_type;
+    using dist_type = std::chi_squared_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/chi_squared_distribution/op_constructor.md
+++ b/reference/random/chi_squared_distribution/op_constructor.md
@@ -43,7 +43,7 @@ int main()
 
   // パラメータを通して範囲指定する
   {
-    typedef std::chi_squared_distribution<> dist_type;
+    using dist_type = std::chi_squared_distribution<>;
 
     // 自由度1.0で分布させる
     dist_type::param_type param(1.0);

--- a/reference/random/chi_squared_distribution/param.md
+++ b/reference/random/chi_squared_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::chi_squared_distribution<> dist_type;
+  using dist_type = std::chi_squared_distribution<>;
 
   dist_type dist(1.0);
 

--- a/reference/random/default_random_engine.md
+++ b/reference/random/default_random_engine.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef implementation-defined default_random_engine;
+  using default_random_engine = implementation-defined;
 }
 ```
 

--- a/reference/random/discard_block_engine.md
+++ b/reference/random/discard_block_engine.md
@@ -9,8 +9,8 @@ namespace std {
   template <class Engine, size_t p, size_t r>
   class discard_block_engine;
 
-  typedef … ranlux24;
-  typedef … ranlux48;
+  using ranlux24 = …;
+  using ranlux48 = …;
 }
 ```
 * ranlux24[link ranlux24.md]

--- a/reference/random/discrete_distribution/op_call.md
+++ b/reference/random/discrete_distribution/op_call.md
@@ -54,7 +54,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::discrete_distribution<> dist_type;
+    using dist_type = std::discrete_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/discrete_distribution/op_constructor.md
+++ b/reference/random/discrete_distribution/op_constructor.md
@@ -96,7 +96,7 @@ int main()
 
   // (5)
   {
-    typedef std::discrete_distribution<> dist_type;
+    using dist_type = std::discrete_distribution<>;
 
     // 初期化子リストで確率列を作成
     dist_type::param_type param = {0.1, 0.2, 0.3};

--- a/reference/random/discrete_distribution/param.md
+++ b/reference/random/discrete_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::discrete_distribution<> dist_type;
+  using dist_type = std::discrete_distribution<>;
 
   dist_type dist = {0.1, 0.2, 0.3};
 

--- a/reference/random/exponential_distribution/op_call.md
+++ b/reference/random/exponential_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::exponential_distribution<> dist_type;
+    using dist_type = std::exponential_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/exponential_distribution/op_constructor.md
+++ b/reference/random/exponential_distribution/op_constructor.md
@@ -41,7 +41,7 @@ int main()
 
   // (2)
   {
-    typedef std::exponential_distribution<> dist_type;
+    using dist_type = std::exponential_distribution<>;
 
     dist_type::param_type param(1.0);
     dist_type dist(param);

--- a/reference/random/exponential_distribution/param.md
+++ b/reference/random/exponential_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::exponential_distribution<> dist_type;
+  using dist_type = std::exponential_distribution<>;
 
   dist_type dist(1.0);
 

--- a/reference/random/extreme_value_distribution/op_call.md
+++ b/reference/random/extreme_value_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::extreme_value_distribution<> dist_type;
+    using dist_type = std::extreme_value_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/extreme_value_distribution/op_constructor.md
+++ b/reference/random/extreme_value_distribution/op_constructor.md
@@ -42,7 +42,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::extreme_value_distribution<> dist_type;
+    using dist_type = std::extreme_value_distribution<>;
 
     // 位置パラメータ0.0、尺度パラメータ1.0で分布させる
     dist_type::param_type param(0.0, 1.0);

--- a/reference/random/extreme_value_distribution/param.md
+++ b/reference/random/extreme_value_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::extreme_value_distribution<> dist_type;
+  using dist_type = std::extreme_value_distribution<>;
 
   dist_type dist(0.0, 1.0);
 

--- a/reference/random/fisher_f_distribution/op_call.md
+++ b/reference/random/fisher_f_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::fisher_f_distribution<> dist_type;
+    using dist_type = std::fisher_f_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/fisher_f_distribution/op_constructor.md
+++ b/reference/random/fisher_f_distribution/op_constructor.md
@@ -43,7 +43,7 @@ int main()
 
   // パラメータを指定する
   {
-    typedef std::fisher_f_distribution<> dist_type;
+    using dist_type = std::fisher_f_distribution<>;
 
     // 自由度3と4で分布させる
     dist_type::param_type param(3.0, 4.0);

--- a/reference/random/fisher_f_distribution/param.md
+++ b/reference/random/fisher_f_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::fisher_f_distribution<> dist_type;
+  using dist_type = std::fisher_f_distribution<>;
 
   dist_type dist(3.0, 4.0);
 

--- a/reference/random/gamma_distribution/op_call.md
+++ b/reference/random/gamma_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::gamma_distribution<> dist_type;
+    using dist_type = std::gamma_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/gamma_distribution/op_constructor.md
+++ b/reference/random/gamma_distribution/op_constructor.md
@@ -42,7 +42,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::gamma_distribution<> dist_type;
+    using dist_type = std::gamma_distribution<>;
 
     // 形状母数1.0、尺度母数1.0で分布させる
     dist_type::param_type param(1.0, 1.0);

--- a/reference/random/gamma_distribution/param.md
+++ b/reference/random/gamma_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::gamma_distribution<> dist_type;
+  using dist_type = std::gamma_distribution<>;
 
   dist_type dist(1.0, 1.0);
 

--- a/reference/random/geometric_distribution/op_call.md
+++ b/reference/random/geometric_distribution/op_call.md
@@ -48,7 +48,7 @@ int main()
 
   // (2) パラメータを渡すバージョン
   {
-    typedef std::geometric_distribution<> dist_type;
+    using dist_type = std::geometric_distribution<>;
     dist_type dist;
 
     // 確率0.5で成功する事象を、成功するまで施行する

--- a/reference/random/geometric_distribution/op_constructor.md
+++ b/reference/random/geometric_distribution/op_constructor.md
@@ -41,7 +41,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::geometric_distribution<> dist_type;
+    using dist_type = std::geometric_distribution<>;
 
     // 確率0.5で成功する事象を、成功するまで施行する
     dist_type::param_type param(0.5);

--- a/reference/random/geometric_distribution/param.md
+++ b/reference/random/geometric_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::geometric_distribution<> dist_type;
+  using dist_type = std::geometric_distribution<>;
 
   dist_type dist(0.5);
 

--- a/reference/random/linear_congruential_engine.md
+++ b/reference/random/linear_congruential_engine.md
@@ -10,8 +10,8 @@ namespace std {
   template <class UIntType, UIntType A, UIntType C, UIntType M>
   class linear_congruential_engine;
 
-  typedef … minstd_rand0;
-  typedef … minstd_rand;
+  using minstd_rand0 = …;
+  using minstd_rand  = …;
 }
 ```
 * minstd_rand0[link minstd_rand0.md]

--- a/reference/random/lognormal_distribution/op_call.md
+++ b/reference/random/lognormal_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::lognormal_distribution<> dist_type;
+    using dist_type = std::lognormal_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/lognormal_distribution/op_constructor.md
+++ b/reference/random/lognormal_distribution/op_constructor.md
@@ -43,7 +43,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::lognormal_distribution<> dist_type;
+    using dist_type = std::lognormal_distribution<>;
 
     // 平均0.0、標準偏差1.0で分布させる
     dist_type::param_type param(0.0, 1.0);

--- a/reference/random/lognormal_distribution/param.md
+++ b/reference/random/lognormal_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::lognormal_distribution<> dist_type;
+  using dist_type = std::lognormal_distribution<>;
 
   dist_type dist(0.0, 1.0);
 

--- a/reference/random/mersenne_twister_engine.md
+++ b/reference/random/mersenne_twister_engine.md
@@ -12,8 +12,8 @@ namespace std {
             UIntType c, size_t l, UIntType f>
   class mersenne_twister_engine;
 
-  typedef … mt19937;
-  typedef … mt19937_64;
+  using mt19937    = …;
+  using mt19937_64 = …;
 }
 ```
 * mt19937[link mt19937.md]

--- a/reference/random/negative_binomial_distribution/op_call.md
+++ b/reference/random/negative_binomial_distribution/op_call.md
@@ -48,7 +48,7 @@ int main()
 
   // (2) パラメータを渡すバージョン
   {
-    typedef std::negative_binomial_distribution<> dist_type;
+    using dist_type = std::negative_binomial_distribution<>;
     dist_type dist;
 
     // 確率0.5で成功する事象を3回成功させる

--- a/reference/random/negative_binomial_distribution/op_constructor.md
+++ b/reference/random/negative_binomial_distribution/op_constructor.md
@@ -41,7 +41,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::negative_binomial_distribution<> dist_type;
+    using dist_type = std::negative_binomial_distribution<>;
 
     // 確率0.5で成功する事象を、3回成功させる
     dist_type::param_type param(3, 0.5);

--- a/reference/random/negative_binomial_distribution/param.md
+++ b/reference/random/negative_binomial_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::negative_binomial_distribution<> dist_type;
+  using dist_type = std::negative_binomial_distribution<>;
 
   dist_type dist(3, 0.5);
 

--- a/reference/random/normal_distribution/op_call.md
+++ b/reference/random/normal_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::normal_distribution<> dist_type;
+    using dist_type = std::normal_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/normal_distribution/op_constructor.md
+++ b/reference/random/normal_distribution/op_constructor.md
@@ -43,7 +43,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::normal_distribution<> dist_type;
+    using dist_type = std::normal_distribution<>;
 
     // 平均0.0、標準偏差1.0で分布させる
     dist_type::param_type param(0.0, 1.0);

--- a/reference/random/normal_distribution/param.md
+++ b/reference/random/normal_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::normal_distribution<> dist_type;
+  using dist_type = std::normal_distribution<>;
 
   dist_type dist(0.0, 1.0);
 

--- a/reference/random/piecewise_constant_distribution/op_call.md
+++ b/reference/random/piecewise_constant_distribution/op_call.md
@@ -59,7 +59,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::piecewise_constant_distribution<> dist_type;
+    using dist_type = std::piecewise_constant_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/piecewise_constant_distribution/op_constructor.md
+++ b/reference/random/piecewise_constant_distribution/op_constructor.md
@@ -114,7 +114,7 @@ int main()
 
   // (5)
   {
-    typedef std::piecewise_constant_distribution<> dist_type;
+    using dist_type = std::piecewise_constant_distribution<>;
 
     std::array<double, 3> intervals = {0.0, 0.5, 1.0}; // 区間数列
     std::array<double, 3> densities = {0.3, 0.5};      // 重み数列

--- a/reference/random/piecewise_constant_distribution/param.md
+++ b/reference/random/piecewise_constant_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::piecewise_constant_distribution<> dist_type;
+  using dist_type = std::piecewise_constant_distribution<>;
 
   std::array<double, 3> intervals = {0.0, 0.5, 1.0};
   std::array<double, 2> densities = {0.3, 0.5};

--- a/reference/random/piecewise_linear_distribution/op_call.md
+++ b/reference/random/piecewise_linear_distribution/op_call.md
@@ -59,7 +59,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::piecewise_linear_distribution<> dist_type;
+    using dist_type = std::piecewise_linear_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/piecewise_linear_distribution/op_constructor.md
+++ b/reference/random/piecewise_linear_distribution/op_constructor.md
@@ -113,7 +113,7 @@ int main()
 
   // (5)
   {
-    typedef std::piecewise_linear_distribution<> dist_type;
+    using dist_type = std::piecewise_linear_distribution<>;
 
     std::array<double, 3> intervals = {0.0, 0.5, 1.0}; // 区間数列
     std::array<double, 3> densities = {0.0, 0.5, 0.0}; // 重み数列

--- a/reference/random/piecewise_linear_distribution/param.md
+++ b/reference/random/piecewise_linear_distribution/param.md
@@ -23,7 +23,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::piecewise_linear_distribution<> dist_type;
+  using dist_type = std::piecewise_linear_distribution<>;
 
   std::array<double, 3> intervals = {0.0, 0.5, 1.0};
   std::array<double, 3> densities = {0.0, 0.5, 0.0};

--- a/reference/random/poisson_distribution/op_call.md
+++ b/reference/random/poisson_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::poisson_distribution<> dist_type;
+    using dist_type = std::poisson_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/poisson_distribution/op_constructor.md
+++ b/reference/random/poisson_distribution/op_constructor.md
@@ -42,7 +42,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::poisson_distribution<> dist_type;
+    using dist_type = std::poisson_distribution<>;
 
     // 平均値1.0で分布させる
     dist_type::param_type param(1.0);

--- a/reference/random/poisson_distribution/param.md
+++ b/reference/random/poisson_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::poisson_distribution<> dist_type;
+  using dist_type = std::poisson_distribution<>;
 
   dist_type dist(1.0);
 

--- a/reference/random/shuffle_order_engine.md
+++ b/reference/random/shuffle_order_engine.md
@@ -9,7 +9,7 @@ namespace std {
   template<class Engine, size_t K>
   class shuffle_order_engine;
 
-  typedef … knuth_b;
+  using knuth_b = …;
 }
 ```
 * knuth_b[link knuth_b.md]

--- a/reference/random/student_t_distribution/op_call.md
+++ b/reference/random/student_t_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::student_t_distribution<> dist_type;
+    using dist_type = std::student_t_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/student_t_distribution/op_constructor.md
+++ b/reference/random/student_t_distribution/op_constructor.md
@@ -43,7 +43,7 @@ int main()
 
   // (2) パラメータを指定する
   {
-    typedef std::student_t_distribution<> dist_type;
+    using dist_type = std::student_t_distribution<>;
 
     // 自由度1で分布させる
     dist_type::param_type param(1.0);

--- a/reference/random/student_t_distribution/param.md
+++ b/reference/random/student_t_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::student_t_distribution<> dist_type;
+  using dist_type = std::student_t_distribution<>;
 
   dist_type dist(1.0);
 

--- a/reference/random/subtract_with_carry_engine.md
+++ b/reference/random/subtract_with_carry_engine.md
@@ -9,10 +9,10 @@ namespace std {
   template <class UIntType, size_t w, size_t s, size_t r>
   class subtract_with_carry_engine;
 
-  typedef … ranlux24_base;
-  typedef … ranlux48_base;
-  typedef … ranlux24;
-  typedef … ranlux48;
+  using ranlux24_base = …;
+  using ranlux48_base = …;
+  using ranlux24      = …;
+  using ranlux48      = …;
 }
 ```
 * ranlux24[link ranlux24.md]

--- a/reference/random/uniform_int_distribution/op_call.md
+++ b/reference/random/uniform_int_distribution/op_call.md
@@ -50,7 +50,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::uniform_int_distribution<> dist_type;
+    using dist_type = std::uniform_int_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/uniform_int_distribution/op_constructor.md
+++ b/reference/random/uniform_int_distribution/op_constructor.md
@@ -46,7 +46,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::uniform_int_distribution<> dist_type;
+    using dist_type = std::uniform_int_distribution<>;
 
     // 0以上3以下の範囲で、値を等確率で生成する
     dist_type::param_type param(0, 3);

--- a/reference/random/uniform_int_distribution/param.md
+++ b/reference/random/uniform_int_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::uniform_int_distribution<> dist_type;
+  using dist_type = std::uniform_int_distribution<>;
 
   dist_type dist(0, 3);
 

--- a/reference/random/uniform_real_distribution/op_call.md
+++ b/reference/random/uniform_real_distribution/op_call.md
@@ -50,7 +50,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::uniform_real_distribution<> dist_type;
+    using dist_type = std::uniform_real_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/uniform_real_distribution/op_constructor.md
+++ b/reference/random/uniform_real_distribution/op_constructor.md
@@ -42,7 +42,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::uniform_real_distribution<> dist_type;
+    using dist_type = std::uniform_real_distribution<>;
 
     // 0.0以上1.0未満の範囲で、値を等確率で生成する
     dist_type::param_type param(0.0, 1.0);

--- a/reference/random/uniform_real_distribution/param.md
+++ b/reference/random/uniform_real_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::uniform_real_distribution<> dist_type;
+  using dist_type = std::uniform_real_distribution<>;
 
   dist_type dist(0.0, 1.0);
 

--- a/reference/random/weibull_distribution/op_call.md
+++ b/reference/random/weibull_distribution/op_call.md
@@ -49,7 +49,7 @@ int main()
   // (2) パラメータを渡すバージョン
   std::cout << std::endl;
   {
-    typedef std::weibull_distribution<> dist_type;
+    using dist_type = std::weibull_distribution<>;
     dist_type dist;
 
     for (int i = 0; i < 5; ++i) {

--- a/reference/random/weibull_distribution/op_constructor.md
+++ b/reference/random/weibull_distribution/op_constructor.md
@@ -42,7 +42,7 @@ int main()
 
   // (2) パラメータを通して範囲指定する
   {
-    typedef std::weibull_distribution<> dist_type;
+    using dist_type = std::weibull_distribution<>;
 
     // 形状パラメータ1.0、尺度パラメータ1.0で分布させる
     dist_type::param_type param(1.0, 1.0);

--- a/reference/random/weibull_distribution/param.md
+++ b/reference/random/weibull_distribution/param.md
@@ -22,7 +22,7 @@ void param(const param_type& parm); // (2)
 
 int main()
 {
-  typedef std::weibull_distribution<> dist_type;
+  using dist_type = std::weibull_distribution<>;
 
   dist_type dist(1.0, 1.0);
 

--- a/reference/ratio/ratio.md
+++ b/reference/ratio/ratio.md
@@ -9,7 +9,7 @@ namespace std {
   template <intmax_t N, intmax_t D = 1>
   class ratio {
   public:
-    typedef ratio<num, den> type;
+    using type = ratio<num, den>;
     static constexpr intmax_t num;
     static constexpr intmax_t den;
   };

--- a/reference/ratio/si_prefix.md
+++ b/reference/ratio/si_prefix.md
@@ -6,26 +6,26 @@
 
 ```cpp
 namespace std {
-  typedef ratio<1, 1000000000000000000000000> yocto;
-  typedef ratio<1,    1000000000000000000000> zepto;
-  typedef ratio<1,       1000000000000000000> atto;
-  typedef ratio<1,          1000000000000000> femto;
-  typedef ratio<1,             1000000000000> pico;
-  typedef ratio<1,                1000000000> nano;
-  typedef ratio<1,                   1000000> micro;
-  typedef ratio<1,                      1000> milli;
-  typedef ratio<1,                       100> centi;
-  typedef ratio<1,                        10> deci;
-  typedef ratio<                       10, 1> deca;
-  typedef ratio<                      100, 1> hecto;
-  typedef ratio<                     1000, 1> kilo;
-  typedef ratio<                  1000000, 1> mega;
-  typedef ratio<               1000000000, 1> giga;
-  typedef ratio<            1000000000000, 1> tera;
-  typedef ratio<         1000000000000000, 1> peta;
-  typedef ratio<      1000000000000000000, 1> exa;
-  typedef ratio<   1000000000000000000000, 1> zetta;
-  typedef ratio<1000000000000000000000000, 1> yotta;
+  using yocto = ratio<1, 1000000000000000000000000>;
+  using zepto = ratio<1,    1000000000000000000000>;
+  using atto  = ratio<1,       1000000000000000000>;
+  using femto = ratio<1,          1000000000000000>;
+  using pico  = ratio<1,             1000000000000>;
+  using nano  = ratio<1,                1000000000>;
+  using micro = ratio<1,                   1000000>;
+  using milli = ratio<1,                      1000>;
+  using centi = ratio<1,                       100>;
+  using deci  = ratio<1,                        10>;
+  using deca  = ratio<                       10, 1>;
+  using hecto = ratio<                      100, 1>;
+  using kilo  = ratio<                     1000, 1>;
+  using mega  = ratio<                  1000000, 1>;
+  using giga  = ratio<               1000000000, 1>;
+  using tera  = ratio<            1000000000000, 1>;
+  using peta  = ratio<         1000000000000000, 1>;
+  using exa   = ratio<      1000000000000000000, 1>;
+  using zetta = ratio<   1000000000000000000000, 1>;
+  using yotta = ratio<1000000000000000000000000, 1>;
 }
 ```
 * ratio[link ratio.md]

--- a/reference/regex/basic_regex.md
+++ b/reference/regex/basic_regex.md
@@ -11,8 +11,8 @@ namespace std {
             class traits = regex_traits<charT> >
   class basic_regex;
 
-  typedef basic_regex<char>    regex;
-  typedef basic_regex<wchar_t> wregex;
+  using regex  = basic_regex<char>;
+  using wregex = basic_regex<wchar_t>;
 }
 ```
 * regex_traits[link regex_traits.md]

--- a/reference/regex/match_results.md
+++ b/reference/regex/match_results.md
@@ -10,10 +10,10 @@ namespace std {
             class Allocator = allocator<sub_match<BidirectionalIterator>>>
   class match_results;
 
-  typedef match_results<const char*>             cmatch;
-  typedef match_results<const wchar_t*>          wcmatch;
-  typedef match_results<string::const_iterator>  smatch;
-  typedef match_results<wstring::const_iterator> wsmatch;
+  using cmatch  = match_results<const char*>;
+  using wcmatch = match_results<const wchar_t*>;
+  using smatch  = match_results<string::const_iterator>;
+  using wsmatch = match_results<wstring::const_iterator>;
 }
 ```
 * allocator[link ../memory/allocator.md]

--- a/reference/regex/regex_constants/error_type.md
+++ b/reference/regex/regex_constants/error_type.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
 namespace regex_constants {
-  typedef implementation-defined error_type;
+  using error_type = implementation-defined;
   constexpr error_type error_collate = unspecified;
   constexpr error_type error_ctype = unspecified;
   constexpr error_type error_escape = unspecified;

--- a/reference/regex/regex_constants/match_flag_type.md
+++ b/reference/regex/regex_constants/match_flag_type.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
 namespace regex_constants{
-  typedef implementation-defined match_flag_type;
+  using match_flag_type = implementation-defined;
   constexpr match_flag_type match_default = {};
   constexpr match_flag_type match_not_bol = unspecified;
   constexpr match_flag_type match_not_eol = unspecified;

--- a/reference/regex/regex_constants/syntax_option_type.md
+++ b/reference/regex/regex_constants/syntax_option_type.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
 namespace regex_constants {
-  typedef implementation-defined syntax_option_type;
+  using syntax_option_type = implementation-defined;
   constexpr syntax_option_type icase = unspecified;
   constexpr syntax_option_type nosubs = unspecified;
   constexpr syntax_option_type optimize = unspecified;

--- a/reference/regex/regex_iterator.md
+++ b/reference/regex/regex_iterator.md
@@ -11,10 +11,10 @@ namespace std {
             class traits = regex_traits<charT> >
   class regex_iterator;
 
-  typedef regex_iterator<const char*> cregex_iterator;
-  typedef regex_iterator<const wchar_t*> wcregex_iterator;
-  typedef regex_iterator<string::const_iterator> sregex_iterator;
-  typedef regex_iterator<wstring::const_iterator> wsregex_iterator;
+  using cregex_iterator  = regex_iterator<const char*>;
+  using wcregex_iterator = regex_iterator<const wchar_t*>;
+  using sregex_iterator  = regex_iterator<string::const_iterator>;
+  using wsregex_iterator = regex_iterator<wstring::const_iterator>;
 }
 ```
 * iterator_traits[link /reference/iterator/iterator_traits.md]

--- a/reference/regex/regex_token_iterator.md
+++ b/reference/regex/regex_token_iterator.md
@@ -11,10 +11,10 @@ namespace std {
             class traits = regex_traits<charT> >
   class regex_token_iterator;
 
-  typedef regex_token_iterator<const char*> cregex_token_iterator;
-  typedef regex_token_iterator<const wchar_t*> wcregex_token_iterator;
-  typedef regex_token_iterator<string::const_iterator> sregex_token_iterator;
-  typedef regex_token_iterator<wstring::const_iterator> wsregex_token_iterator;
+  using cregex_token_iterator  = regex_token_iterator<const char*>;
+  using wcregex_token_iterator = regex_token_iterator<const wchar_t*>;
+  using sregex_token_iterator  = regex_token_iterator<string::const_iterator>;
+  using wsregex_token_iterator = regex_token_iterator<wstring::const_iterator>;
 }
 ```
 * iterator_traits[link /reference/iterator/iterator_traits.md]

--- a/reference/regex/sub_match.md
+++ b/reference/regex/sub_match.md
@@ -9,10 +9,10 @@ namespace std {
   template <class BidirectionalIterator>
   class sub_match : public pair<BidirectionalIterator, BidirectionalIterator>;
 
-  typedef sub_match<const char*>             csub_match;
-  typedef sub_match<const wchar_t*>          wcsub_match;
-  typedef sub_match<string::const_iterator>  ssub_match;
-  typedef sub_match<wstring::const_iterator> wssub_match;
+  using csub_match  = sub_match<const char*>;
+  using wcsub_match = sub_match<const wchar_t*>;
+  using ssub_match  = sub_match<string::const_iterator>;
+  using wssub_match = sub_match<wstring::const_iterator>;
 }
 ```
 * pair[link ../utility/pair.md]

--- a/reference/scoped_allocator/scoped_allocator_adaptor.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor.md
@@ -107,7 +107,7 @@ class MyAlloc : public std::allocator<T> {
   template <class> friend class MyAlloc;
 public:
   template <class U>
-  struct rebind { typedef MyAlloc<U> other; };
+  struct rebind { using other = MyAlloc<U>; };
 
   MyAlloc(int state = 0)
     : state_(state) {}
@@ -180,7 +180,7 @@ class MyAlloc : public std::allocator<T> {
   template <class> friend class MyAlloc;
 public:
   template <class U>
-  struct rebind { typedef MyAlloc<U> other; };
+  struct rebind { using other = MyAlloc<U>; };
 
   MyAlloc(int state = 0)
     : state_(state) {}

--- a/reference/sstream/basic_istringstream.md
+++ b/reference/sstream/basic_istringstream.md
@@ -9,8 +9,8 @@ namespace std {
             class Allocator = allocator<CharT> >
   class basic_istringstream : public basic_istream<CharT, Traits>;
   
-  typedef basic_istringstream<char>    istringstream;
-  typedef basic_istringstream<wchar_t> wistringstream;
+  using istringstream  = basic_istringstream<char>;
+  using wistringstream = basic_istringstream<wchar_t>;
 }
 ```
 * char_traits[link /reference/string/char_traits.md]

--- a/reference/streambuf/basic_streambuf.md
+++ b/reference/streambuf/basic_streambuf.md
@@ -8,8 +8,8 @@ namespace std {
   template<class CharT, class Traits = char_traits<CharT>>
   class basic_streambuf { …… };
 
-  typedef basic_streambuf<char> streambuf;
-  typedef basic_streambuf<wchar_t> wstreambuf;
+  using streambuf  = basic_streambuf<char>;
+  using wstreambuf = basic_streambuf<wchar_t>;
 }
 ```
 * char_traits[link ../string/char_traits.md]

--- a/reference/string/basic_string.md
+++ b/reference/string/basic_string.md
@@ -10,10 +10,10 @@ namespace std {
             class Allocator = allocator<charT> >
   class basic_string;
 
-  typedef basic_string<char>     string;
-  typedef basic_string<char16_t> u16string;  // C++11から
-  typedef basic_string<char32_t> u32string;  // C++11から
-  typedef basic_string<wchar_t>  wstring;
+  using string    = basic_string<char>;
+  using u16string = basic_string<char16_t>;  // C++11から
+  using u32string = basic_string<char32_t>;  // C++11から
+  using wstring   = basic_string<wchar_t>;
 }
 ```
 * char_traits[link char_traits.md]

--- a/reference/tuple/tuple_element.md
+++ b/reference/tuple/tuple_element.md
@@ -15,7 +15,7 @@ namespace std {
   template <size_t I, class... Types>
   class tuple_element<I, tuple<Types...>> {
   public:
-    typedef TI type;
+    using type = TI;
   };
 
   template <size_t I, class T>

--- a/reference/type_traits/add_const.md
+++ b/reference/type_traits/add_const.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct add_const {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/add_cv.md
+++ b/reference/type_traits/add_cv.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct add_cv {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/add_lvalue_reference.md
+++ b/reference/type_traits/add_lvalue_reference.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct add_lvalue_reference {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/add_pointer.md
+++ b/reference/type_traits/add_pointer.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct add_pointer {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/add_rvalue_reference.md
+++ b/reference/type_traits/add_rvalue_reference.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct add_rvalue_reference {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/add_volatile.md
+++ b/reference/type_traits/add_volatile.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct add_volatile {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/aligned_storage.md
+++ b/reference/type_traits/aligned_storage.md
@@ -9,7 +9,7 @@ namespace std {
   template <std::size_t Len,
             std::size_t Align = default-alignment>
   struct aligned_storage {
-    typedef … type;
+    using type = …;
   };
 
   template <std::size_t Len,

--- a/reference/type_traits/aligned_union.md
+++ b/reference/type_traits/aligned_union.md
@@ -9,7 +9,7 @@ namespace std {
   template <std::size_t Len,
             class... Types>
   struct aligned_union {
-    typedef … type;
+    using type = …;
     static constexpr std::size_t alignment_value = …;
   };
 
@@ -48,7 +48,7 @@ union X {
 
 int main()
 {
-  typedef std::aligned_union<sizeof(X), int, std::string> aligned_X;
+  using aligned_X = std::aligned_union<sizeof(X), int, std::string>;
 
   aligned_X::type x;
 

--- a/reference/type_traits/common_type.md
+++ b/reference/type_traits/common_type.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class... Types>
   struct common_type {
-    typedef … type;
+    using type = …;
   };
 
   template <class... T>
@@ -66,17 +66,17 @@ struct common_type;
 
 template <class T>
 struct common_type<T> {
-  typedef T type;
+  using type = T;
 };
 
 template <class T, class U>
 struct common_type<T, U> {
-  typedef decltype(true ? declval<T>() : declval<U>()) type;
+  using type = decltype(true ? declval<T>() : declval<U>());
 };
 
 template <class T, class U, class... V>
 struct common_type<T, U, V...> {
-  typedef typename common_type<typename common_type<T, U>::type, V...>::type type;
+  using type = typename common_type<typename common_type<T, U>::type, V...>::type;
 };
 ```
 * declval[link /reference/utility/declval.md]
@@ -92,17 +92,17 @@ using common_type_t = typename common_type<T...>::type;
 
 template <class T>
 struct common_type<T> {
-  typedef decay_t<T> type;
+  using type = decay_t<T>;
 };
 
 template <class T, class U>
 struct common_type<T, U> {
-  typedef decay_t<decltype(true ? declval<T>() : declval<U>())> type;
+  using type = decay_t<decltype(true ? declval<T>() : declval<U>())>;
 };
 
 template <class T, class U, class... V>
 struct common_type<T, U, V...> {
-  typedef common_type_t<common_type_t<T, U>, V...> type;
+  using type = common_type_t<common_type_t<T, U>, V...>;
 };
 ```
 * decay_t[link decay.md]

--- a/reference/type_traits/conditional.md
+++ b/reference/type_traits/conditional.md
@@ -8,7 +8,7 @@
 namespace std {
   template <bool B, class T, class F>
   struct conditional {
-    typedef … type;
+    using type = …;
   };
 
   template <bool B, class T, class F>

--- a/reference/type_traits/decay.md
+++ b/reference/type_traits/decay.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct decay {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/false_type.md
+++ b/reference/type_traits/false_type.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef integral_constant<bool, false> true_type;
+  using true_type = integral_constant<bool, false>;
 }
 ```
 * integral_constant[link integral_constant.md]

--- a/reference/type_traits/integral_constant.md
+++ b/reference/type_traits/integral_constant.md
@@ -10,8 +10,8 @@ namespace std {
   struct integral_constant {
     static constexpr T value = v;
 
-    typedef T value_type;
-    typedef integral_constant<T,v> type;
+    using value_type = T;
+    using type       = integral_constant<T,v>;
 
     constexpr operator value_type()          { return value; } // C++11
     constexpr operator value_type() noexcept { return value; } // C++14
@@ -31,7 +31,7 @@ namespace std {
 ```cpp
 #include <type_traits>
 
-typedef std::integral_constant<int, 0> int_zero;
+using int_zero = std::integral_constant<int, 0>;
 
 static_assert(int_zero::value == 0, "value == 0");
 static_assert(std::is_same<int_zero::value_type, int>::value, "value_type == int");

--- a/reference/type_traits/is_function.md
+++ b/reference/type_traits/is_function.md
@@ -23,7 +23,7 @@ namespace std {
 ```cpp
 #include <type_traits>
 
-typedef void f();
+using f = void();
 
 static_assert(std::is_function<f>::value == true, "value == true, f is function");
 static_assert(std::is_same<std::is_function<f>::value_type, bool>::value, "value_type == bool");

--- a/reference/type_traits/is_same.md
+++ b/reference/type_traits/is_same.md
@@ -23,7 +23,7 @@ namespace std {
 ```cpp
 #include <type_traits>
 
-typedef std::is_same<int, int> same;
+using same = std::is_same<int, int>;
 
 static_assert(same::value == true, "int == int");
 static_assert(std::is_same<same::value_type, bool>::value, "value_type == bool");
@@ -31,14 +31,14 @@ static_assert(std::is_same<same::type, std::true_type>::value, "type == true_typ
 static_assert(same() == true, "same() == true");
 
 struct my_type{};
-typedef std::is_same<int, my_type> not_same;
+using not_same = std::is_same<int, my_type>;
 
 static_assert(not_same::value == false, "int != my_type");
 static_assert(std::is_same<not_same::value_type, bool>::value, "value_type == bool");
 static_assert(std::is_same<not_same::type, std::false_type>::value, "type == false_type");
 static_assert(not_same() == false, "not_same() == false");
 
-typedef int my_int;
+using my_int = int;
 
 static_assert(std::is_same<int, my_int>::value == true, "int == my_int");
 static_assert(std::is_same<my_type, my_type>::value == true, "my_type == my_type");

--- a/reference/type_traits/make_signed.md
+++ b/reference/type_traits/make_signed.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct make_signed {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/make_unsigned.md
+++ b/reference/type_traits/make_unsigned.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct make_unsigned {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/rank.md
+++ b/reference/type_traits/rank.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct rank {
-    typedef … type;
+    using type = …;
   };
 }
 ```

--- a/reference/type_traits/remove_all_extents.md
+++ b/reference/type_traits/remove_all_extents.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct remove_all_extents {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/remove_const.md
+++ b/reference/type_traits/remove_const.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct remove_const {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/remove_cv.md
+++ b/reference/type_traits/remove_cv.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct remove_cv {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/remove_extent.md
+++ b/reference/type_traits/remove_extent.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct remove_extent {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/remove_pointer.md
+++ b/reference/type_traits/remove_pointer.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct remove_pointer {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/remove_reference.md
+++ b/reference/type_traits/remove_reference.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct remove_reference {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/remove_volatile.md
+++ b/reference/type_traits/remove_volatile.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct remove_volatile {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/result_of.md
+++ b/reference/type_traits/result_of.md
@@ -10,7 +10,7 @@ namespace std {
 
   template <class F, class... ArgTypes>
   class result_of<F(ArgTypes...)> {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/type_traits/true_type.md
+++ b/reference/type_traits/true_type.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  typedef integral_constant<bool, true> true_type;
+  using true_type = integral_constant<bool, true>;
 }
 ```
 * integral_constant[link integral_constant.md]

--- a/reference/type_traits/underlying_type.md
+++ b/reference/type_traits/underlying_type.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T>
   struct underlying_type {
-    typedef … type;
+    using type = …;
   };
 
   template <class T>

--- a/reference/unordered_map/unordered_map/begin.md
+++ b/reference/unordered_map/unordered_map/begin.md
@@ -45,7 +45,7 @@ const_iterator begin() const noexcept;
 
 int main()
 {
-  typedef std::unordered_map<std::string, int> mymap;
+  using mymap = std::unordered_map<std::string, int>;
 
   mymap um{ { "1st", 1 }, { "2nd", 2 }, { "3rd", 3 }, };
   const mymap cum{um};

--- a/reference/unordered_map/unordered_map/cbegin.md
+++ b/reference/unordered_map/unordered_map/cbegin.md
@@ -37,7 +37,7 @@ const_iterator cbegin() const noexcept;
 
 int main()
 {
-  typedef std::unordered_map<std::string, int> mymap;
+  using mymap = std::unordered_map<std::string, int>;
 
   mymap um{ { "1st", 1 }, { "2nd", 2 }, { "3rd", 3 }, };
 

--- a/reference/unordered_map/unordered_map/cend.md
+++ b/reference/unordered_map/unordered_map/cend.md
@@ -37,7 +37,7 @@ const_iterator cend() const noexcept;
 
 int main()
 {
-  typedef std::unordered_map<std::string, int> mymap;
+  using mymap = std::unordered_map<std::string, int>;
 
   mymap um{ { "1st", 1 }, { "2nd", 2 }, { "3rd", 3 }, };
 

--- a/reference/unordered_map/unordered_map/emplace.md
+++ b/reference/unordered_map/unordered_map/emplace.md
@@ -76,7 +76,7 @@ pair<iterator, bool> emplace(Args&&... args);
 #include <algorithm>  // for std::for_each
 
 // サンプル用typedef
-typedef std::pair<const std::string, std::complex<double>> sc;
+using sc = std::pair<const std::string, std::complex<double>>;
 
 // サンプル用typedefのための挿入演算子
 std::ostream& operator<<(std::ostream& os, const sc& p)

--- a/reference/unordered_map/unordered_map/end.md
+++ b/reference/unordered_map/unordered_map/end.md
@@ -43,7 +43,7 @@ const_iterator end() const noexcept;
 
 int main()
 {
-  typedef std::unordered_map<std::string, int> mymap;
+  using mymap = std::unordered_map<std::string, int>;
 
   mymap um{ { "1st", 1 }, { "2nd", 2 }, { "3rd", 3 }, };
   const mymap cum{um};

--- a/reference/unordered_map/unordered_map/equal_range.md
+++ b/reference/unordered_map/unordered_map/equal_range.md
@@ -47,7 +47,7 @@ int main()
   c.insert(std::make_pair(4,'d'));
   c.insert(std::make_pair(5,'e'));
 
-  typedef std::unordered_map<int,char>::iterator it_t;
+  using it_t = std::unordered_map<int,char>::iterator;
   std::pair<it_t, it_t> ret = c.equal_range(3);
 
   std::cout << "low: " << ret.first->first << " " << ret.first->second << std::endl;

--- a/reference/unordered_map/unordered_map/erase.md
+++ b/reference/unordered_map/unordered_map/erase.md
@@ -63,7 +63,7 @@ iterator erase(const_iterator first, const_iterator last); // (3)
 #include <string>
 #include <utility>
 
-typedef std::pair<const std::string, int> si;
+using si = std::pair<const std::string, int>;
 
 std::ostream& operator<<(std::ostream& os, const si& p)
 {

--- a/reference/unordered_map/unordered_map/insert.md
+++ b/reference/unordered_map/unordered_map/insert.md
@@ -113,8 +113,8 @@ void insert(initializer_list<value_type> il);                  // (6)
 #include <utility>
 #include <initializer_list>
 
-typedef std::pair<const int, std::string> cis;
-typedef std::pair<int, std::string> is;
+using cis = std::pair<const int, std::string>;
+using is  = std::pair<int, std::string>;
 
 std::ostream& operator<<(std::ostream& os, const cis& p)
 {

--- a/reference/unordered_map/unordered_multimap/begin.md
+++ b/reference/unordered_map/unordered_multimap/begin.md
@@ -45,7 +45,7 @@ const_iterator begin() const noexcept;
 
 int main()
 {
-  typedef std::unordered_multimap<std::string, int> mymap;
+  using mymap = std::unordered_multimap<std::string, int>;
 
   mymap um{ { "1st", 1 }, { "2nd", 2 }, { "3rd", 3 }, };
   const mymap cum{um};

--- a/reference/unordered_map/unordered_multimap/cbegin.md
+++ b/reference/unordered_map/unordered_multimap/cbegin.md
@@ -37,7 +37,7 @@ const_iterator cbegin() const noexcept;
 
 int main()
 {
-  typedef std::unordered_multimap<std::string, int> mymap;
+  using mymap = std::unordered_multimap<std::string, int>;
 
   mymap um{ { "1st", 1 }, { "2nd", 2 }, { "3rd", 3 }, };
 

--- a/reference/unordered_map/unordered_multimap/cend.md
+++ b/reference/unordered_map/unordered_multimap/cend.md
@@ -37,7 +37,7 @@ const_iterator cend() const noexcept;
 
 int main()
 {
-  typedef std::unordered_multimap<std::string, int> mymap;
+  using mymap = std::unordered_multimap<std::string, int>;
 
   mymap um{ { "1st", 1 }, { "2nd", 2 }, { "3rd", 3 }, };
 

--- a/reference/unordered_map/unordered_multimap/emplace.md
+++ b/reference/unordered_map/unordered_multimap/emplace.md
@@ -67,7 +67,7 @@ iterator emplace(Args&&... args);
 #include <algorithm>  // for std::for_each
 
 // サンプル用typedef
-typedef std::pair<const int, std::string> is;
+using is = std::pair<const int, std::string>;
 
 // サンプル用typedefのための挿入演算子
 std::ostream& operator<<(std::ostream& os, const is& p)

--- a/reference/unordered_map/unordered_multimap/emplace_hint.md
+++ b/reference/unordered_map/unordered_multimap/emplace_hint.md
@@ -76,7 +76,7 @@ iterator emplace_hint(const_iterator position, Args&&... args);
 #include <iterator>   // for std::next
 
 // サンプル用typedef
-typedef std::pair<const int, std::string> is;
+using is = std::pair<const int, std::string>;
 
 // サンプル用typedefのための挿入演算子
 std::ostream& operator<<(std::ostream& os, const is& p)

--- a/reference/unordered_map/unordered_multimap/end.md
+++ b/reference/unordered_map/unordered_multimap/end.md
@@ -43,7 +43,7 @@ const_iterator end() const noexcept;
 
 int main()
 {
-  typedef std::unordered_multimap<std::string, int> mymap;
+  using mymap = std::unordered_multimap<std::string, int>;
 
   mymap um{ { "1st", 1 }, { "2nd", 2 }, { "3rd", 3 }, };
   const mymap cum{um};

--- a/reference/unordered_map/unordered_multimap/equal_range.md
+++ b/reference/unordered_map/unordered_multimap/equal_range.md
@@ -38,7 +38,7 @@ pair<const_iterator,const_iterator> equal_range(const key_type& x) const;
 #include <unordered_map>
 #include <algorithm>
 
-typedef std::unordered_multimap<int,char>::iterator it_t;
+using it_t = std::unordered_multimap<int,char>::iterator;
 
 void disp( std::pair<const int,char>& p) {
   std::cout << p.second << std::endl;

--- a/reference/unordered_map/unordered_multimap/erase.md
+++ b/reference/unordered_map/unordered_multimap/erase.md
@@ -63,7 +63,7 @@ iterator erase(const_iterator first, const_iterator last); // (3)
 #include <string>
 #include <utility>
 
-typedef std::pair<const std::string, int> si;
+using si = std::pair<const std::string, int>;
 
 std::ostream& operator<<(std::ostream& os, const si& p)
 {

--- a/reference/unordered_map/unordered_multimap/insert.md
+++ b/reference/unordered_map/unordered_multimap/insert.md
@@ -107,8 +107,8 @@ void insert(initializer_list<value_type> il);                  // (6)
 #include <utility>
 #include <initializer_list>
 
-typedef std::pair<const int, std::string> cis;
-typedef std::pair<int, std::string> is;
+using cis = std::pair<const int, std::string>;
+using is  = std::pair<int, std::string>;
 
 std::ostream& operator<<(std::ostream& os, const cis& p)
 {

--- a/reference/utility/integer_sequence.md
+++ b/reference/utility/integer_sequence.md
@@ -8,7 +8,7 @@
 namespace std {
   template <class T, T... I>
   struct integer_sequence {
-    typedef T value_type;
+    using value_type = T;
     static constexpr size_t size() noexcept { return sizeof...(I); }
   };
 }

--- a/reference/utility/pair/tuple_element.md
+++ b/reference/utility/pair/tuple_element.md
@@ -10,12 +10,12 @@ namespace std {
 
   template <class T1, class T2>
   struct tuple_element<0, pair<T1, T2>> {
-    typedef T1 type;
+    using type = T1;
   };
 
   template <class T1, class T2>
   struct tuple_element<1, pair<T1, T2>> {
-    typedef T2 type;
+    using type = T2;
   };
 }
 ```


### PR DESCRIPTION
#394 

`typdef` がコードで残っている箇所は
```
$ git grep -n -A1 -B1 'typedef\s\+[a-zA-Z]\+.*;'
editors_doc/type-type_template_page.md-19-```cpp
editors_doc/type-type_template_page.md:20:typedef origin_type new_type;
editors_doc/type-type_template_page.md-21-```
--
reference/map/multimap.md-155-  // charをキー、intを値として扱う連想配列
reference/map/multimap.md:156:  typedef std::multimap<char, int> MCI; // C++03 では型名を何度も書く必要があるので typedef しておく
reference/map/multimap.md-157-  MCI m;
--
reference/type_traits/is_function.md-25-
reference/type_traits/is_function.md:26:typedef void f();
reference/type_traits/is_function.md-27-
```

* [`editors_doc/type-type_template_page.md`](https://github.com/cpprefjp/site/blob/master/editors_doc/type-type_template_page.md) は "C++14で削除された機能" ？ なので保留
* [`reference/map/multimap.md`](https://github.com/cpprefjp/site/blob/master/reference/map/multimap.md) は C++03 版なので保留
* [`reference/type_traits/is_function.md`](https://github.com/cpprefjp/site/blob/master/reference/type_traits/is_function.md ) については `using` を使って `static_assert` が通るコードを書けなかったので，申し訳ありませんがどなたかお願いします

ご査証願います．