### PR TITLE
stop_token ヘッダと関連クラスの概要を追加

### DIFF
--- a/reference.md
+++ b/reference.md
@@ -173,6 +173,7 @@
 | [`<shared_mutex>`](/reference/shared_mutex.md)             | 共有ミューテックス    | C++14          |
 | [`<condition_variable>`](/reference/condition_variable.md) | 条件変数              | C++11          |
 | [`<future>`](/reference/future.md)                         | Future                | C++11          |
+| [`<stop_token>`](/reference/stop_token.md)                 | 停止状態              | C++20          |
 
 
 ## <a id="clib-facilities" href="#clib-facilities">C言語互換ライブラリ</a>

--- a/reference/stop_token.md
+++ b/reference/stop_token.md
@@ -1,0 +1,24 @@
+# stop_token
+* stop_token[meta header]
+* cpp20[meta cpp]
+
+`<stop_token>`ヘッダはマルチスレッド処理に対する停止要求の状態 `停止状態` を扱うクラスを定義する。
+
+| 名前 | 説明 | 対応バージョン |
+|-----------------------------------------------|------------------------------|-------|
+| [`stop_token`](stop_token/stop_token.md)      | 停止状態を表すクラス(class) | C++20 |
+| [`stop_source`](stop_token/stop_source.md)    | 停止要求を発生させるクラス(class) | C++20 |
+| [`stop_callback`](stop_token/stop_callback.md)| 停止要求に応じて呼び出されるコールバックを表すクラステンプレート (class template) | C++20 |
+| [`nostopstate`](stop_token/nostopstate.md)    | 停止状態を扱わない[`stop_source`](stop_token/stop_source.md)を構築するためのタグ (class) | C++20 |
+
+## バージョン
+### 言語
+- C++20
+
+### 処理系
+
+- [Clang](/implementation.md#clang): ??
+- [GCC](/implementation.md#gcc): ??
+- [ICC](/implementation.md#icc): ??
+- [Visual C++](/implementation.md#visual_cpp): ??
+

--- a/reference/stop_token.md
+++ b/reference/stop_token.md
@@ -22,3 +22,5 @@
 - [ICC](/implementation.md#icc): ??
 - [Visual C++](/implementation.md#visual_cpp): ??
 
+## 参照
+- [P0660R10 Stop token and joining thread](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0660r10.pdf)

--- a/reference/stop_token/nostopstate.md
+++ b/reference/stop_token/nostopstate.md
@@ -1,0 +1,62 @@
+# nostopstate
+* stop_token[meta header]
+* std[meta namespace]
+* class[meta id-type]
+* cpp20[meta cpp]
+
+```cpp
+namespace std {
+  struct nostopstate_t {
+    explicit nostopstate_t() = default;
+  };
+
+  inline constexpr nostopstate_t nostopstate{};
+}
+```
+
+## 概要
+`nostopstate_t`型とその値`nostopstate`は、停止状態を扱わない[`stop_source`](stop_source.md)を構築するためのタグである。  
+`stop_source`クラスのコンストラクタに`nostopstate`を渡すと、その`stop_source`は停止要求を扱うためのリソースを確保せず、停止要求を作成したり`stop_token`クラスと停止状態を共有したりできない状態になる。
+
+
+## 例
+```cpp example
+#include <cassert>
+#include <stop_token>
+
+int main()
+{
+  std::stop_source ss1;
+  std::stop_source ss2(std::nostopstate);
+
+  assert(ss1.stop_possible() == true);
+  assert(ss2.stop_possible() == false);
+
+  std::stop_token st1 = ss1.get_token();
+  std::stop_token st2 = ss2.get_token();
+
+  assert(st1.stop_possible() == true);
+  assert(st2.stop_possible() == false);
+}
+```
+* std::stop_token[link stop_token.md]
+* std::stop_source[link stop_source.md]
+* std::nostopstate[link nostopstate.md]
+* stop_possible()[link stop_token/stop_possible.md]
+* get_token()[link stop_source/get_token.md]
+
+### 出力
+```
+```
+
+## バージョン
+### 言語
+- C++20
+
+
+### 処理系
+- [Clang](/implementation.md#clang): ??
+- [GCC](/implementation.md#gcc): ??
+- [ICC](/implementation.md#icc): ??
+- [Visual C++](/implementation.md#visual_cpp): ??
+

--- a/reference/stop_token/nostopstate.md
+++ b/reference/stop_token/nostopstate.md
@@ -42,8 +42,8 @@ int main()
 * std::stop_token[link stop_token.md]
 * std::stop_source[link stop_source.md]
 * std::nostopstate[link nostopstate.md]
-* stop_possible()[link stop_token/stop_possible.md]
-* get_token()[link stop_source/get_token.md]
+* stop_possible()[link stop_token/stop_possible.md.nolink]
+* get_token()[link stop_source/get_token.md.nolink]
 
 ### 出力
 ```

--- a/reference/stop_token/stop_callback.md
+++ b/reference/stop_token/stop_callback.md
@@ -18,9 +18,9 @@ namespace std {
 
 | 名前 | 説明 | 対応バージョン |
 |---------------------------------------------------|--------------------------------------------------------------------|-------|
-| [`(constructor)`](stop_callback/op_constructor.md)| コンストラクタ | C++20 |
-| [`(destructor)`](stop_callback/op_destructor.md)  | デストラクタ | C++20 |
-| [`operator=`](stop_callback/op_assign.md)         | 代入演算子 | C++20 |
+| [`(constructor)`](stop_callback/op_constructor.md.nolink)| コンストラクタ | C++20 |
+| [`(destructor)`](stop_callback/op_destructor.md.nolink)  | デストラクタ | C++20 |
+| [`operator=`](stop_callback/op_assign.md.nolink)         | 代入演算子 | C++20 |
 
 ## メンバ型
 
@@ -32,7 +32,7 @@ namespace std {
 
 | 名前 | 説明 | 対応バージョン |
 |---------------------------------------------|------------------------------------|-------|
-| [`(deduction_guide)`](stop_callback/op_deduction_guide.md) | クラステンプレートの推論補助 | C++20 |
+| [`(deduction_guide)`](stop_callback/op_deduction_guide.md.nolink) | クラステンプレートの推論補助 | C++20 |
 
 ## 適格条件
 テンプレート引数の`Callback`は`invocable`と`destructible`制約を満たさなければならい。
@@ -72,8 +72,8 @@ int main()
 * stop_token[link stop_token.md]
 * stop_source[link stop_source.md]
 * stop_callback[link stop_callback.md]
-* request_stop()[link stop_source/request_stop.md]
-* get_token()[link stop_source/get_token.md]
+* request_stop()[link stop_source/request_stop.md.nolink]
+* get_token()[link stop_source/get_token.md.nolink]
 
 ### 出力
 ```

--- a/reference/stop_token/stop_callback.md
+++ b/reference/stop_token/stop_callback.md
@@ -1,0 +1,92 @@
+# stop_callback
+* stop_token[meta header]
+* std[meta namespace]
+* class template[meta id-type]
+* cpp20[meta cpp]
+
+```cpp
+namespace std {
+  template<class Callback>
+  class stop_callback;
+}
+```
+
+## 概要
+`stop_callback`クラステンプレートは、停止要求が作成された際に呼び出されるコールバックを表す。
+
+## メンバ関数
+
+| 名前 | 説明 | 対応バージョン |
+|---------------------------------------------------|--------------------------------------------------------------------|-------|
+| [`(constructor)`](stop_callback/op_constructor.md)| コンストラクタ | C++20 |
+| [`(destructor)`](stop_callback/op_destructor.md)  | デストラクタ | C++20 |
+| [`operator=`](stop_callback/op_assign.md)         | 代入演算子 | C++20 |
+
+## メンバ型
+
+| 名前            | 説明           | 対応バージョン |
+|-----------------|----------------|----------------|
+| `callback_type` | テンプレート引数`Callback`に指定した型| C++20 |
+
+## 推論補助
+
+| 名前 | 説明 | 対応バージョン |
+|---------------------------------------------|------------------------------------|-------|
+| [`(deduction_guide)`](stop_callback/op_deduction_guide.md) | クラステンプレートの推論補助 | C++20 |
+
+## 適格条件
+テンプレート引数の`Callback`は`invocable`と`destructible`制約を満たさなければならい。
+
+## 事前条件
+テンプレート引数の`Callback`は`invocable`と`destructible`制約を満たさなければならい。
+
+## 例
+```cpp example
+#include <cassert>
+#include <string>
+#include <stop_token>
+
+int main()
+{
+  std::string msg;
+
+  std::stop_source ss;
+  std::stop_token st = ss.get_token();
+  std::stop_callback cb1(st, [&] { msg += "hello"; });
+
+  assert(msg == "");
+
+  ss.request_stop();
+
+  // 停止要求が作成される前に登録されていたコールバック関数は、
+  // 停止要求が作成された際にその中で呼び出される
+  assert(msg == "hello");
+
+  std::stop_callback cb2(st, [&] { msg += " world"; });
+
+  // 停止要求が作成されたあとに登録されたコールバック関数は、
+  // std::stop_callbackクラスのコンストラクタの中で即座に呼び出される
+  assert(msg == "hello world");
+}
+```
+* stop_token[link stop_token.md]
+* stop_source[link stop_source.md]
+* stop_callback[link stop_callback.md]
+* request_stop()[link stop_source/request_stop.md]
+* get_token()[link stop_source/get_token.md]
+
+### 出力
+```
+```
+
+## バージョン
+### 言語
+- C++20
+
+
+### 処理系
+- [Clang](/implementation.md#clang): ??
+- [GCC](/implementation.md#gcc): ??
+- [ICC](/implementation.md#icc): ??
+- [Visual C++](/implementation.md#visual_cpp): ??
+

--- a/reference/stop_token/stop_source.md
+++ b/reference/stop_token/stop_source.md
@@ -18,21 +18,21 @@ namespace std {
 
 | 名前 | 説明 | 対応バージョン |
 |-------------------------------------------------|--------------------------------------------------------------------|-------|
-| [`(constructor)`](stop_source/op_constructor.md) | コンストラクタ | C++20 |
-| [`(destructor)`](stop_source/op_destructor.md)   | デストラクタ | C++20 |
-| [`operator=`](stop_source/op_assign.md)          | 代入演算子 | C++20 |
-| [`swap`](stop_source/swap.md)                    | 別の`stop_source`と交換する | C++20 |
-| [`get_token`](stop_source/get_token.md)          | 自身と停止状態を共有する`stop_token`を構築して返す | C++20 |
-| [`stop_possible`](stop_source/stop_possible.md)  | 停止要求を作成可能どうかを取得する | C++20 |
-| [`stop_requested`](stop_source/stop_requested.md)| 停止要求を作成したかどうかを取得する | C++20 |
-| [`request_stop`](stop_source/request_stop.md)    | 停止要求を作成する | C++20 |
+| [`(constructor)`](stop_source/op_constructor.md.nolink) | コンストラクタ | C++20 |
+| [`(destructor)`](stop_source/op_destructor.md.nolink)   | デストラクタ | C++20 |
+| [`operator=`](stop_source/op_assign.md.nolink)          | 代入演算子 | C++20 |
+| [`swap`](stop_source/swap.md.nolink)                    | 別の`stop_source`と交換する | C++20 |
+| [`get_token`](stop_source/get_token.md.nolink)          | 自身と停止状態を共有する`stop_token`を構築して返す | C++20 |
+| [`stop_possible`](stop_source/stop_possible.md.nolink)  | 停止要求を作成可能どうかを取得する | C++20 |
+| [`stop_requested`](stop_source/stop_requested.md.nolink)| 停止要求を作成したかどうかを取得する | C++20 |
+| [`request_stop`](stop_source/request_stop.md.nolink)    | 停止要求を作成する | C++20 |
 
 ## 非メンバ関数
 | 名前 | 説明 | 対応バージョン |
 |---------------------------------|---------------------------------------|-------|
-| [`operator==`](stop_source/op_equal.md)         | 等値演算子 | C++20 |
-| [`operator!=`](stop_source/op_not_equal.md)     | 非等値演算子 | C++20 |
-| [`swap`](stop_source/swap_free.md) | 2つの`stop_source`オブジェクトを入れ替える | C++11 |
+| [`operator==`](stop_source/op_equal.md.nolink)         | 等値演算子 | C++20 |
+| [`operator!=`](stop_source/op_not_equal.md.nolink)     | 非等値演算子 | C++20 |
+| [`swap`](stop_source/swap_free.md.nolink) | 2つの`stop_source`オブジェクトを入れ替える | C++11 |
 
 
 ## 例
@@ -58,9 +58,9 @@ int main()
 ```
 * stop_token[link stop_token.md]
 * stop_source[link stop_source.md]
-* stop_requested()[link stop_source/stop_requested.md]
-* request_stop()[link stop_source/request_stop.md]
-* get_token()[link stop_source/get_token.md]
+* stop_requested()[link stop_source/stop_requested.md.nolink]
+* request_stop()[link stop_source/request_stop.md.nolink]
+* get_token()[link stop_source/get_token.md.nolink]
 
 ### 出力
 ```

--- a/reference/stop_token/stop_source.md
+++ b/reference/stop_token/stop_source.md
@@ -1,0 +1,79 @@
+# stop_source
+* stop_source[meta header]
+* std[meta namespace]
+* class[meta id-type]
+* cpp20[meta cpp]
+
+```cpp
+namespace std {
+  class stop_source;
+}
+```
+
+## 概要
+クラス`stop_source`は、停止要求を作成するためのインターフェースを提供する。  
+また、自身と停止状態を共有する[`stop_token`](stop_token.md)クラスのオブジェクトを構築できる。
+
+## メンバ関数
+
+| 名前 | 説明 | 対応バージョン |
+|-------------------------------------------------|--------------------------------------------------------------------|-------|
+| [`(constructor)`](stop_source/op_constructor.md) | コンストラクタ | C++20 |
+| [`(destructor)`](stop_source/op_destructor.md)   | デストラクタ | C++20 |
+| [`operator=`](stop_source/op_assign.md)          | 代入演算子 | C++20 |
+| [`swap`](stop_source/swap.md)                    | 別の`stop_source`と交換する | C++20 |
+| [`get_token`](stop_source/get_token.md)          | 自身と停止状態を共有する`stop_token`を構築して返す | C++20 |
+| [`stop_possible`](stop_source/stop_possible.md)  | 停止要求を作成可能どうかを取得する | C++20 |
+| [`stop_requested`](stop_source/stop_requested.md)| 停止要求を作成したかどうかを取得する | C++20 |
+| [`request_stop`](stop_source/request_stop.md)    | 停止要求を作成する | C++20 |
+
+## 非メンバ関数
+| 名前 | 説明 | 対応バージョン |
+|---------------------------------|---------------------------------------|-------|
+| [`operator==`](stop_source/op_equal.md)         | 等値演算子 | C++20 |
+| [`operator!=`](stop_source/op_not_equal.md)     | 非等値演算子 | C++20 |
+| [`swap`](stop_source/swap_free.md) | 2つの`stop_source`オブジェクトを入れ替える | C++11 |
+
+
+## 例
+```cpp example
+#include <cassert>
+#include <stop_token>
+
+int main()
+{
+  std::stop_source ss;
+
+  assert(ss.stop_possible() == true);
+  assert(ss.stop_requested() == false);
+
+  std::stop_token st = ss.get_token();
+  assert(st.stop_requested() == false);
+
+  ss.request_stop();
+
+  assert(ss.stop_requested() == true);
+  assert(st.stop_requested() == true);
+}
+```
+* stop_token[link stop_token.md]
+* stop_source[link stop_source.md]
+* stop_requested()[link stop_source/stop_requested.md]
+* request_stop()[link stop_source/request_stop.md]
+* get_token()[link stop_source/get_token.md]
+
+### 出力
+```
+```
+
+## バージョン
+### 言語
+- C++20
+
+
+### 処理系
+- [Clang](/implementation.md#clang): ??
+- [GCC](/implementation.md#gcc): ??
+- [ICC](/implementation.md#icc): ??
+- [Visual C++](/implementation.md#visual_cpp): ??
+

--- a/reference/stop_token/stop_source.md
+++ b/reference/stop_token/stop_source.md
@@ -1,5 +1,5 @@
 # stop_source
-* stop_source[meta header]
+* stop_token[meta header]
 * std[meta namespace]
 * class[meta id-type]
 * cpp20[meta cpp]

--- a/reference/stop_token/stop_token.md
+++ b/reference/stop_token/stop_token.md
@@ -1,0 +1,78 @@
+# stop_token
+* stop_token[meta header]
+* std[meta namespace]
+* class[meta id-type]
+* cpp20[meta cpp]
+
+```cpp
+namespace std {
+  class stop_token;
+}
+```
+
+## 概要
+クラス`stop_token`は、停止要求が作成されたかどうか、あるいは停止要求が作成されうるかどうかなど、停止状態を問い合わせるためのインターフェースを提供する。  
+またこのクラスは、停止要求に応じて呼び出されるコールバックを登録する`stop_callback`クラスのコンストラクタへ渡される。
+
+## メンバ関数
+
+| 名前 | 説明 | 対応バージョン |
+|-------------------------------------------------|--------------------------------------------------------------------|-------|
+| [`(constructor)`](stop_token/op_constructor.md) | コンストラクタ | C++20 |
+| [`(destructor)`](stop_token/op_destructor.md)   | デストラクタ | C++20 |
+| [`operator=`](stop_token/op_assign.md)          | 代入演算子 | C++20 |
+| [`swap`](stop_token/swap.md)                    | 別の`stop_token`と交換する | C++20 |
+| [`stop_requested`](stop_token/stop_requested.md)| 停止要求が作成されたかどうかを取得する | C++20 |
+| [`stop_possible`](stop_token/stop_possible.md)  | 停止要求が作成されうるかどうかを取得する | C++20 |
+
+## 非メンバ関数
+| 名前 | 説明 | 対応バージョン |
+|------------------------------------------------|---------------------------------------|-------|
+| [`operator==`](stop_token/op_equal.md)         | 等値演算子 | C++20 |
+| [`operator!=`](stop_token/op_not_equal.md)     | 非等値演算子 | C++20 |
+| [`swap`](stop_token/swap_free.md)              | 2つの`stop_token`オブジェクトを入れ替える | C++20 |
+
+
+## 例
+```cpp example
+#include <cassert>
+#include <stop_token>
+
+int main()
+{
+  std::stop_source ss;
+
+  assert(ss.stop_possible() == true);
+  assert(ss.stop_requested() == false);
+
+  std::stop_token st = ss.get_token();
+  assert(st.stop_requested() == false);
+
+  ss.request_stop();
+
+  assert(ss.stop_requested() == true);
+  assert(st.stop_requested() == true);
+}
+```
+* stop_token[link stop_token.md]
+* stop_source[link stop_source.md]
+* stop_requested()[link stop_token/stop_requested.md]
+* request_stop()[link stop_source/request_stop.md]
+* get_token()[link stop_source/get_token.md]
+
+### 出力
+```
+```
+
+
+## バージョン
+### 言語
+- C++20
+
+
+### 処理系
+- [Clang](/implementation.md#clang): ??
+- [GCC](/implementation.md#gcc): ??
+- [ICC](/implementation.md#icc): ??
+- [Visual C++](/implementation.md#visual_cpp): ??
+

--- a/reference/stop_token/stop_token.md
+++ b/reference/stop_token/stop_token.md
@@ -18,19 +18,19 @@ namespace std {
 
 | 名前 | 説明 | 対応バージョン |
 |-------------------------------------------------|--------------------------------------------------------------------|-------|
-| [`(constructor)`](stop_token/op_constructor.md) | コンストラクタ | C++20 |
-| [`(destructor)`](stop_token/op_destructor.md)   | デストラクタ | C++20 |
-| [`operator=`](stop_token/op_assign.md)          | 代入演算子 | C++20 |
-| [`swap`](stop_token/swap.md)                    | 別の`stop_token`と交換する | C++20 |
-| [`stop_requested`](stop_token/stop_requested.md)| 停止要求が作成されたかどうかを取得する | C++20 |
-| [`stop_possible`](stop_token/stop_possible.md)  | 停止要求が作成されうるかどうかを取得する | C++20 |
+| [`(constructor)`](stop_token/op_constructor.md.nolink) | コンストラクタ | C++20 |
+| [`(destructor)`](stop_token/op_destructor.md.nolink)   | デストラクタ | C++20 |
+| [`operator=`](stop_token/op_assign.md.nolink)          | 代入演算子 | C++20 |
+| [`swap`](stop_token/swap.md.nolink)                    | 別の`stop_token`と交換する | C++20 |
+| [`stop_requested`](stop_token/stop_requested.md.nolink)| 停止要求が作成されたかどうかを取得する | C++20 |
+| [`stop_possible`](stop_token/stop_possible.md.nolink)  | 停止要求が作成されうるかどうかを取得する | C++20 |
 
 ## 非メンバ関数
 | 名前 | 説明 | 対応バージョン |
 |------------------------------------------------|---------------------------------------|-------|
-| [`operator==`](stop_token/op_equal.md)         | 等値演算子 | C++20 |
-| [`operator!=`](stop_token/op_not_equal.md)     | 非等値演算子 | C++20 |
-| [`swap`](stop_token/swap_free.md)              | 2つの`stop_token`オブジェクトを入れ替える | C++20 |
+| [`operator==`](stop_token/op_equal.md.nolink)         | 等値演算子 | C++20 |
+| [`operator!=`](stop_token/op_not_equal.md.nolink)     | 非等値演算子 | C++20 |
+| [`swap`](stop_token/swap_free.md.nolink)              | 2つの`stop_token`オブジェクトを入れ替える | C++20 |
 
 
 ## 例
@@ -56,9 +56,9 @@ int main()
 ```
 * stop_token[link stop_token.md]
 * stop_source[link stop_source.md]
-* stop_requested()[link stop_token/stop_requested.md]
-* request_stop()[link stop_source/request_stop.md]
-* get_token()[link stop_source/get_token.md]
+* stop_requested()[link stop_token/stop_requested.md.nolink]
+* request_stop()[link stop_source/request_stop.md.nolink]
+* get_token()[link stop_source/get_token.md.nolink]
 
 ### 出力
 ```

--- a/working_style.md
+++ b/working_style.md
@@ -111,6 +111,8 @@ C++11以降対応については対応バージョンを明記します。バー
 | rvalue reference                   | 右辺値参照                   |
 | sequence container(s)              | シーケンスコンテナ           |
 | signed                             | 符号付き                     |
+| stop request                       | 停止要求                     |
+| stop state                         | 停止状態                     |
 | Spurious Failure                   | 見かけ上の失敗<br/> [https://togetter.com/li/430770](https://togetter.com/li/430770) |
 | strict weak ordering               | 狭義の弱順序                 |
 | strong ordering                    | 全順序                       |


### PR DESCRIPTION
タイトルの通り、 stop_token ヘッダと関連クラスの概要を追加しました。
なので、メンバ関数のリファレンスはTODO状態です。

初めての執筆で具合が分からないですが、なるべく他の記事や editors_doc の記載を参照して書きました。こんな感じで大丈夫でしょうか？

よろしくお願いしますー