### PR TITLE
basic_ostream::put の関数シグネチャの修正

### DIFF
--- a/reference/ostream/basic_ostream/put.md
+++ b/reference/ostream/basic_ostream/put.md
@@ -5,7 +5,7 @@
 * function[meta id-type]
 
 ```cpp
-basic_ostream<CharT, Traits>& write(const char_type* s, streamsize n);
+basic_ostream<CharT, Traits>& put(char_type c);
 ```
 
 ## 概要


### PR DESCRIPTION
[basic_ostream::put](https://cpprefjp.github.io/reference/ostream/basic_ostream/put.html) の記事にて
`write`のシグネチャが紹介されているため,`put`のシグネチャに差し替え.

簡単な修正ですが、push権限がないのでPull-requestを送信いたします。
ご精査のほどよろしくお願いいたします。