### PR TITLE
clampの引数順序の修正

### DIFF
--- a/reference/algorithm/clamp.md
+++ b/reference/algorithm/clamp.md
@@ -31,7 +31,7 @@ namespace std {
 
 
 ## 備考
-- `clamp(v, high, low)`は[`min`](min.md)`(`[`max`](max.md)`(v, low), high)`と同等
+- `clamp(v, low, high)`は[`min`](min.md)`(`[`max`](max.md)`(v, low), high)`と同等
 
 
 ## 例


### PR DESCRIPTION
備考部分の`low`、`high`の順序が逆になっていた。