### PR TITLE
C++17 constexpr if : 2段階名前探索における注意点、関数のシグネチャを修正

### DIFF
--- a/lang/cpp17/if_constexpr.md
+++ b/lang/cpp17/if_constexpr.md
@@ -75,7 +75,7 @@ constexpr if文の導入によりそのような複雑な手法を用いずに�
 #include <type_traits>
 
 template <typename T>
-void f()
+void f(T)
 {
   if constexpr (std::is_same_v<T, int>)
   {


### PR DESCRIPTION
間違っているとは言い切れないが、この例だけシグネチャが違うのでミスである可能性が高いと判断。