### PR TITLE
optional クラステンプレートの要件を修正

### DIFF
--- a/reference/optional/optional.md
+++ b/reference/optional/optional.md
@@ -35,9 +35,8 @@ namespace std {
 型`T`が以下のいずれかに該当してはならない：
 
 - 参照型
-- CV修飾された型
-- [`std::in_place_t`](/reference/utility/in_place_t.md)
-- [`std::nullopt_t`](nullopt_t.md)
+- (CV修飾された)[`std::in_place_t`](/reference/utility/in_place_t.md)
+- (CV修飾された)[`std::nullopt_t`](nullopt_t.md)
 
 また、型`T`は[破棄可能](/reference/concepts/Destructible.md)であること。
 


### PR DESCRIPTION
原文は "A program that necessitates the instantiation of template optional for a reference type, or for possibly cv-qualified types in_place_t or nullopt_t is ill-formed" です。"possibly cv-qualified" は `in_place_t` と `nullopt_t` に掛かっているはずなので、その部分を修正しました。