### PR TITLE
minmaxの注記に、ダングリングが発生するケースを追加

### DIFF
--- a/reference/algorithm/minmax.md
+++ b/reference/algorithm/minmax.md
@@ -53,6 +53,24 @@ namespace std {
 - 2値比較バージョンは1操作。
 - `initializer_list`バージョンは高々`(3/2) * t.size()`回の述語適用。
 
+## 備考
+- (1), (2) : 引数に右辺値を与えた場合、`minmax`の呼び出しを含む式の評価が終わった時点で、返された参照はダングリングすることに注意：
+```cpp example
+#include <cassert>
+#include <algorithm>
+
+int main()
+{
+  int x = 10;
+  auto result1 = std::minmax(x, 11);   // typeof(result1) == std::pair<const int&, const int&>
+  assert(result1.first == 10);         // ok: result1.first は xを参照している
+  assert(result1.second == 11);        // 不定: result1.secondは 消失した右辺値を参照している
+
+  std::pair<int, int> result2 = std::minmax(x, 11);
+  assert(result2.first == 10);         // ok: result2.first は xのコピーを持っている
+  assert(result2.second == 11);        // ok: result2.second は 右辺値11のコピーを持っている
+}
+```
 
 ## 例
 ```cpp example


### PR DESCRIPTION
qiitaにて、std::minmax()の落とし穴について投稿いたしました。
https://qiita.com/sumomoneko/items/58358eb8bcc8b70a481b

実際にminmax()を使う際に参照されることが多いであろうこのサイトにて、
注意喚起があって良いのではと思い、またyumetodoさんの後押しもあって
備考を追記しました。

下記議論を参照し、サンプルコードの拡張記法にも対応させています。
https://github.com/cpprefjp/site/issues/481
最適化の具合により、assert()で問題が出たり出なかったりします。