### PR TITLE
アライメント指定されたデータの動的メモリ確保

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -125,7 +125,7 @@
 | [`enum class`変数の初期値として整数を指定する際の規則を調整](/lang/cpp17/construction_enum_class_values.md) | キャストを使用することなく整数を初期値として使用し、`E e{0};`のような初期化を許可 | 7 | 1.9 | No | 2017 Update 3 |
 | [浮動小数点数の16進数リテラル](/lang/cpp17/hexadecimal_floating_literals.md) | `hexfloat`マニピュレータや`printf()`の16進数出力に合わせて、浮動小数点数のリテラルも16進数表記できるようにする | 3.0 | 3.0 | 18.0 | 2017 Update 5 |
 | [属性の名前空間指定に繰り返しをなくす](/lang/cpp17/using_attribute_namespaces.md) | `[[using CC: opt(1), debug]]`のように属性の名前空間宣言をまとめて行う | 7 | 3.9 | 18.0 | 2017 Update 3 |
-| [アライメント指定されたデータの動的メモリ確保][P0035R4] | `operator new`と`operator delete`でアライメント値を取得できるようにする | 7 | 4 | No | 2017 Update 5 |
+| [アライメント指定されたデータの動的メモリ確保](/lang/cpp17/dynamic_memory_allocation_for_over-aligned_data.md) | `operator new`と`operator delete`でアライメント値を取得できるようにする | 7 | 4 | No | 2017 Update 5 |
 | [クラステンプレートのテンプレート引数推論](/lang/cpp17/type_deduction_for_class_templates.md) | コンストラクタの引数からクラスのテンプレート引数を推論できるようにする | 7 | 5 | No | 2017 Update 7 |
 | [非型テンプレート引数の`auto`宣言][P0127R2] | `template <typename T, T x>`という冗長なコードを`template <auto x>`のようにして受けられるようにし、<br/> `X<3>; X<true>; X<'a'>`のように定数を簡潔に渡せるようにする | 7 | 4 | No | 2017 Update 7 |
 | [値のコピー省略を保証][P0135R1] | 一時オブジェクトをコピーする際に、単純な値を持つクラスであればコピーが省略されることを保証する | 7 | 4 | No | 2017 Update 6 |
@@ -148,7 +148,6 @@
 [n4268]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n4268.html
 [P0136R1]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0136r1.html
 [P0017R1]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0017r1.html
-[P0035R4]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0035r4.html
 [P0127R2]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0127r2.html
 [P0135R1]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0135r1.html
 [P0296R2]: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0296r2.html

--- a/lang/cpp17/dynamic_memory_allocation_for_over-aligned_data.md
+++ b/lang/cpp17/dynamic_memory_allocation_for_over-aligned_data.md
@@ -1,0 +1,44 @@
+# アライメント指定されたデータの動的メモリ確保
+* cpp17[meta cpp]
+
+## 概要
+
+クラスのアライメント要求がデフォルトで満たされるものより大きい場合でも、動的に確保されたメモリ領域が指定したアライメントを満たしていることが保証される。
+
+特殊な命令を使う、メモリアクセスを最適化するなどの理由により、変数のアライメントが必要になることがある。そのような目的のため、C++11において[`alignas`](/lang/cpp11/alignas.md)を用いてクラスのアライメントを指定できるようになった。しかし、デフォルトで満たされるアライメントよりも大きな値を設定した場合には、動的確保したメモリ領域がその指定に沿ってアライメントされる保証はなかった。
+
+```cpp
+// 16バイト境界にアライメントされるべきクラス
+class alignas(16) float4 {
+    float f[4];
+};
+
+float4  v; // C++11でも適切にアライメントされる
+float4* p = new float4[1000]; // C++17以降では適切にアライメントされる
+```
+
+C++17以前で適切にアライメントされたメモリ領域を動的に確保するためには、C++11で追加された[`std::align`](/reference/memory/align.md)を用いて大きく確保した領域から指定を満たす部分を取り出すか、`posix_memalign`や`_aligned_malloc`などの処理系固有の関数を使用する必要があった。
+
+## 仕様
+
+[`operator new`](/reference/new/op_new.md)に、[`align_val_t`](/reference/new/align_val_t.md)を取るオーバーロードが追加された。[`align_val_t`](/reference/new/align_val_t.md)は意図しない型変換を防止するための`enum class`であり、列挙値は定義されない。
+
+```cpp
+namespace std {
+    enum class align_val_t : std::size_t {};
+}
+void* operator new(std::size_t size, std::align_val_t alignment);
+```
+
+動的確保時になされるアライメントのデフォルト値は`__STDCPP_DEFAULT_NEW_ALIGNMENT__`で定義されている。これを超えるアライメント要求を持つクラスに対する[`new`](/reference/new/op_new.md)呼び出しは、[`align_val_t`](/reference/new/align_val_t.md)が渡された場合のもので解決される。また、対応するユーザー定義[`new`](/reference/new/op_new.md)が存在する場合、互換性のため呼び出しはそちらで解決される。もしユーザー定義`new`に`align_val_t`を取るものと取らないものがある場合、取るものが優先される。`delete`も同様である。
+
+`new T`の呼び出しが[`align_val_t`](/reference/new/align_val_t.md)を取る[`new`](/reference/new/op_new.md)で解決される場合、`align_val_t`の値は`alignof(T)`の結果になる。
+
+## 関連項目
+- [new](/reference/new.md)
+- [`std::align`](/reference/memory/align.md)
+- [C++11 alignas](/lang/cpp11/alignas.md)
+- [C++11 alignof](/lang/cpp11/alignof.md)
+
+## 参照
+- [P0035R4 Dynamic memory allocation for over-aligned data](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0035r4.html)


### PR DESCRIPTION
言語機能一覧にページを作っていたなかったため、作成しました。

それに伴って、implementation-statusからのリンク先を変更しました。