### PR TITLE
Visual C++バージョン表記の、抜けていたコロンを追加

### DIFF
--- a/reference/cmath/acos.md
+++ b/reference/cmath/acos.md
@@ -79,7 +79,7 @@ acos(-1.0) = 3.141593
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/asin.md
+++ b/reference/cmath/asin.md
@@ -75,7 +75,7 @@ asin(1.0)   = 1.570796
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/atan.md
+++ b/reference/cmath/atan.md
@@ -76,7 +76,7 @@ atan(∞)    = 1.570796
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/atan2.md
+++ b/reference/cmath/atan2.md
@@ -97,7 +97,7 @@ atan2(-1.0, 1.0)  = -0.785398
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/cos.md
+++ b/reference/cmath/cos.md
@@ -95,7 +95,7 @@ int main()
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/cosh.md
+++ b/reference/cmath/cosh.md
@@ -68,7 +68,7 @@ cosh(1.0)  = 1.543081
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/exp.md
+++ b/reference/cmath/exp.md
@@ -73,7 +73,7 @@ exp(-∞) = 0.000000
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/fabs.md
+++ b/reference/cmath/fabs.md
@@ -76,7 +76,7 @@ fabs(-∞)   = inf
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/log.md
+++ b/reference/cmath/log.md
@@ -75,7 +75,7 @@ log(-1.0) = nan
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/log10.md
+++ b/reference/cmath/log10.md
@@ -108,7 +108,7 @@ log10(100000000.000000) : 8.000000
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/pow.md
+++ b/reference/cmath/pow.md
@@ -108,7 +108,7 @@ pow(2.0, -∞)   = 0.000000
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/sin.md
+++ b/reference/cmath/sin.md
@@ -95,7 +95,7 @@ int main()
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/sinh.md
+++ b/reference/cmath/sinh.md
@@ -68,7 +68,7 @@ sinh(1.0)  = 1.175201
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/sqrt.md
+++ b/reference/cmath/sqrt.md
@@ -81,7 +81,7 @@ sqrt(-1.0) = -nan
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/tan.md
+++ b/reference/cmath/tan.md
@@ -70,7 +70,7 @@ tan(pi/2) = 16331239353195370.000000
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/cmath/tanh.md
+++ b/reference/cmath/tanh.md
@@ -65,7 +65,7 @@ tanh(1.0)  = 0.761594
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.1, 4.5.2, 4.6.1, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.1, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0
 
 #### 備考
 特定の環境で `constexpr` 指定されている場合がある。（独自拡張）

--- a/reference/forward_list.md
+++ b/reference/forward_list.md
@@ -183,7 +183,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/forward_list/clear.md
+++ b/reference/forward_list/clear.md
@@ -69,7 +69,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/forward_list/empty.md
+++ b/reference/forward_list/empty.md
@@ -63,7 +63,7 @@ false
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/forward_list/erase_after.md
+++ b/reference/forward_list/erase_after.md
@@ -87,7 +87,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/forward_list/front.md
+++ b/reference/forward_list/front.md
@@ -51,7 +51,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/forward_list/max_size.md
+++ b/reference/forward_list/max_size.md
@@ -55,7 +55,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/forward_list/pop_front.md
+++ b/reference/forward_list/pop_front.md
@@ -58,7 +58,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/forward_list/push_front.md
+++ b/reference/forward_list/push_front.md
@@ -64,7 +64,7 @@ world
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/forward_list/resize.md
+++ b/reference/forward_list/resize.md
@@ -79,7 +79,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 ## 参照
 

--- a/reference/forward_list/splice_after.md
+++ b/reference/forward_list/splice_after.md
@@ -132,7 +132,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0(右辺値参照バージョンのみ実装されている)
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/bad_function_call.md
+++ b/reference/functional/bad_function_call.md
@@ -50,7 +50,7 @@ bad function call
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.4, 4.7.2(what()が"std::bad_weak_ptr"を返すので規格違反。バグ報告済み: [#55847](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55847)。4.7.3で修正されている。)
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ### 参照

--- a/reference/functional/bind.md
+++ b/reference/functional/bind.md
@@ -87,7 +87,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/bit_and.md
+++ b/reference/functional/bit_and.md
@@ -89,7 +89,7 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## C++14バージョン
@@ -97,7 +97,7 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.4
 - [GCC, C++11 mode](/implementation.md#gcc): 4.9
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/bit_not.md
+++ b/reference/functional/bit_not.md
@@ -79,7 +79,7 @@ int main()
 - [Clang, C++14 mode](/implementation.md#clang): 3.4
 - [GCC, C++14 mode](/implementation.md#gcc): 4.9
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/bit_or.md
+++ b/reference/functional/bit_or.md
@@ -89,7 +89,7 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## C++14バージョン
@@ -97,7 +97,7 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.4
 - [GCC, C++11 mode](/implementation.md#gcc): 4.9
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/bit_xor.md
+++ b/reference/functional/bit_xor.md
@@ -89,7 +89,7 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## C++14バージョン
@@ -97,7 +97,7 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.4
 - [GCC, C++11 mode](/implementation.md#gcc): 4.9
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/cref.md
+++ b/reference/functional/cref.md
@@ -68,7 +68,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/hash.md
+++ b/reference/functional/hash.md
@@ -121,7 +121,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 ## 参照
 - [ハッシュ関数 - Wikipedia](https://ja.wikipedia.org/wiki/ハッシュ関数)

--- a/reference/functional/not_fn.md
+++ b/reference/functional/not_fn.md
@@ -103,7 +103,7 @@ true
 - [Clang, C++17 mode](/implementation.md#clang): 3.9.1
 - [GCC, C++17 mode](/implementation.md#gcc): 7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/ref.md
+++ b/reference/functional/ref.md
@@ -66,7 +66,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/reference_wrapper.md
+++ b/reference/functional/reference_wrapper.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/reference_wrapper/get.md
+++ b/reference/functional/reference_wrapper/get.md
@@ -53,7 +53,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 ## 参照
 

--- a/reference/functional/reference_wrapper/op_assign.md
+++ b/reference/functional/reference_wrapper/op_assign.md
@@ -58,7 +58,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/reference_wrapper/op_call.md
+++ b/reference/functional/reference_wrapper/op_call.md
@@ -66,7 +66,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/reference_wrapper/op_cast_ref_t.md
+++ b/reference/functional/reference_wrapper/op_cast_ref_t.md
@@ -52,7 +52,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/functional/reference_wrapper/op_constructor.md
+++ b/reference/functional/reference_wrapper/op_constructor.md
@@ -59,7 +59,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/future/make_error_condition.md
+++ b/reference/future/make_error_condition.md
@@ -63,7 +63,7 @@ message : Broken promise
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/begin.md
+++ b/reference/iterator/begin.md
@@ -87,7 +87,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/cbegin.md
+++ b/reference/iterator/cbegin.md
@@ -64,7 +64,7 @@ int main()
 - [Clang, C++14 mode](/implementation.md#clang): 3.4
 - [GCC, C++14 mode](/implementation.md#gcc): 5.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/cend.md
+++ b/reference/iterator/cend.md
@@ -64,7 +64,7 @@ int main()
 - [Clang, C++14 mode](/implementation.md#clang): 3.4
 - [GCC, C++14 mode](/implementation.md#gcc): 5.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/crbegin.md
+++ b/reference/iterator/crbegin.md
@@ -89,7 +89,7 @@ int main()
 - [Clang, C++14 mode](/implementation.md#clang): 3.4
 - [GCC, C++14 mode](/implementation.md#gcc): 5.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/crend.md
+++ b/reference/iterator/crend.md
@@ -89,7 +89,7 @@ int main()
 - [Clang, C++14 mode](/implementation.md#clang): 3.4
 - [GCC, C++14 mode](/implementation.md#gcc): 5.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/end.md
+++ b/reference/iterator/end.md
@@ -87,7 +87,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/istreambuf_iterator/op_arrow.md
+++ b/reference/iterator/istreambuf_iterator/op_arrow.md
@@ -38,7 +38,7 @@ pointer operator->() const;
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/make_move_iterator.md
+++ b/reference/iterator/make_move_iterator.md
@@ -61,7 +61,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/make_reverse_iterator.md
+++ b/reference/iterator/make_reverse_iterator.md
@@ -59,7 +59,7 @@ int main()
 - [Clang, C++14 mode](/implementation.md#clang): 3.5
 - [GCC, C++14 mode](/implementation.md#gcc): 5.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator.md
+++ b/reference/iterator/move_iterator.md
@@ -108,7 +108,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/base.md
+++ b/reference/iterator/move_iterator/base.md
@@ -53,7 +53,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_arrow.md
+++ b/reference/iterator/move_iterator/op_arrow.md
@@ -55,7 +55,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_assign.md
+++ b/reference/iterator/move_iterator/op_assign.md
@@ -57,7 +57,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_at.md
+++ b/reference/iterator/move_iterator/op_at.md
@@ -55,7 +55,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_constructor.md
+++ b/reference/iterator/move_iterator/op_constructor.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_decrement.md
+++ b/reference/iterator/move_iterator/op_decrement.md
@@ -71,7 +71,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_deref.md
+++ b/reference/iterator/move_iterator/op_deref.md
@@ -53,7 +53,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_equal.md
+++ b/reference/iterator/move_iterator/op_equal.md
@@ -61,7 +61,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_greater.md
+++ b/reference/iterator/move_iterator/op_greater.md
@@ -62,7 +62,7 @@ greater
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_greater_equal.md
+++ b/reference/iterator/move_iterator/op_greater_equal.md
@@ -62,7 +62,7 @@ greater
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_increment.md
+++ b/reference/iterator/move_iterator/op_increment.md
@@ -70,7 +70,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_less.md
+++ b/reference/iterator/move_iterator/op_less.md
@@ -63,7 +63,7 @@ less
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_less_equal.md
+++ b/reference/iterator/move_iterator/op_less_equal.md
@@ -62,7 +62,7 @@ less
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_minus.md
+++ b/reference/iterator/move_iterator/op_minus.md
@@ -61,7 +61,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_minus_assign.md
+++ b/reference/iterator/move_iterator/op_minus_assign.md
@@ -61,7 +61,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_not_equal.md
+++ b/reference/iterator/move_iterator/op_not_equal.md
@@ -63,7 +63,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_plus.md
+++ b/reference/iterator/move_iterator/op_plus.md
@@ -58,7 +58,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_plus_assign.md
+++ b/reference/iterator/move_iterator/op_plus_assign.md
@@ -60,7 +60,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_unary_minus.md
+++ b/reference/iterator/move_iterator/op_unary_minus.md
@@ -55,7 +55,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/move_iterator/op_unary_plus.md
+++ b/reference/iterator/move_iterator/op_unary_plus.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/next.md
+++ b/reference/iterator/next.md
@@ -71,7 +71,7 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.4.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/prev.md
+++ b/reference/iterator/prev.md
@@ -68,7 +68,7 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.4
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/rbegin.md
+++ b/reference/iterator/rbegin.md
@@ -104,7 +104,7 @@ int main()
 - [Clang, C++14 mode](/implementation.md#clang): 3.4
 - [GCC, C++14 mode](/implementation.md#gcc): 5.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/iterator/rend.md
+++ b/reference/iterator/rend.md
@@ -104,7 +104,7 @@ int main()
 - [Clang, C++14 mode](/implementation.md#clang): 3.4
 - [GCC, C++14 mode](/implementation.md#gcc): 5.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/list/cbegin.md
+++ b/reference/list/cbegin.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/list/cend.md
+++ b/reference/list/cend.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/list/clear.md
+++ b/reference/list/clear.md
@@ -65,7 +65,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/list/crbegin.md
+++ b/reference/list/crbegin.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc):
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/list/crend.md
+++ b/reference/list/crend.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/list/emplace.md
+++ b/reference/list/emplace.md
@@ -72,7 +72,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.4
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/list/emplace_back.md
+++ b/reference/list/emplace_back.md
@@ -60,7 +60,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.4
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/list/emplace_front.md
+++ b/reference/list/emplace_front.md
@@ -60,7 +60,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.4
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/locale/tolower.md
+++ b/reference/locale/tolower.md
@@ -53,7 +53,7 @@ a
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.2, 4.6.3, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.3, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0, 11.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0, 11.0
 
 
 ## 実装例

--- a/reference/locale/toupper.md
+++ b/reference/locale/toupper.md
@@ -53,7 +53,7 @@ A
 - [GCC](/implementation.md#gcc): 3.4.6, 4.2.4, 4.3.5, 4.4.5, 4.5.2, 4.6.3, 4.7.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.4.5, 4.5.2, 4.6.3, 4.7.0
 - [ICC](/implementation.md#icc): 10.1, 11.0, 11.1, 12.0
-- [Visual C++](/implementation.md#visual_cpp) 7.1, 8.0, 9.0, 10.0, 11.0
+- [Visual C++](/implementation.md#visual_cpp): 7.1, 8.0, 9.0, 10.0, 11.0
 
 ## 実装例
 ```cpp

--- a/reference/memory/unique_ptr.md
+++ b/reference/memory/unique_ptr.md
@@ -131,7 +131,7 @@ hoge::~hoge()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.4, 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/queue/priority_queue/emplace.md
+++ b/reference/queue/priority_queue/emplace.md
@@ -70,7 +70,7 @@ int main ()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 ## 参照
 - [N2680 Proposed Wording for Placement Insert (Revision 1)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2680.pdf)

--- a/reference/queue/priority_queue/op_constructor.md
+++ b/reference/queue/priority_queue/op_constructor.md
@@ -191,7 +191,7 @@ que5 : 5 4 3 2 1
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0(アロケータ付き初期化以外は使用可能)
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/queue/priority_queue/push.md
+++ b/reference/queue/priority_queue/push.md
@@ -73,7 +73,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/queue/priority_queue/swap.md
+++ b/reference/queue/priority_queue/swap.md
@@ -84,7 +84,7 @@ int main ()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/queue/priority_queue/swap_free.md
+++ b/reference/queue/priority_queue/swap_free.md
@@ -83,7 +83,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/queue/queue/emplace.md
+++ b/reference/queue/queue/emplace.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): ??
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp)
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 参照

--- a/reference/queue/queue/swap.md
+++ b/reference/queue/queue/swap.md
@@ -79,7 +79,7 @@ int main ()
 - [GCC](/implementation.md#gcc): ??
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp)
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 参照

--- a/reference/queue/queue/swap_free.md
+++ b/reference/queue/queue/swap_free.md
@@ -81,7 +81,7 @@ int main ()
 - [GCC](/implementation.md#gcc): ??
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp)
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/max.md
+++ b/reference/random/bernoulli_distribution/max.md
@@ -46,7 +46,7 @@ true
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/min.md
+++ b/reference/random/bernoulli_distribution/min.md
@@ -46,7 +46,7 @@ false
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/op_call.md
+++ b/reference/random/bernoulli_distribution/op_call.md
@@ -93,7 +93,7 @@ true
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/op_constructor.md
+++ b/reference/random/bernoulli_distribution/op_constructor.md
@@ -94,7 +94,7 @@ true
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/op_equal.md
+++ b/reference/random/bernoulli_distribution/op_equal.md
@@ -57,7 +57,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/op_istream.md
+++ b/reference/random/bernoulli_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/op_not_equal.md
+++ b/reference/random/bernoulli_distribution/op_not_equal.md
@@ -57,7 +57,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/op_ostream.md
+++ b/reference/random/bernoulli_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/p.md
+++ b/reference/random/bernoulli_distribution/p.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/param.md
+++ b/reference/random/bernoulli_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/bernoulli_distribution/reset.md
+++ b/reference/random/bernoulli_distribution/reset.md
@@ -67,7 +67,7 @@ true
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/max.md
+++ b/reference/random/binomial_distribution/max.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/min.md
+++ b/reference/random/binomial_distribution/min.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/op_call.md
+++ b/reference/random/binomial_distribution/op_call.md
@@ -81,7 +81,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/op_constructor.md
+++ b/reference/random/binomial_distribution/op_constructor.md
@@ -72,7 +72,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/op_equal.md
+++ b/reference/random/binomial_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/op_istream.md
+++ b/reference/random/binomial_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/op_not_equal.md
+++ b/reference/random/binomial_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/op_ostream.md
+++ b/reference/random/binomial_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/p.md
+++ b/reference/random/binomial_distribution/p.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/param.md
+++ b/reference/random/binomial_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/reset.md
+++ b/reference/random/binomial_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/binomial_distribution/t.md
+++ b/reference/random/binomial_distribution/t.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/a.md
+++ b/reference/random/cauchy_distribution/a.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/b.md
+++ b/reference/random/cauchy_distribution/b.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/op_call.md
+++ b/reference/random/cauchy_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/op_constructor.md
+++ b/reference/random/cauchy_distribution/op_constructor.md
@@ -94,7 +94,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/op_equal.md
+++ b/reference/random/cauchy_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/op_istream.md
+++ b/reference/random/cauchy_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/op_not_equal.md
+++ b/reference/random/cauchy_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/op_ostream.md
+++ b/reference/random/cauchy_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/param.md
+++ b/reference/random/cauchy_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/cauchy_distribution/reset.md
+++ b/reference/random/cauchy_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/chi_squared_distribution/n.md
+++ b/reference/random/chi_squared_distribution/n.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/chi_squared_distribution/op_call.md
+++ b/reference/random/chi_squared_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/chi_squared_distribution/op_constructor.md
+++ b/reference/random/chi_squared_distribution/op_constructor.md
@@ -93,7 +93,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/chi_squared_distribution/op_equal.md
+++ b/reference/random/chi_squared_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/chi_squared_distribution/op_istream.md
+++ b/reference/random/chi_squared_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/chi_squared_distribution/op_not_equal.md
+++ b/reference/random/chi_squared_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/chi_squared_distribution/op_ostream.md
+++ b/reference/random/chi_squared_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/chi_squared_distribution/param.md
+++ b/reference/random/chi_squared_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/chi_squared_distribution/reset.md
+++ b/reference/random/chi_squared_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/base.md
+++ b/reference/random/discard_block_engine/base.md
@@ -47,7 +47,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/discard.md
+++ b/reference/random/discard_block_engine/discard.md
@@ -74,7 +74,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/max.md
+++ b/reference/random/discard_block_engine/max.md
@@ -50,7 +50,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/min.md
+++ b/reference/random/discard_block_engine/min.md
@@ -50,7 +50,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/op_call.md
+++ b/reference/random/discard_block_engine/op_call.md
@@ -70,7 +70,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/op_constructor.md
+++ b/reference/random/discard_block_engine/op_constructor.md
@@ -117,7 +117,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/op_equal.md
+++ b/reference/random/discard_block_engine/op_equal.md
@@ -59,7 +59,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/op_istream.md
+++ b/reference/random/discard_block_engine/op_istream.md
@@ -80,7 +80,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/op_not_equal.md
+++ b/reference/random/discard_block_engine/op_not_equal.md
@@ -61,7 +61,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/op_ostream.md
+++ b/reference/random/discard_block_engine/op_ostream.md
@@ -59,7 +59,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discard_block_engine/seed.md
+++ b/reference/random/discard_block_engine/seed.md
@@ -111,7 +111,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/max.md
+++ b/reference/random/discrete_distribution/max.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/min.md
+++ b/reference/random/discrete_distribution/min.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/op_call.md
+++ b/reference/random/discrete_distribution/op_call.md
@@ -95,7 +95,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/op_constructor.md
+++ b/reference/random/discrete_distribution/op_constructor.md
@@ -141,7 +141,7 @@ parameter constructor : 2
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/op_equal.md
+++ b/reference/random/discrete_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/op_istream.md
+++ b/reference/random/discrete_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/op_not_equal.md
+++ b/reference/random/discrete_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/op_ostream.md
+++ b/reference/random/discrete_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/param.md
+++ b/reference/random/discrete_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/probabilities.md
+++ b/reference/random/discrete_distribution/probabilities.md
@@ -52,7 +52,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/discrete_distribution/reset.md
+++ b/reference/random/discrete_distribution/reset.md
@@ -65,7 +65,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/exponential_distribution/lambda.md
+++ b/reference/random/exponential_distribution/lambda.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/exponential_distribution/op_call.md
+++ b/reference/random/exponential_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/exponential_distribution/op_constructor.md
+++ b/reference/random/exponential_distribution/op_constructor.md
@@ -71,7 +71,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/exponential_distribution/op_equal.md
+++ b/reference/random/exponential_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/exponential_distribution/op_istream.md
+++ b/reference/random/exponential_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/exponential_distribution/op_not_equal.md
+++ b/reference/random/exponential_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/exponential_distribution/op_ostream.md
+++ b/reference/random/exponential_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/exponential_distribution/param.md
+++ b/reference/random/exponential_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/exponential_distribution/reset.md
+++ b/reference/random/exponential_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/a.md
+++ b/reference/random/extreme_value_distribution/a.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/b.md
+++ b/reference/random/extreme_value_distribution/b.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/max.md
+++ b/reference/random/extreme_value_distribution/max.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/min.md
+++ b/reference/random/extreme_value_distribution/min.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/op_call.md
+++ b/reference/random/extreme_value_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/op_constructor.md
+++ b/reference/random/extreme_value_distribution/op_constructor.md
@@ -92,7 +92,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/op_equal.md
+++ b/reference/random/extreme_value_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/op_istream.md
+++ b/reference/random/extreme_value_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/op_not_equal.md
+++ b/reference/random/extreme_value_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/op_ostream.md
+++ b/reference/random/extreme_value_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/param.md
+++ b/reference/random/extreme_value_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/extreme_value_distribution/reset.md
+++ b/reference/random/extreme_value_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/m.md
+++ b/reference/random/fisher_f_distribution/m.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/n.md
+++ b/reference/random/fisher_f_distribution/n.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/op_call.md
+++ b/reference/random/fisher_f_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/op_constructor.md
+++ b/reference/random/fisher_f_distribution/op_constructor.md
@@ -94,7 +94,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/op_equal.md
+++ b/reference/random/fisher_f_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/op_istream.md
+++ b/reference/random/fisher_f_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/op_not_equal.md
+++ b/reference/random/fisher_f_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/op_ostream.md
+++ b/reference/random/fisher_f_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/param.md
+++ b/reference/random/fisher_f_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/fisher_f_distribution/reset.md
+++ b/reference/random/fisher_f_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/alpha.md
+++ b/reference/random/gamma_distribution/alpha.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/beta.md
+++ b/reference/random/gamma_distribution/beta.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/op_call.md
+++ b/reference/random/gamma_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/op_constructor.md
+++ b/reference/random/gamma_distribution/op_constructor.md
@@ -73,7 +73,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/op_equal.md
+++ b/reference/random/gamma_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/op_istream.md
+++ b/reference/random/gamma_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/op_not_equal.md
+++ b/reference/random/gamma_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/op_ostream.md
+++ b/reference/random/gamma_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/param.md
+++ b/reference/random/gamma_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/gamma_distribution/reset.md
+++ b/reference/random/gamma_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/max.md
+++ b/reference/random/geometric_distribution/max.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/min.md
+++ b/reference/random/geometric_distribution/min.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/op_call.md
+++ b/reference/random/geometric_distribution/op_call.md
@@ -81,7 +81,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2(パラメータを渡さないバージョンのみ)
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 ### 備考
 GCC 4.8時点のlibstdc++では、パラメータを渡すバージョンの`operator()`呼び出しはコンパイルエラーになる。  

--- a/reference/random/geometric_distribution/op_constructor.md
+++ b/reference/random/geometric_distribution/op_constructor.md
@@ -72,7 +72,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/op_equal.md
+++ b/reference/random/geometric_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/op_istream.md
+++ b/reference/random/geometric_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/op_not_equal.md
+++ b/reference/random/geometric_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/op_ostream.md
+++ b/reference/random/geometric_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/p.md
+++ b/reference/random/geometric_distribution/p.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/param.md
+++ b/reference/random/geometric_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/geometric_distribution/reset.md
+++ b/reference/random/geometric_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/base.md
+++ b/reference/random/independent_bits_engine/base.md
@@ -48,7 +48,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/discard.md
+++ b/reference/random/independent_bits_engine/discard.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/max.md
+++ b/reference/random/independent_bits_engine/max.md
@@ -52,7 +52,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/min.md
+++ b/reference/random/independent_bits_engine/min.md
@@ -52,7 +52,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/op_call.md
+++ b/reference/random/independent_bits_engine/op_call.md
@@ -71,7 +71,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/op_constructor.md
+++ b/reference/random/independent_bits_engine/op_constructor.md
@@ -120,7 +120,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/op_equal.md
+++ b/reference/random/independent_bits_engine/op_equal.md
@@ -63,7 +63,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/op_istream.md
+++ b/reference/random/independent_bits_engine/op_istream.md
@@ -84,7 +84,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/op_not_equal.md
+++ b/reference/random/independent_bits_engine/op_not_equal.md
@@ -65,7 +65,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/op_ostream.md
+++ b/reference/random/independent_bits_engine/op_ostream.md
@@ -61,7 +61,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/independent_bits_engine/seed.md
+++ b/reference/random/independent_bits_engine/seed.md
@@ -113,7 +113,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/discard.md
+++ b/reference/random/linear_congruential_engine/discard.md
@@ -75,7 +75,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/max.md
+++ b/reference/random/linear_congruential_engine/max.md
@@ -50,7 +50,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/min.md
+++ b/reference/random/linear_congruential_engine/min.md
@@ -50,7 +50,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/op_call.md
+++ b/reference/random/linear_congruential_engine/op_call.md
@@ -70,7 +70,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/op_constructor.md
+++ b/reference/random/linear_congruential_engine/op_constructor.md
@@ -93,7 +93,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/op_equal.md
+++ b/reference/random/linear_congruential_engine/op_equal.md
@@ -59,7 +59,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/op_istream.md
+++ b/reference/random/linear_congruential_engine/op_istream.md
@@ -80,7 +80,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/op_not_equal.md
+++ b/reference/random/linear_congruential_engine/op_not_equal.md
@@ -61,7 +61,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/op_ostream.md
+++ b/reference/random/linear_congruential_engine/op_ostream.md
@@ -59,7 +59,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/linear_congruential_engine/seed.md
+++ b/reference/random/linear_congruential_engine/seed.md
@@ -106,7 +106,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/m.md
+++ b/reference/random/lognormal_distribution/m.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/op_call.md
+++ b/reference/random/lognormal_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/op_constructor.md
+++ b/reference/random/lognormal_distribution/op_constructor.md
@@ -94,7 +94,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/op_equal.md
+++ b/reference/random/lognormal_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/op_istream.md
+++ b/reference/random/lognormal_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/op_not_equal.md
+++ b/reference/random/lognormal_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/op_ostream.md
+++ b/reference/random/lognormal_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/param.md
+++ b/reference/random/lognormal_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/reset.md
+++ b/reference/random/lognormal_distribution/reset.md
@@ -71,7 +71,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/lognormal_distribution/s.md
+++ b/reference/random/lognormal_distribution/s.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/mersenne_twister_engine/discard.md
+++ b/reference/random/mersenne_twister_engine/discard.md
@@ -75,7 +75,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/mersenne_twister_engine/max.md
+++ b/reference/random/mersenne_twister_engine/max.md
@@ -50,7 +50,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/mersenne_twister_engine/min.md
+++ b/reference/random/mersenne_twister_engine/min.md
@@ -50,7 +50,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/mersenne_twister_engine/op_call.md
+++ b/reference/random/mersenne_twister_engine/op_call.md
@@ -70,7 +70,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/mersenne_twister_engine/op_constructor.md
+++ b/reference/random/mersenne_twister_engine/op_constructor.md
@@ -97,7 +97,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/mersenne_twister_engine/op_equal.md
+++ b/reference/random/mersenne_twister_engine/op_equal.md
@@ -62,7 +62,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/mersenne_twister_engine/op_istream.md
+++ b/reference/random/mersenne_twister_engine/op_istream.md
@@ -83,7 +83,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/mersenne_twister_engine/op_not_equal.md
+++ b/reference/random/mersenne_twister_engine/op_not_equal.md
@@ -64,7 +64,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/mersenne_twister_engine/op_ostream.md
+++ b/reference/random/mersenne_twister_engine/op_ostream.md
@@ -62,7 +62,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 ### 備考
 GCC(libstdc++) では、出力が誤っている。（C++ 標準では状態の数だけ出力されることになっているが、GCC では状態の数より出力される数の方が一つ多い）。

--- a/reference/random/mersenne_twister_engine/seed.md
+++ b/reference/random/mersenne_twister_engine/seed.md
@@ -109,7 +109,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/k.md
+++ b/reference/random/negative_binomial_distribution/k.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/max.md
+++ b/reference/random/negative_binomial_distribution/max.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/min.md
+++ b/reference/random/negative_binomial_distribution/min.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/op_call.md
+++ b/reference/random/negative_binomial_distribution/op_call.md
@@ -81,7 +81,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2(パラメータを渡さないバージョンのみ)
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 ### 備考
 GCC 4.8時点のlibstdc++では、パラメータを渡すバージョンの`operator()`呼び出しはコンパイルエラーになる。  

--- a/reference/random/negative_binomial_distribution/op_constructor.md
+++ b/reference/random/negative_binomial_distribution/op_constructor.md
@@ -72,7 +72,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/op_equal.md
+++ b/reference/random/negative_binomial_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/op_istream.md
+++ b/reference/random/negative_binomial_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/op_not_equal.md
+++ b/reference/random/negative_binomial_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/op_ostream.md
+++ b/reference/random/negative_binomial_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/p.md
+++ b/reference/random/negative_binomial_distribution/p.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/param.md
+++ b/reference/random/negative_binomial_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/negative_binomial_distribution/reset.md
+++ b/reference/random/negative_binomial_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/mean.md
+++ b/reference/random/normal_distribution/mean.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/op_call.md
+++ b/reference/random/normal_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/op_constructor.md
+++ b/reference/random/normal_distribution/op_constructor.md
@@ -94,7 +94,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/op_equal.md
+++ b/reference/random/normal_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/op_istream.md
+++ b/reference/random/normal_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/op_not_equal.md
+++ b/reference/random/normal_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/op_ostream.md
+++ b/reference/random/normal_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/param.md
+++ b/reference/random/normal_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/reset.md
+++ b/reference/random/normal_distribution/reset.md
@@ -71,7 +71,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/normal_distribution/stddev.md
+++ b/reference/random/normal_distribution/stddev.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/densities.md
+++ b/reference/random/piecewise_constant_distribution/densities.md
@@ -62,7 +62,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/intervals.md
+++ b/reference/random/piecewise_constant_distribution/intervals.md
@@ -63,7 +63,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/max.md
+++ b/reference/random/piecewise_constant_distribution/max.md
@@ -57,7 +57,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/min.md
+++ b/reference/random/piecewise_constant_distribution/min.md
@@ -57,7 +57,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/op_call.md
+++ b/reference/random/piecewise_constant_distribution/op_call.md
@@ -109,7 +109,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/op_constructor.md
+++ b/reference/random/piecewise_constant_distribution/op_constructor.md
@@ -149,7 +149,7 @@ parameter constructor : 0.49003
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/op_equal.md
+++ b/reference/random/piecewise_constant_distribution/op_equal.md
@@ -77,7 +77,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/op_istream.md
+++ b/reference/random/piecewise_constant_distribution/op_istream.md
@@ -89,7 +89,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/op_not_equal.md
+++ b/reference/random/piecewise_constant_distribution/op_not_equal.md
@@ -77,7 +77,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/op_ostream.md
+++ b/reference/random/piecewise_constant_distribution/op_ostream.md
@@ -68,7 +68,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/param.md
+++ b/reference/random/piecewise_constant_distribution/param.md
@@ -70,7 +70,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_constant_distribution/reset.md
+++ b/reference/random/piecewise_constant_distribution/reset.md
@@ -76,7 +76,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/densities.md
+++ b/reference/random/piecewise_linear_distribution/densities.md
@@ -63,7 +63,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/intervals.md
+++ b/reference/random/piecewise_linear_distribution/intervals.md
@@ -63,7 +63,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/max.md
+++ b/reference/random/piecewise_linear_distribution/max.md
@@ -57,7 +57,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/min.md
+++ b/reference/random/piecewise_linear_distribution/min.md
@@ -57,7 +57,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/op_call.md
+++ b/reference/random/piecewise_linear_distribution/op_call.md
@@ -108,7 +108,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/op_constructor.md
+++ b/reference/random/piecewise_linear_distribution/op_constructor.md
@@ -151,7 +151,7 @@ parameter constructor : 0.260002
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/op_equal.md
+++ b/reference/random/piecewise_linear_distribution/op_equal.md
@@ -77,7 +77,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/op_istream.md
+++ b/reference/random/piecewise_linear_distribution/op_istream.md
@@ -89,7 +89,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/op_not_equal.md
+++ b/reference/random/piecewise_linear_distribution/op_not_equal.md
@@ -77,7 +77,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/op_ostream.md
+++ b/reference/random/piecewise_linear_distribution/op_ostream.md
@@ -68,7 +68,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/param.md
+++ b/reference/random/piecewise_linear_distribution/param.md
@@ -74,7 +74,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/piecewise_linear_distribution/reset.md
+++ b/reference/random/piecewise_linear_distribution/reset.md
@@ -76,7 +76,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/max.md
+++ b/reference/random/poisson_distribution/max.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/mean.md
+++ b/reference/random/poisson_distribution/mean.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/min.md
+++ b/reference/random/poisson_distribution/min.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/op_call.md
+++ b/reference/random/poisson_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/op_constructor.md
+++ b/reference/random/poisson_distribution/op_constructor.md
@@ -73,7 +73,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/op_equal.md
+++ b/reference/random/poisson_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/op_istream.md
+++ b/reference/random/poisson_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/op_not_equal.md
+++ b/reference/random/poisson_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/op_ostream.md
+++ b/reference/random/poisson_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/param.md
+++ b/reference/random/poisson_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/poisson_distribution/reset.md
+++ b/reference/random/poisson_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/seed_seq/generate.md
+++ b/reference/random/seed_seq/generate.md
@@ -108,7 +108,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/seed_seq/op_constructor.md
+++ b/reference/random/seed_seq/op_constructor.md
@@ -137,7 +137,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/seed_seq/param.md
+++ b/reference/random/seed_seq/param.md
@@ -82,7 +82,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/seed_seq/size.md
+++ b/reference/random/seed_seq/size.md
@@ -51,7 +51,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/base.md
+++ b/reference/random/shuffle_order_engine/base.md
@@ -47,7 +47,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/discard.md
+++ b/reference/random/shuffle_order_engine/discard.md
@@ -75,7 +75,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/max.md
+++ b/reference/random/shuffle_order_engine/max.md
@@ -50,7 +50,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/min.md
+++ b/reference/random/shuffle_order_engine/min.md
@@ -50,7 +50,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/op_call.md
+++ b/reference/random/shuffle_order_engine/op_call.md
@@ -70,7 +70,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/op_constructor.md
+++ b/reference/random/shuffle_order_engine/op_constructor.md
@@ -118,7 +118,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/op_equal.md
+++ b/reference/random/shuffle_order_engine/op_equal.md
@@ -59,7 +59,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/op_istream.md
+++ b/reference/random/shuffle_order_engine/op_istream.md
@@ -80,7 +80,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/op_not_equal.md
+++ b/reference/random/shuffle_order_engine/op_not_equal.md
@@ -61,7 +61,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/op_ostream.md
+++ b/reference/random/shuffle_order_engine/op_ostream.md
@@ -59,7 +59,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/shuffle_order_engine/seed.md
+++ b/reference/random/shuffle_order_engine/seed.md
@@ -112,7 +112,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/student_t_distribution/n.md
+++ b/reference/random/student_t_distribution/n.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/student_t_distribution/op_call.md
+++ b/reference/random/student_t_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/student_t_distribution/op_constructor.md
+++ b/reference/random/student_t_distribution/op_constructor.md
@@ -94,7 +94,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/student_t_distribution/op_equal.md
+++ b/reference/random/student_t_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/student_t_distribution/op_istream.md
+++ b/reference/random/student_t_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/student_t_distribution/op_not_equal.md
+++ b/reference/random/student_t_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/student_t_distribution/op_ostream.md
+++ b/reference/random/student_t_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/student_t_distribution/param.md
+++ b/reference/random/student_t_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/student_t_distribution/reset.md
+++ b/reference/random/student_t_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/a.md
+++ b/reference/random/uniform_int_distribution/a.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/b.md
+++ b/reference/random/uniform_int_distribution/b.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/max.md
+++ b/reference/random/uniform_int_distribution/max.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/min.md
+++ b/reference/random/uniform_int_distribution/min.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/op_call.md
+++ b/reference/random/uniform_int_distribution/op_call.md
@@ -91,7 +91,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/op_constructor.md
+++ b/reference/random/uniform_int_distribution/op_constructor.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/op_equal.md
+++ b/reference/random/uniform_int_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/op_istream.md
+++ b/reference/random/uniform_int_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/op_not_equal.md
+++ b/reference/random/uniform_int_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/op_ostream.md
+++ b/reference/random/uniform_int_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/param.md
+++ b/reference/random/uniform_int_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_int_distribution/reset.md
+++ b/reference/random/uniform_int_distribution/reset.md
@@ -65,7 +65,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/a.md
+++ b/reference/random/uniform_real_distribution/a.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/b.md
+++ b/reference/random/uniform_real_distribution/b.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/max.md
+++ b/reference/random/uniform_real_distribution/max.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/min.md
+++ b/reference/random/uniform_real_distribution/min.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/op_call.md
+++ b/reference/random/uniform_real_distribution/op_call.md
@@ -91,7 +91,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/op_constructor.md
+++ b/reference/random/uniform_real_distribution/op_constructor.md
@@ -73,7 +73,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/op_equal.md
+++ b/reference/random/uniform_real_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/op_istream.md
+++ b/reference/random/uniform_real_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/op_not_equal.md
+++ b/reference/random/uniform_real_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/op_ostream.md
+++ b/reference/random/uniform_real_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/param.md
+++ b/reference/random/uniform_real_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/uniform_real_distribution/reset.md
+++ b/reference/random/uniform_real_distribution/reset.md
@@ -65,7 +65,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/a.md
+++ b/reference/random/weibull_distribution/a.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/b.md
+++ b/reference/random/weibull_distribution/b.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/max.md
+++ b/reference/random/weibull_distribution/max.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/min.md
+++ b/reference/random/weibull_distribution/min.md
@@ -46,7 +46,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/op_call.md
+++ b/reference/random/weibull_distribution/op_call.md
@@ -90,7 +90,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/op_constructor.md
+++ b/reference/random/weibull_distribution/op_constructor.md
@@ -92,7 +92,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/op_equal.md
+++ b/reference/random/weibull_distribution/op_equal.md
@@ -58,7 +58,7 @@ equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/op_istream.md
+++ b/reference/random/weibull_distribution/op_istream.md
@@ -77,7 +77,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/op_not_equal.md
+++ b/reference/random/weibull_distribution/op_not_equal.md
@@ -58,7 +58,7 @@ not equal
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/op_ostream.md
+++ b/reference/random/weibull_distribution/op_ostream.md
@@ -56,7 +56,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/param.md
+++ b/reference/random/weibull_distribution/param.md
@@ -54,7 +54,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/random/weibull_distribution/reset.md
+++ b/reference/random/weibull_distribution/reset.md
@@ -67,7 +67,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.2
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/scoped_allocator/scoped_allocator_adaptor/allocate.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/allocate.md
@@ -76,4 +76,4 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/construct.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/construct.md
@@ -216,4 +216,4 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.3 (`forward_as_tuple()`まで含めた完全な実装)
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/deallocate.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/deallocate.md
@@ -74,4 +74,4 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/destroy.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/destroy.md
@@ -92,4 +92,4 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.1
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/inner_allocator.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/inner_allocator.md
@@ -104,4 +104,4 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/max_size.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/max_size.md
@@ -70,4 +70,4 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/op_constructor.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/op_constructor.md
@@ -115,4 +115,4 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/op_equal.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/op_equal.md
@@ -76,4 +76,4 @@ equal
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/op_not_equal.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/op_not_equal.md
@@ -74,4 +74,4 @@ equal
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/outer_allocator.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/outer_allocator.md
@@ -104,4 +104,4 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.0
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/scoped_allocator/scoped_allocator_adaptor/select_on_container_copy_construction.md
+++ b/reference/scoped_allocator/scoped_allocator_adaptor/select_on_container_copy_construction.md
@@ -69,4 +69,4 @@ int main()
 - [Clang, C++11 mode](/implementation.md#clang): 3.1
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??

--- a/reference/stack/swap.md
+++ b/reference/stack/swap.md
@@ -91,7 +91,7 @@ void swap(stack& s) noexcept(noexcept(swap(c, s.c)))
 - [GCC](/implementation.md#gcc): ??
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp)
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 参照

--- a/reference/stack/swap_free.md
+++ b/reference/stack/swap_free.md
@@ -87,5 +87,5 @@ y : 4 1 3
 - [GCC](/implementation.md#gcc): ??
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp)
+- [Visual C++](/implementation.md#visual_cpp): 
 

--- a/reference/system_error/error_category.md
+++ b/reference/system_error/error_category.md
@@ -79,7 +79,7 @@ user defined error
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/system_error/error_category/default_error_condition.md
+++ b/reference/system_error/error_category/default_error_condition.md
@@ -60,7 +60,7 @@ Not a directory
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_category/equivalent.md
+++ b/reference/system_error/error_category/equivalent.md
@@ -72,6 +72,6 @@ false
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 ## 参照

--- a/reference/system_error/error_category/message.md
+++ b/reference/system_error/error_category/message.md
@@ -51,7 +51,7 @@ Not a directory
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_category/name.md
+++ b/reference/system_error/error_category/name.md
@@ -54,7 +54,7 @@ system
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_category/op_constructor.md
+++ b/reference/system_error/error_category/op_constructor.md
@@ -62,7 +62,7 @@ user defined error
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0(ただしnoexceptは使用不可)
+- [Visual C++](/implementation.md#visual_cpp): 10.0(ただしnoexceptは使用不可)
 
 
 ## 参照

--- a/reference/system_error/error_category/op_equal.md
+++ b/reference/system_error/error_category/op_equal.md
@@ -58,7 +58,7 @@ false
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_category/op_less.md
+++ b/reference/system_error/error_category/op_less.md
@@ -58,7 +58,7 @@ false
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_category/op_not_equal.md
+++ b/reference/system_error/error_category/op_not_equal.md
@@ -58,7 +58,7 @@ true
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_code.md
+++ b/reference/system_error/error_code.md
@@ -78,7 +78,7 @@ Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_code/assign.md
+++ b/reference/system_error/error_code/assign.md
@@ -71,7 +71,7 @@ generic
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_code/category.md
+++ b/reference/system_error/error_code/category.md
@@ -56,7 +56,7 @@ generic
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_code/clear.md
+++ b/reference/system_error/error_code/clear.md
@@ -71,7 +71,7 @@ system
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_code/default_error_condition.md
+++ b/reference/system_error/error_code/default_error_condition.md
@@ -87,7 +87,7 @@ Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_code/message.md
+++ b/reference/system_error/error_code/message.md
@@ -49,7 +49,7 @@ Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 ## 参照
 

--- a/reference/system_error/error_code/op_assign.md
+++ b/reference/system_error/error_code/op_assign.md
@@ -85,7 +85,7 @@ generic
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 参照

--- a/reference/system_error/error_code/op_bool.md
+++ b/reference/system_error/error_code/op_bool.md
@@ -70,7 +70,7 @@ error! : Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_code/op_constructor.md
+++ b/reference/system_error/error_code/op_constructor.md
@@ -134,7 +134,7 @@ generic
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0(enum class未対応のため、ErrorCodeEnumのコンストラクタは動作しない)
+- [Visual C++](/implementation.md#visual_cpp): 10.0(enum class未対応のため、ErrorCodeEnumのコンストラクタは動作しない)
 
 
 ## 参照

--- a/reference/system_error/error_code/value.md
+++ b/reference/system_error/error_code/value.md
@@ -52,7 +52,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_condition.md
+++ b/reference/system_error/error_condition.md
@@ -86,7 +86,7 @@ Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_condition/assign.md
+++ b/reference/system_error/error_condition/assign.md
@@ -71,7 +71,7 @@ generic
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_condition/category.md
+++ b/reference/system_error/error_condition/category.md
@@ -56,7 +56,7 @@ generic
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_condition/clear.md
+++ b/reference/system_error/error_condition/clear.md
@@ -72,7 +72,7 @@ generic
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_condition/message.md
+++ b/reference/system_error/error_condition/message.md
@@ -55,7 +55,7 @@ Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_condition/op_assign.md
+++ b/reference/system_error/error_condition/op_assign.md
@@ -78,7 +78,7 @@ generic
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_condition/op_bool.md
+++ b/reference/system_error/error_condition/op_bool.md
@@ -70,7 +70,7 @@ error! : Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_condition/op_constructor.md
+++ b/reference/system_error/error_condition/op_constructor.md
@@ -124,7 +124,7 @@ generic
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/error_condition/value.md
+++ b/reference/system_error/error_condition/value.md
@@ -52,7 +52,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/generic_category.md
+++ b/reference/system_error/generic_category.md
@@ -67,7 +67,7 @@ Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/is_error_condition_enum.md
+++ b/reference/system_error/is_error_condition_enum.md
@@ -63,7 +63,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.4.7, 4.5.4, 4.6.4, 4.7.0, 4.7.3, 4.8.2, 4.9.0, 4.9.1, 4.9.2, 5.1.0, 5.2.0, 6.0.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp)
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 関連項目

--- a/reference/system_error/make_error_code.md
+++ b/reference/system_error/make_error_code.md
@@ -63,7 +63,7 @@ message : Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/make_error_condition.md
+++ b/reference/system_error/make_error_condition.md
@@ -63,7 +63,7 @@ message : Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/op_equal.md
+++ b/reference/system_error/op_equal.md
@@ -117,7 +117,7 @@ error_condition == error_condition : false
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/op_less.md
+++ b/reference/system_error/op_less.md
@@ -65,6 +65,6 @@ error_condition < error_condition : false
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 ## 参照

--- a/reference/system_error/op_not_equal.md
+++ b/reference/system_error/op_not_equal.md
@@ -78,7 +78,7 @@ error_condition != error_condition : true
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/op_ostream.md
+++ b/reference/system_error/op_ostream.md
@@ -61,7 +61,7 @@ generic:22
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/system_category.md
+++ b/reference/system_error/system_category.md
@@ -66,7 +66,7 @@ Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 
 ## 参照

--- a/reference/system_error/system_error.md
+++ b/reference/system_error/system_error.md
@@ -67,6 +67,6 @@ system error!: Invalid argument
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 

--- a/reference/tuple/forward_as_tuple.md
+++ b/reference/tuple/forward_as_tuple.md
@@ -61,7 +61,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 注意事項

--- a/reference/tuple/ignore.md
+++ b/reference/tuple/ignore.md
@@ -26,7 +26,7 @@ namespace std {
 - [GCC](/implementation.md#gcc): ?
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): 
-- [Visual C++](/implementation.md#visual_cpp) 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 9.0, 10.0
 
 
 ## 関連項目

--- a/reference/tuple/make_tuple.md
+++ b/reference/tuple/make_tuple.md
@@ -70,7 +70,7 @@ int main()
 - [GCC](/implementation.md#gcc): ?
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ?
-- [Visual C++](/implementation.md#visual_cpp) 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 9.0, 10.0
 
 
 ## 参照

--- a/reference/tuple/tie.md
+++ b/reference/tuple/tie.md
@@ -152,7 +152,7 @@ text, b.txt
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) 9.0, 10.0
+- [Visual C++](/implementation.md#visual_cpp): 9.0, 10.0
 
 
 ## 関連項目

--- a/reference/tuple/tuple/get.md
+++ b/reference/tuple/tuple/get.md
@@ -152,7 +152,7 @@ Hello
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 関連項目

--- a/reference/tuple/tuple/op_assign.md
+++ b/reference/tuple/tuple/op_assign.md
@@ -100,7 +100,7 @@ int main()
 - [Clang](/implementation.md#clang): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): 
-- [Visual C++](/implementation.md#visual_cpp) 
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 参照

--- a/reference/tuple/tuple/op_constructor.md
+++ b/reference/tuple/tuple/op_constructor.md
@@ -150,7 +150,7 @@ int main()
 - [Clang](/implementation.md#clang): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): 
-- [Visual C++](/implementation.md#visual_cpp)
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 参照

--- a/reference/tuple/tuple/op_equal.md
+++ b/reference/tuple/tuple/op_equal.md
@@ -73,7 +73,7 @@ false
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/tuple/tuple/op_greater.md
+++ b/reference/tuple/tuple/op_greater.md
@@ -66,7 +66,7 @@ true
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/tuple/tuple/op_greater_equal.md
+++ b/reference/tuple/tuple/op_greater_equal.md
@@ -72,7 +72,7 @@ true
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/tuple/tuple/op_less.md
+++ b/reference/tuple/tuple/op_less.md
@@ -72,7 +72,7 @@ false
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 関連項目

--- a/reference/tuple/tuple/op_less_equal.md
+++ b/reference/tuple/tuple/op_less_equal.md
@@ -72,7 +72,7 @@ true
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/tuple/tuple/op_not_equal.md
+++ b/reference/tuple/tuple/op_not_equal.md
@@ -68,7 +68,7 @@ true
 - [GCC](/implementation.md#gcc): ??
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/tuple/tuple/swap.md
+++ b/reference/tuple/tuple/swap.md
@@ -61,7 +61,7 @@ int main()
 - [Clang](/implementation.md#clang): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): 
-- [Visual C++](/implementation.md#visual_cpp) 
+- [Visual C++](/implementation.md#visual_cpp): 
 
 
 ## 参照

--- a/reference/tuple/tuple_cat.md
+++ b/reference/tuple/tuple_cat.md
@@ -76,7 +76,7 @@ World
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/tuple/tuple_element.md
+++ b/reference/tuple/tuple_element.md
@@ -102,7 +102,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/tuple/tuple_size.md
+++ b/reference/tuple/tuple_size.md
@@ -76,7 +76,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.1
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/type_traits/false_type.md
+++ b/reference/type_traits/false_type.md
@@ -41,7 +41,7 @@ int main(){}
 ### 処理系
 - [Clang, C++11 mode](/implementation.md#clang): 3.2
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.5.3, 4.6.2, 4.7.0
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 #### 備考
 上の例でコンパイラによってはエラーになる。GCC 4.3.4, 4.5.3, Visual C++ 10.0 は [`integral_constant`](integral_constant.md) が `operator value_type()` を持っていないためエラーになる。

--- a/reference/type_traits/true_type.md
+++ b/reference/type_traits/true_type.md
@@ -41,7 +41,7 @@ int main(){}
 ### 処理系
 - [Clang, C++11 mode](/implementation.md#clang): 3.2
 - [GCC, C++11 mode](/implementation.md#gcc): 4.3.4, 4.5.3, 4.6.2, 4.7.0
-- [Visual C++](/implementation.md#visual_cpp) 10.0
+- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 #### 備考
 上の例でコンパイラによってはエラーになる。GCC 4.3.4, 4.5.3, Visual C++ 10.0 は [`integral_constant`](integral_constant.md) が `operator value_type()` を持っていないためエラーになる。

--- a/reference/unordered_set/unordered_multiset/swap_free.md
+++ b/reference/unordered_set/unordered_multiset/swap_free.md
@@ -76,7 +76,7 @@ ums2 after:3, 3, 2, 2, 1, 1,
 - [GCC](/implementation.md#gcc): -
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ?
-- [Visual C++](/implementation.md#visual_cpp) ?
+- [Visual C++](/implementation.md#visual_cpp): ?
 
 ## 実装例
 ```cpp

--- a/reference/unordered_set/unordered_set/swap_free.md
+++ b/reference/unordered_set/unordered_set/swap_free.md
@@ -76,7 +76,7 @@ us2 after:3, 2, 1,
 - [GCC](/implementation.md#gcc): -
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 - [ICC](/implementation.md#icc): ?
-- [Visual C++](/implementation.md#visual_cpp) ?
+- [Visual C++](/implementation.md#visual_cpp): ?
 
 ## 実装例
 ```cpp

--- a/reference/valarray/valarray/begin_free.md
+++ b/reference/valarray/valarray/begin_free.md
@@ -66,7 +66,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.4
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/valarray/valarray/end_free.md
+++ b/reference/valarray/valarray/end_free.md
@@ -66,7 +66,7 @@ int main()
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.6.4
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 
 ## 参照

--- a/reference/valarray/valarray/swap.md
+++ b/reference/valarray/valarray/swap.md
@@ -73,6 +73,6 @@ b : {1,2,3}
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 

--- a/reference/valarray/valarray/swap_free.md
+++ b/reference/valarray/valarray/swap_free.md
@@ -75,6 +75,6 @@ b : {1,2,3}
 - [GCC](/implementation.md#gcc): 
 - [GCC, C++11 mode](/implementation.md#gcc): 4.7.3
 - [ICC](/implementation.md#icc): ??
-- [Visual C++](/implementation.md#visual_cpp) ??
+- [Visual C++](/implementation.md#visual_cpp): ??
 
 

--- a/reference/vector/insert.md
+++ b/reference/vector/insert.md
@@ -117,7 +117,7 @@ ccc
 	- [GCC](/implementation.md#gcc): 
 	- [GCC, C++11 mode](/implementation.md#gcc): 4.7.0
 	- [ICC](/implementation.md#icc): ??
-	- [Visual C++](/implementation.md#visual_cpp) 10.0
+	- [Visual C++](/implementation.md#visual_cpp): 10.0
 
 - C++11 : 初期化子リストバージョン
 	- [Clang](/implementation.md#clang): ??


### PR DESCRIPTION
雛形が間違っていたころの名残。
Visual C++全体のバージョン表記を変更するにあたって、パースしやすくした。