### PR TITLE
vector::operator[ ] : vector::begin()へのリンク忘れを修正

### DIFF
--- a/reference/vector/op_at.md
+++ b/reference/vector/op_at.md
@@ -22,7 +22,7 @@ const_reference operator[](size_type n) const;
 
 
 ## 備考
-`vector`型のオブジェクト`v`に対して、`v[n]` と `*(v.begin() + n)` は同じ結果になる。
+`vector`型のオブジェクト`v`に対して、`v[n]` と `*(v.`[`begin()`](begin.md)` + n)` は同じ結果になる。
 
 
 ## 例


### PR DESCRIPTION
array::operator[ ] と同様に説明文中の `begin()` が `vector::begin` へのリンクとなるよう変更しました。