### PR TITLE
basic_stringのfind系メンバ関数と比較演算子の対応バージョンを修正

### DIFF
--- a/reference/string/basic_string/find.md
+++ b/reference/string/basic_string/find.md
@@ -11,7 +11,7 @@ size_type find(const basic_string& str, size_type pos = 0) const noexcept; // (1
 size_type find(const charT* s, size_type pos, size_type n) const;          // (2)
 size_type find(const charT* s, size_type pos = 0) const;                   // (3)
 
-size_type find(charT c, size_type pos = 0) const;                          // (4) C++11
+size_type find(charT c, size_type pos = 0) const;                          // (4)
 
 size_type find(std::basic_string_view<charT, traits> sv,
                size_type pos = 0) const noexcept;                          // (5) C++17

--- a/reference/string/basic_string/find_first_not_of.md
+++ b/reference/string/basic_string/find_first_not_of.md
@@ -11,7 +11,7 @@ size_type find_first_not_of(const basic_string& str, size_type pos = 0) const no
 size_type find_first_not_of(const charT* s, size_type pos, size_type n) const;          // (2)
 size_type find_first_not_of(const charT* s, size_type pos = 0) const;                   // (3)
 
-size_type find_first_not_of(charT c, size_type pos = 0) const;                          // (4) C++11
+size_type find_first_not_of(charT c, size_type pos = 0) const;                          // (4)
 
 size_type find_first_not_of(std::basic_string_view<charT, traits> sv,
                             size_type pos = 0) const noexcept;                          // (5) C++17

--- a/reference/string/basic_string/find_first_of.md
+++ b/reference/string/basic_string/find_first_of.md
@@ -11,7 +11,7 @@ size_type find_first_of(const basic_string& str, size_type pos = 0) const noexce
 size_type find_first_of(const charT* s, size_type pos, size_type n) const;          // (2)
 size_type find_first_of(const charT* s, size_type pos = 0) const;                   // (3)
 
-size_type find_first_of(charT c, size_type pos = 0) const;                          // (4) C++11
+size_type find_first_of(charT c, size_type pos = 0) const;                          // (4)
 
 size_type find_first_of(std::basic_string_view<charT, traits> sv,
                         size_type pos = 0) const noexcept;                          // (5) C++17

--- a/reference/string/basic_string/find_last_not_of.md
+++ b/reference/string/basic_string/find_last_not_of.md
@@ -11,7 +11,7 @@ size_type find_last_not_of(const basic_string& str, size_type pos = npos) const 
 size_type find_last_not_of(const charT* s, size_type pos, size_type n) const;             // (2)
 size_type find_last_not_of(const charT* s, size_type pos = npos) const;                   // (3)
 
-size_type find_last_not_of(charT c, size_type pos = npos) const;                          // (4) C++11
+size_type find_last_not_of(charT c, size_type pos = npos) const;                          // (4)
 
 size_type find_last_not_of(std::basic_string_view<charT, traits> sv,
                            size_type pos = npos) const noexcept;                          // (5) C++17

--- a/reference/string/basic_string/find_last_of.md
+++ b/reference/string/basic_string/find_last_of.md
@@ -11,7 +11,7 @@ size_type find_last_of(const basic_string& str, size_type pos = npos) const noex
 size_type find_last_of(const charT* s, size_type pos, size_type n) const;             // (2)
 size_type find_last_of(const charT* s, size_type pos = npos) const;                   // (3)
 
-size_type find_last_of(charT c, size_type pos = npos) const;                          // (4) C++11
+size_type find_last_of(charT c, size_type pos = npos) const;                          // (4)
 
 size_type find_last_of(std::basic_string_view<charT, traits> sv,
                        size_type pos = npos) const noexcept;                          // (5) C++17

--- a/reference/string/basic_string/op_equal.md
+++ b/reference/string/basic_string/op_equal.md
@@ -7,7 +7,7 @@
 namespace std {
   template <class CharT, class Traits, class Allocator>
   bool operator==(const basic_string<CharT, Traits, Allocator>& a,
-                  const basic_string<CharT, Traits, Allocator>& b); // (1) C++11
+                  const basic_string<CharT, Traits, Allocator>& b); // (1) C++03
 
   template <class CharT, class Traits, class Allocator>
   bool operator==(const basic_string<CharT, Traits, Allocator>& a,

--- a/reference/string/basic_string/op_greater.md
+++ b/reference/string/basic_string/op_greater.md
@@ -7,7 +7,11 @@
 namespace std {
   template <class CharT, class Traits, class Allocator>
   bool operator>(const basic_string<CharT, Traits, Allocator>& a,
-                 const basic_string<CharT, Traits, Allocator>& b) noexcept; // (1)
+                 const basic_string<CharT, Traits, Allocator>& b); // (1) C++03
+
+  template <class CharT, class Traits, class Allocator>
+  bool operator>(const basic_string<CharT, Traits, Allocator>& a,
+                 const basic_string<CharT, Traits, Allocator>& b) noexcept; // (1) C++14
 
   template <class CharT, class Traits, class Allocator>
   bool operator>(const CharT* a,

--- a/reference/string/basic_string/op_greater_equal.md
+++ b/reference/string/basic_string/op_greater_equal.md
@@ -7,7 +7,11 @@
 namespace std {
   template <class CharT, class Traits, class Allocator>
   bool operator>=(const basic_string<CharT, Traits, Allocator>& a,
-                  const basic_string<CharT, Traits, Allocator>& b) noexcept; // (1)
+                  const basic_string<CharT, Traits, Allocator>& b); // (1) C++03
+
+  template <class CharT, class Traits, class Allocator>
+  bool operator>=(const basic_string<CharT, Traits, Allocator>& a,
+                  const basic_string<CharT, Traits, Allocator>& b) noexcept; // (1) C++14
 
   template <class CharT, class Traits, class Allocator>
   bool operator>=(const CharT* a,

--- a/reference/string/basic_string/op_less.md
+++ b/reference/string/basic_string/op_less.md
@@ -7,7 +7,11 @@
 namespace std {
   template <class CharT, class Traits, class Allocator>
   bool operator<(const basic_string<CharT, Traits, Allocator>& a,
-                 const basic_string<CharT, Traits, Allocator>& b) noexcept; // (1)
+                 const basic_string<CharT, Traits, Allocator>& b); // (1) C++03
+
+  template <class CharT, class Traits, class Allocator>
+  bool operator<(const basic_string<CharT, Traits, Allocator>& a,
+                 const basic_string<CharT, Traits, Allocator>& b) noexcept; // (1) C++14
 
   template <class CharT, class Traits, class Allocator>
   bool operator<(const CharT* a,

--- a/reference/string/basic_string/op_less_equal.md
+++ b/reference/string/basic_string/op_less_equal.md
@@ -7,7 +7,11 @@
 namespace std {
   template <class CharT, class Traits, class Allocator>
   bool operator<=(const basic_string<CharT, Traits, Allocator>& a,
-                  const basic_string<CharT, Traits, Allocator>& b) noexcept; // (1)
+                  const basic_string<CharT, Traits, Allocator>& b); // (1) C++03
+
+  template <class CharT, class Traits, class Allocator>
+  bool operator<=(const basic_string<CharT, Traits, Allocator>& a,
+                  const basic_string<CharT, Traits, Allocator>& b) noexcept; // (1) C++14
 
   template <class CharT, class Traits, class Allocator>
   bool operator<=(const CharT* a,

--- a/reference/string/basic_string/op_not_equal.md
+++ b/reference/string/basic_string/op_not_equal.md
@@ -7,7 +7,7 @@
 namespace std {
   template <class CharT, class Traits, class Allocator>
   bool operator!=(const basic_string<CharT, Traits, Allocator>& a,
-                  const basic_string<CharT, Traits, Allocator>& b); // (1) C++11
+                  const basic_string<CharT, Traits, Allocator>& b); // (1) C++03
 
   template <class CharT, class Traits, class Allocator>
   bool operator!=(const basic_string<CharT, Traits, Allocator>& a,

--- a/reference/string/basic_string/rfind.md
+++ b/reference/string/basic_string/rfind.md
@@ -11,7 +11,7 @@ size_type rfind(const basic_string& str, size_type pos = npos) const noexcept; /
 size_type rfind(const charT* s, size_type pos, size_type n) const;             // (2)
 size_type rfind(const charT* s, size_type pos = npos) const;                   // (3)
 
-size_type rfind(charT c, size_type pos = npos) const;                          // (4) C++11
+size_type rfind(charT c, size_type pos = npos) const;                          // (4)
 
 size_type rfind(std::basic_string_view<charT, traits> sv,
                 size_type pos = npos) const noexcept;                          // (5) C++17


### PR DESCRIPTION
basic_stringのリファレンスに対し、次の修正をしました。

## find系メンバ関数のうち引数に `charT` 型をとるものから対応バージョンを削除

次のメンバ関数において引数に `charT` 型をとるものから「C++11」という補足を削除しました。

* find
* find_first_not_of
* find_first_of
* find_last_not_of
* find_last_of
* rfind

`charT` 型を引数にとるメンバ関数はC++03の頃から存在していると思うからです。

「C++11」という記述は 85da2ec23c49e72dcc133acfed6a430be4591a44 において追加されていましたが、その意図はよくわかりませんでした。

## basic_string同士の `==` 演算子と `!=` 演算子の対応バージョンを変更

basic_string同士の `==` 演算子と `!=` 演算子の対応バージョンを「C++11」から「C++03」に変更しました。

理由はfind系メンバ関数に対する変更と同じです。

## basic_string同士の演算子 `>`, `>=`, `<=`, `<` に 'noexcept` 版を追加

basic_string同士の演算子 `>`, `>=`, `<=`, `<` には `noexcept` 版の記述がなかったので、 `==` 演算子と同等の記述を追加してみました。

## よくわかっていないところ

basic_string同士の比較演算子の `noexcept` 版の対応バージョンは「C++14」になっています（`==` がそうなっていたので `>=` なども今回それに合わせました）。

ですが、N3337 を見るとC++11でもnoexceptが付いているように思えました。

* https://timsong-cpp.github.io/cppwp/n3337/string::operator==

なので当該演算子で今C++14と書いている所はC++11と書くのが正しいような気がします。ただ、cppreference.comやcplusplus.comでもnoexceptはC++14から付くような記述になっていて、どうしてそうなっているのか理解できていません。

* https://en.cppreference.com/w/cpp/string/basic_string/operator_cmp
* http://www.cplusplus.com/reference/string/basic_string/operators/
