### PR TITLE
any::operator=の効果を修正

### DIFF
--- a/reference/any/any/op_assign.md
+++ b/reference/any/any/op_assign.md
@@ -26,7 +26,7 @@ any& operator=(T&& rhs);            // (3)
 ## 効果
 - (1) : `any(rhs).`[`swap`](swap.md)`(*this)`と同等。この効果自体では例外を送出しない
 - (2) : `any(`[`std::move`](/reference/utility/move.md)`(rhs)).`[`swap`](swap.md)`(*this)`と同等。この効果自体では例外を送出しない。`*this`の状態は、この関数を呼び出す前の`rhs`と同等の状態となり、`rhs`は有効だが未規定の状態を持つようになる
-- (3) : [`std::forward`](/reference/utility/forward.md)`<T>(value)`をコンストラクタ引数として、型[`std::decay_t<T>`](/reference/type_traits/decay.md)のオブジェクト`tmp`を直接構築し、`tmp.`[`swap`](swap.md)`(*this)`する。この効果自体では例外を送出しない
+- (3) : [`std::forward`](/reference/utility/forward.md)`<T>(value)`をコンストラクタ引数として、型[`std::decay_t<T>`](/reference/type_traits/decay.md)のオブジェクトを直接構築して保持する`any`オブジェクト`tmp`を構築し、`tmp.`[`swap`](swap.md)`(*this)`する。この効果自体では例外を送出しない
 
 
 ## 戻り値


### PR DESCRIPTION
std::decay_t<T>とstd::anyを取り違えているような文脈だったので、修正しました。