### PR TITLE
Fix sample implementations of std::to_string().

### DIFF
--- a/reference/string/to_string.md
+++ b/reference/string/to_string.md
@@ -70,71 +70,77 @@ int main()
 
 std::string to_string(int val)
 {
-  char buffer[std::numeric_limits<int>::digits10 + 2]; // '-' + NULL
+  char buffer[std::numeric_limits<int>::digits10 + 1
+          + 2]; // '-' + '\0'
   std::sprintf(buffer, "%d", val);
   return buffer;
 }
 
 std::string to_string(unsigned int val)
 {
-  char buffer[std::numeric_limits<unsigned int>::digits10 + 1];
+  char buffer[std::numeric_limits<unsigned int>::digits10 + 1
+          + 1]; // '\0'
   std::sprintf(buffer, "%u", val);
   return buffer;
 }
 
 std::string to_string(long val)
 {
-  char buffer[std::numeric_limits<long>::digits10 + 2]; // '-' + NULL
+  char buffer[std::numeric_limits<long>::digits10 + 1
+          + 2]; // '-' + '\0'
   std::sprintf(buffer, "%ld", val);
   return buffer;
 }
 
 std::string to_string(unsigned long val)
 {
-  char buffer[std::numeric_limits<unsigned long>::digits10 + 1];
+  char buffer[std::numeric_limits<unsigned long>::digits10 + 1
+          + 1]; // '\0'
   std::sprintf(buffer, "%lu", val);
   return buffer;
 }
 
 std::string to_string(long long int val)
 {
-  char buffer[std::numeric_limits<long long int>::digits10 + 2]; // '-' + NULL
+  char buffer[std::numeric_limits<long long int>::digits10 + 1
+          + 2]; // '-' + '\0'
   std::sprintf(buffer, "%lld", val);
   return buffer;
 }
 
 std::string to_string(unsigned long long int val)
 {
-  char buffer[std::numeric_limits<unsigned long long int>::digits10 + 1];
+  char buffer[std::numeric_limits<unsigned long long int>::digits10 + 1
+          + 1]; // '\0'
   std::sprintf(buffer, "%llu", val);
   return buffer;
 }
 
 std::string to_string(float val)
 {
-  char buff[std::numeric_limits<float>::max_exponent10
+  char buffer[std::numeric_limits<float>::max_exponent10 + 1
           + 6   // fixed precision (printf's default)
-          + 3]; // '-' + '.' + NULL
-  std::sprintf(buff, "%f", val);
-  return buff;
+          + 3]; // '-' + '.' + '\0'
+  std::sprintf(buffer, "%f", val);
+  return buffer;
 }
 
 std::string to_string(double val)
 {
-  char buff[std::numeric_limits<double>::max_exponent10
+  char buffer[std::numeric_limits<double>::max_exponent10 + 1
           + 6   // fixed precision (printf's default)
-          + 3]; // '-' + '.' + NULL
-  std::sprintf(buff, "%f", val);
-  return buff;
+          + 3]; // '-' + '.' + '\0'
+  std::sprintf(buffer, "%f", val);
+  return buffer;
 }
 
 std::string to_string(long double val)
 {
-  char buff[std::numeric_limits<long double>::max_exponent10
+  char buffer[std::numeric_limits<long double>::max_exponent10 + 1
           + 6   // fixed precision (printf's default)
-          + 3]; // '-' + '.' + NULL
-  std::sprintf(buff, "%Lf", val);
-  return buff;
+          + 3]; // '-' + '.' + '\0'
+  std::sprintf(buffer, "%Lf", val);
+  return buffer;
 }
 ```
 * digits10[link /reference/limits/numeric_limits/digits10.md]


### PR DESCRIPTION
`std::to_string()` のサンプル実装の修正です.
- `std::numeric_limits<T>::digits10` 及び `max_exponent10` の値は実際の最大桁数 *-1* になるため, バッファサイズは現状より1バイトだけ多いものが必要です.
- バッファの変数名に `buffer` と `buff` が使われていましたが, 特に分ける理由もなさそうに見えたので `buffer` に統一しました.
- コメント中の `NULL` を `'\0'` に変更しました.