### PR TITLE
コンセプトから meta namespace を削除

### DIFF
--- a/reference/concepts/Callable.md
+++ b/reference/concepts/Callable.md
@@ -1,6 +1,5 @@
 # Callable
 * concepts[meta header]
-* std[meta namespace]
 * cpp11[meta cpp]
 
 

--- a/reference/concepts/CopyAssignable.md
+++ b/reference/concepts/CopyAssignable.md
@@ -1,6 +1,5 @@
 # CopyAssignable
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 CopyAssignableは、任意の型`T`が、コピー代入可能であることを表す要件である。

--- a/reference/concepts/CopyConstructible.md
+++ b/reference/concepts/CopyConstructible.md
@@ -1,6 +1,5 @@
 # CopyConstructible
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 CopyConstructibleは、任意の型`T`がコピー構築可能であることを表す要件である。

--- a/reference/concepts/DefaultConstructible.md
+++ b/reference/concepts/DefaultConstructible.md
@@ -1,6 +1,5 @@
 # DefaultConstructible
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 DefaultConstructibleは、任意の型`T`がデフォルト構築可能であること表す要件である。

--- a/reference/concepts/Destructible.md
+++ b/reference/concepts/Destructible.md
@@ -1,6 +1,5 @@
 # Destructible
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 Destructibleは、任意の型`T`が破棄可能であることを表す要件である。

--- a/reference/concepts/EqualityComparable.md
+++ b/reference/concepts/EqualityComparable.md
@@ -1,6 +1,5 @@
 # EqualityComparable
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 EqualityComparableは、2つのオブジェクト`a`と`b`が`==`演算子で等価関係にあるかを表す要件である。

--- a/reference/concepts/Invoke.md
+++ b/reference/concepts/Invoke.md
@@ -1,6 +1,5 @@
 # INVOKE
 * concepts[meta header]
-* std[meta namespace]
 * cpp11[meta cpp]
 
 ## 用語定義

--- a/reference/concepts/LessThanComparable.md
+++ b/reference/concepts/LessThanComparable.md
@@ -1,6 +1,5 @@
 # LessThanComparable
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 LessThanComparableは、2つのオブジェクト`a`と`b`が`<`演算子で大小関係にあるかを表す要件である。

--- a/reference/concepts/MoveAssignable.md
+++ b/reference/concepts/MoveAssignable.md
@@ -1,6 +1,5 @@
 # MoveAssignable
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 MoveAssignableは、任意の型`T`がムーブ代入可能であることを表す要件である。

--- a/reference/concepts/MoveConstructible.md
+++ b/reference/concepts/MoveConstructible.md
@@ -1,6 +1,5 @@
 # MoveConstructible
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 MoveConstructibleは、任意の型`T`がムーブ構築可能であることを表す要件である。

--- a/reference/concepts/Swappable.md
+++ b/reference/concepts/Swappable.md
@@ -1,6 +1,5 @@
 # Swappable
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 Swappableは、任意の型`T`のオブジェクトと任意の型`U`のオブジェクトが入れ替え可能かを表す要件である。

--- a/reference/concepts/ValueSwappable.md
+++ b/reference/concepts/ValueSwappable.md
@@ -1,6 +1,5 @@
 # ValueSwappable
 * concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 ValueSwappableは、イテレータ要件を満たす型のオブジェクトが、間接参照した値で入れ替え可能かを表す要件である

--- a/reference/container_concepts/CopyInsertable.md
+++ b/reference/container_concepts/CopyInsertable.md
@@ -1,6 +1,5 @@
 # CopyInsertable
 * container_concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 CopyInsertableは、任意のコンテナ`X`に対して、その要素型オブジェクトをコピー挿入可能かを表す要件である。

--- a/reference/container_concepts/EmplaceConstructible.md
+++ b/reference/container_concepts/EmplaceConstructible.md
@@ -1,6 +1,5 @@
 # EmplaceConstructible
 * container_concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 EmplaceConstructibleは、任意のコンテナ`X`に対して、要素型`T`のコンストラクタ引数列`args`から直接構築可能かを表す要件である。

--- a/reference/container_concepts/MoveInsertable.md
+++ b/reference/container_concepts/MoveInsertable.md
@@ -1,6 +1,5 @@
 # MoveInsertable
 * container_concepts[meta header]
-* std[meta namespace]
 
 ## 概要
 MoveInsertableは、任意のコンテナ`X`に対して、その要素型の右辺値オブジェクトをムーブ挿入可能かを表す要件である。


### PR DESCRIPTION
ref: #469 https://github.com/cpprefjp/site/issues/469#issuecomment-326191629

>> タイトルで std::Callable とすべきではないと思います．

> これはミスなので、見つけたら適時直してください。

直しました。

ジェネレータのソースコードを読んでみましたが、 meta が無ければヘッダの文字列がそのまま使われるので、単純に削除して大丈夫だと思います。

https://github.com/cpprefjp/markdown_to_html/blob/e8bdbadd6e2838c8bd1ce377316a915cc6bcad08/meta.py#L133
