### PR TITLE
std::optionalの比較演算子のタイポ修正

### DIFF
--- a/reference/optional/optional/op_greater.md
+++ b/reference/optional/optional/op_greater.md
@@ -22,7 +22,7 @@ namespace std {
 * nullopt_t[link /reference/optional/nullopt_t.md]
 
 ## 概要
-`optional`において、左辺が右辺より小さいかの判定を行う。
+`optional`において、左辺が右辺より大きいかの判定を行う。
 
 
 ## 要件
@@ -30,7 +30,7 @@ namespace std {
 
 
 ## 戻り値
-- (1) : `x`と`y`がどちらも有効値を持っていれば、有効値同士を`>`演算子で比較した結果を返す。`x`が有効値を持っていなければ`false`を返す。`x`が有効値を持っていなければ`true`を返す
+- (1) : `x`と`y`がどちらも有効値を持っていれば、有効値同士を`>`演算子で比較した結果を返す。`x`が有効値を持っていなければ`false`を返す。`y`が有効値を持っていなければ`true`を返す
 - (2) : `x.`[`has_value()`](has_value.md)を返す
 - (3) : `false`を返す
 - (4) : `return x.`[`has_value()`](has_value.md) `? x.`[`value()`](value.md) `> v : false;`

--- a/reference/optional/optional/op_greater_equal.md
+++ b/reference/optional/optional/op_greater_equal.md
@@ -22,7 +22,7 @@ namespace std {
 * nullopt_t[link /reference/optional/nullopt_t.md]
 
 ## 概要
-`optional`において、左辺が右辺より小さいかの判定を行う。
+`optional`において、左辺が右辺以上かの判定を行う。
 
 
 ## 要件
@@ -30,7 +30,7 @@ namespace std {
 
 
 ## 戻り値
-- (1) : `x`と`y`がどちらも有効値を持っていれば、有効値同士を`>=`演算子で比較した結果を返す。`x`が有効値を持っていなければ`true`を返す。`x`が有効値を持っていなければ`false`を返す
+- (1) : `x`と`y`がどちらも有効値を持っていれば、有効値同士を`>=`演算子で比較した結果を返す。`y`が有効値を持っていなければ`true`を返す。`x`が有効値を持っていなければ`false`を返す
 - (2) : `true`を返す
 - (3) : `!x.`[`has_value()`](has_value.md)を返す
 - (4) : `return x.`[`has_value()`](has_value.md) `? x.`[`value()`](value.md) `>= v : false;`


### PR DESCRIPTION
std::optionalの比較演算`>`と`>=`の説明のタイポを修正しました