### PR TITLE
std::pairに対する要素型を指定するstd::getのオーバーロードの追記

### DIFF
--- a/reference/utility/pair/get.md
+++ b/reference/utility/pair/get.md
@@ -33,6 +33,38 @@ namespace std {
   template <std::size_t I, class T1, class T2>
   constexpr const tuple_element_t<I, pair<T1, T2>>&&
     get(const pair<T1, T2>&& p) noexcept;              // (4) C++17
+    
+  template <class T, class U>
+  constexpr T&
+    get(pair<T, U>& p) noexcept;                       // (5) C++14
+    
+  template <class T, class U>
+  constexpr const T&
+    get(const pair<T, U>& p) noexcept;                 // (6) C++14
+    
+  template <class T, class U>
+  constexpr T&&
+    get(pair<T, U>&& p) noexcept;                      // (7) C++14
+    
+  template <class T, class U>
+  constexpr const T&&
+    get(const pair<T, U>&& p) noexcept;                // (8) C++17
+    
+  template <class T, class U>
+  constexpr T&
+    get(pair<U, T>& p) noexcept;                       // (9) C++14
+    
+  template <class T, class U>
+  constexpr const T&
+    get(const pair<U, T>& p) noexcept;                 // (10) C++14
+    
+  template <class T, class U>
+  constexpr T&&
+    get(pair<U, T>&& p) noexcept;                      // (11) C++14
+    
+  template <class T, class U>
+  constexpr const T&&
+    get(const pair<U, T>&& p) noexcept;                // (12) C++17
 }
 ```
 * tuple_element[link tuple_element.md]
@@ -46,13 +78,15 @@ namespace std {
 
 
 ## 要件
-テンプレートパラメータ`I`が、[`pair`](/reference/utility/pair.md)の要素数よりも小さいこと。
-
-この要件を満たさない場合はコンパイルエラーとなる。
+- (1) ～ (4) : テンプレートパラメータ`I`が、0か1であること。この要件を満たさない場合は、コンパイルエラーとなる。
+- (5) ～ (12) : 型Tと型Uが異なる型であること。この要件を満たさない場合は、コンパイルエラーとなる。
 
 
 ## 戻り値
-[`pair`](/reference/utility/pair.md)の`I`番目の要素
+
+- (1) ～ (4) : [`pair`](/reference/utility/pair.md)の`I`番目の要素
+- (5) ～ (8) : p.firstへの参照
+- (9) ～ (12) : p.secondへの参照
 
 
 ## 例外
@@ -67,18 +101,34 @@ namespace std {
 int main()
 {
   std::pair<int, char> p(1, 'a');
+  
+  //位置を指定して取得する方法。(1)〜(4)
+  {
+    int& i = std::get<0>(p);
+    char& c = std::get<1>(p);
 
-  int& i = std::get<0>(p);
-  char& c = std::get<1>(p);
+    std::cout << i << std::endl;
+    std::cout << c << std::endl;
+  }
+  std::cout << std::endl;
+  
+  //型を指定して取得する方法。(5)〜(12)
+  {
+    int& i = std::get<int>(p);
+    char& c = std::get<char>(p);
 
-  std::cout << i << std::endl;
-  std::cout << c << std::endl;
+    std::cout << i << std::endl;
+    std::cout << c << std::endl;
+  }
 }
 ```
 * std::get[color ff0000]
 
 ### 出力
 ```
+1
+a
+
 1
 a
 ```


### PR DESCRIPTION
tupleは追記されていましたが、pairは無いようなので追記しました。
ご査収ください。