### PR TITLE
is_bounded 表記ゆれを修正

### DIFF
--- a/reference/limits/numeric_limits/is_bounded.md
+++ b/reference/limits/numeric_limits/is_bounded.md
@@ -15,7 +15,7 @@ static constexpr bool is_bounded;
 ## 概要
 型`T`の値のなす集合が有限かを判定する。  
 浮動小数点数は値として無限大を持つことがあるが、値の種類は有限個なので `is_bounded` は `true` である。  
-基本型(fundamental types)は全て有限である。
+単純型(fundamental types)は全て有限である。
 
 
 ## 例


### PR DESCRIPTION
- modified: `reference/limits/numeric_limits/is_bounded.md`

訳語表と相違していたため, `std::numeric_limits::is_bounded` について
_fundamental types_ の訳を「基本型」から「単純型」に変更した.