### PR TITLE
 Google Analyticsのポリシーを表記

### DIFF
--- a/index.md
+++ b/index.md
@@ -62,6 +62,10 @@ cpprefjp プロジェクトに参加する方法は簡単です。
 
 本サイトは、サイトの改善のためにGoogleアナリティクスを使用しています。本サイトをご利用中のブラウザは、Googleに特定の情報を自動的に送信します。本サイトは、この分析のためにCookieを使用します。利用者は、本サイトを利用することで、この目的においてCookieを使用することを許可したものとみなします。
 
+Googleによるデータ使用の詳細は、以下のURLで確認することができます。
+
+https://www.google.com/intl/ja/policies/privacy/partners/
+
 
 ## ライセンスについて
 本サイトの情報は、[クリエイティブ・コモンズ 表示 3.0 非移植 ライセンス(CC BY)](https://creativecommons.org/licenses/by/3.0/)の下に提供しています。

--- a/index.md
+++ b/index.md
@@ -64,7 +64,7 @@ cpprefjp プロジェクトに参加する方法は簡単です。
 
 Googleによるデータ使用の詳細は、以下のURLで確認することができます。
 
-https://www.google.com/intl/ja/policies/privacy/partners/
+<https://www.google.com/intl/ja/policies/privacy/partners/>
 
 
 ## ライセンスについて

--- a/index.md
+++ b/index.md
@@ -58,6 +58,11 @@ cpprefjp プロジェクトに参加する方法は簡単です。
 - [Standard Template Library プログラミング on the Web](http://episteme.wankuma.com/stlprog/index.html)
 
 
+## プライバシーポリシー
+
+本サイトは、サイトの改善のためにGoogleアナリティクスを使用しています。本サイトをご利用中のブラウザは、Googleに特定の情報を自動的に送信します。本サイトは、この分析のためにCookieを使用します。利用者は、本サイトを利用することで、この目的においてCookieを使用することを許可したものとみなします。
+
+
 ## ライセンスについて
 本サイトの情報は、[クリエイティブ・コモンズ 表示 3.0 非移植 ライセンス(CC BY)](https://creativecommons.org/licenses/by/3.0/)の下に提供しています。
 


### PR DESCRIPTION
アナリティクス利用規約の第7項「プライバシー」では、サイト内でアナリティクスを利用する際にプライバシーポリシーを示さなければならないとされています。この目的のため、現状を簡潔に説明したポリシーを新しくトップページに表記します。

https://www.google.com/analytics/terms/jp.html