### PR TITLE
fixed probable mistake in the description of final

### DIFF
--- a/lang/cpp11.md
+++ b/lang/cpp11.md
@@ -36,7 +36,7 @@ C++11とは、2011年8月に改訂され、ISO/IEC 14882:2011で標準規格化�
 | [移譲コンストラクタ](cpp11/delegating_constructors.md) | コンストラクタから他のコンストラクタに処理を移譲する |
 | [非静的メンバ変数の初期化](cpp11/non_static_data_member_initializers.md) | メンバ変数を、宣言と同時に初期値指定する |
 | [継承コンストラクタ](cpp11/inheriting_constructors.md) | 基本クラスのコンストラクタを継承する |
-| [`override`と`final`](cpp11/override_final.md) | メンバ関数のオーバーライド指定、および派生クラスでのオーバーロードの禁止を指定する |
+| [`override`と`final`](cpp11/override_final.md) | メンバ関数のオーバーライド指定、および派生クラスでのオーバーライドの禁止を指定する |
 | [明示的な型変換演算子のオーバーロード](cpp11/explicit_conversion_operator.md) | 明示的な型変換が行われる場合にのみ呼び出される演算子をオーバーロードできるようにする |
 | [`friend`宣言できる対象を拡張](cpp11/extend_friend_targets.md) | テンプレートパラメータや型の別名を`friend`宣言する |
 | [メンバ関数の左辺値／右辺値修飾](cpp11/ref_qualifier_for_this.md) | オブジェクトが左辺値／右辺値の場合のみ呼び出し可能であることの指定 |


### PR DESCRIPTION
finalの概要説明部分で、オーバーライドであるべき部分がオーバーロードと表記されていた箇所を修正しました。