### PR TITLE
std::char_traits::compare 定数時間 から 線形時間 に変更

### DIFF
--- a/reference/string/char_traits/compare.md
+++ b/reference/string/char_traits/compare.md
@@ -20,7 +20,7 @@ static int compare(const char_type* s1, const char_type* s2, size_t n);
 
 
 ## 計算量
-定数時間
+線形時間
 
 
 ## 例


### PR DESCRIPTION
規格(参考にしたのはドラフトのN3337とN4296ですが)によると `linear` とのことだったので、変更しました。
