### PR TITLE
ページ内検索でinlineをキーワードにしたときに、インライン変数が引っかからないのが不便な気がするので説明に含める

### DIFF
--- a/lang/cpp17.md
+++ b/lang/cpp17.md
@@ -28,7 +28,7 @@ C++17以降、言語の策定にship train modelというリリース体制が�
 | 言語機能 | 説明 |
 |----------|------|
 | [十六進浮動小数点数リテラル](cpp17/hexadecimal_floating_literals.md) | 十六進数表記で浮動小数点数リテラルを記述できるようにする |
-| [インライン変数](cpp17/inline_variables.md) | 翻訳単位を跨いでひとつのオブジェクトになる変数を定義する |
+| [インライン変数](cpp17/inline_variables.md) | `inline`指定をすることで翻訳単位を跨いでひとつのオブジェクトになる変数を定義する |
 | [構造化束縛](cpp17/structured_bindings.md) | 組・タプル・配列を展開して変数定義する |
 | [波括弧初期化の型推論の新規則](cpp17/new_rules_for_auto_deduction_from_braced-init-list.md) | 波括弧初期化子が単一要素の場合は `T` に推論，複数要素の場合は不適格 |
 | [`[[maybe_unused]]`属性](cpp17/maybe_unused.md)       | 使用しない可能性のある変数に対する警告を抑制する |


### PR DESCRIPTION
https://cpprefjp.github.io/lang/cpp17.html
をブラウザで開いているときに、ページ内検索でinlineをキーワードにしたときに、インライン変数が引っかからないのが不便な気がするので説明に含めてみました。
すくなくとも自分は過去4回くらいあれ、引っかからないぞとなって探し回った経験があるので提案します。