### PR TITLE
サンプルコードの脱字修正 (C++17 入れ子名前空間)

### DIFF
--- a/lang/cpp17/nested_namespace.md
+++ b/lang/cpp17/nested_namespace.md
@@ -13,7 +13,7 @@
 #include <iostream>
 
 // 新機能: C++17 で可能となる入れ子名前空間の定義
-namespace aaa::bbb:ccc
+namespace aaa::bbb::ccc
 {
   void f()
   { std::cout << "a new nested namespace definition is worked!\n"; }


### PR DESCRIPTION
: が一つ抜けているようです