### PR TITLE
[std:: mt19937] 項目：予測可能性に記載された参照先のリンク切れを修正します

### DIFF
--- a/reference/random/mt19937.md
+++ b/reference/random/mt19937.md
@@ -58,7 +58,7 @@ namespace std {
 ## 予測可能性
 `mt19937`は、624個の連続した過去の出力履歴があれば、次に出現する値を予測できる。
 
-参照 : [Mersenne Twisterの次に出す値を推測する - 憂鬱な午後のひととき](http://homepage1.nifty.com/herumi/diary/1505.html#18)
+参照 : [Mersenne Twisterの次に出す値を推測する - 憂鬱な午後のひととき](http://herumi.in.coocan.jp/diary/1505.html#18)
 
 
 ## 例


### PR DESCRIPTION
ページ移転によりドメインが変更されたようです。
http://homepage1.nifty.com/herumi/diary/1505.html#18
↓
http://herumi.in.coocan.jp/diary/1505.html#18