### PR TITLE
サイトのビルドを GitHub Actions 化した

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,10 @@ jobs:
     - run: git submodule update -i
       working-directory: site_generator/cpprefjp/site
 
-    # setuptools が無いって怒られたので
-    - run: sudo apt-get install -y python3-setuptools
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.x
 
     # あとはスクリプトで頑張る
     - run: ./cpprefjp/site/.github/workflows/script/build.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,8 +46,8 @@ jobs:
       with:
         repository: cpprefjp/site
         path: site_generator/cpprefjp/site
-        # atom 生成のためにある程度履歴が必要
-        fetch-depth: 10
+        # atom 生成のために全履歴が必要
+        fetch-depth: 0
     - run: git submodule update -i
       working-directory: site_generator/cpprefjp/site
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
       # - master
       # テストのために今だけこのブランチを反映させる
       - github-actions
+  schedule:
+    # UTC 表記
+    # 日本時間 23:30
+    - cron: "30 14 * * *"
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: build
+
+on:
+  push:
+    branches:
+      # - master
+      # テストのために今だけこのブランチを反映させる
+      - github-actions
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Register SSH key
+      env:
+        CPPREFJP_GITHUB_IO_SECRETS: ${{ secrets.CPPREFJP_GITHUB_IO_SECRETS }}
+      run: |
+        mkdir -p $HOME/.ssh
+        echo "$CPPREFJP_GITHUB_IO_SECRETS" > $HOME/.ssh/id_ed25519
+        chmod 600 $HOME/.ssh/id_ed25519
+
+    # site_generator
+    - uses: actions/checkout@v2
+      with:
+        repository: cpprefjp/site_generator
+        path: site_generator
+    - run: git submodule update -i
+      working-directory: site_generator
+
+    # kunai
+    - uses: actions/checkout@v2
+      with:
+        repository: cpprefjp/kunai
+        path: site_generator/kunai
+    - run: git submodule update -i
+      working-directory: site_generator/kunai
+
+    # cpprefjp.github.io
+    - uses: actions/checkout@v2
+      with:
+        repository: cpprefjp/cpprefjp.github.io
+        path: site_generator/cpprefjp/cpprefjp.github.io
+
+    # site
+    - uses: actions/checkout@v2
+      with:
+        repository: cpprefjp/site
+        path: site_generator/cpprefjp/site
+    - run: git submodule update -i
+      working-directory: site_generator/cpprefjp/site
+
+    # あとはスクリプトで頑張る
+    - run: ./cpprefjp/site/.github/workflows/script/build.sh
+      working-directory: site_generator

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
       with:
         repository: cpprefjp/site
         path: site_generator/cpprefjp/site
+        # atom 生成のためにある程度履歴が必要
+        fetch-depth: 10
     - run: git submodule update -i
       working-directory: site_generator/cpprefjp/site
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,7 @@ name: build
 on:
   push:
     branches:
-      # - master
-      # テストのために今だけこのブランチを反映させる
-      - github-actions
+      - master
   schedule:
     # UTC 表記
     # 日本時間 23:30

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,9 @@ jobs:
     - run: git submodule update -i
       working-directory: site_generator/cpprefjp/site
 
+    # setuptools が無いって怒られたので
+    - run: sudo apt-get install -y python3-setuptools
+
     # あとはスクリプトで頑張る
     - run: ./cpprefjp/site/.github/workflows/script/build.sh
       working-directory: site_generator

--- a/.github/workflows/script/build.sh
+++ b/.github/workflows/script/build.sh
@@ -2,6 +2,8 @@
 
 # site_generator 直下でこのスクリプトを実行すること
 
+set -ex
+
 # dist を生成
 pushd kunai
   npm install

--- a/.github/workflows/script/build.sh
+++ b/.github/workflows/script/build.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# site_generator 直下でこのスクリプトを実行すること
+
+# dist を生成
+pushd kunai
+  npm install
+  npm run build
+popd
+
+# dist の中身を cpprefjp の static ディレクトリに反映
+pushd cpprefjp/static/static
+  ln -s ../../../kunai/dist kunai
+popd
+
+# crsearch.json ファイルを生成
+pushd crsearch.json
+  ln -s ../cpprefjp/site site
+  pip3 install -r docker/requirements.txt
+  python3 run.py
+popd
+
+# crsearch.json を cpprefjp の static ディレクトリに反映
+mkdir -p cpprefjp/static/static/crsearch
+pushd cpprefjp/static/static/crsearch
+  ln -s ../../../../crsearch.json/crsearch.json crsearch.json
+popd
+
+# サイトの生成
+pip3 install -r docker/requirements.txt
+python3 run.py settings.cpprefjp
+
+# 生成されたサイトの中身を push
+pushd cpprefjp/cpprefjp.github.io
+  # push するために ssh のリモートを追加する
+  git remote add origin2 git@github.com:cpprefjp/cpprefjp.github.io.git
+
+  git add ./ --all
+  git commit -a "--author=cpprefjp-autoupdate <shigemasa7watanabe@gmail.com>" -m "update automatically"
+  git push origin2 master
+popd

--- a/.github/workflows/script/build.sh
+++ b/.github/workflows/script/build.sh
@@ -30,7 +30,7 @@ popd
 
 # サイトの生成
 pip3 install -r docker/requirements.txt
-python3 run.py settings.cpprefjp
+python3 run.py settings.cpprefjp --concurrency=`nproc`
 
 # 生成されたサイトの中身を push
 pushd cpprefjp/cpprefjp.github.io

--- a/.github/workflows/script/build.sh
+++ b/.github/workflows/script/build.sh
@@ -38,6 +38,8 @@ pushd cpprefjp/cpprefjp.github.io
   git remote add origin2 git@github.com:cpprefjp/cpprefjp.github.io.git
 
   git add ./ --all
-  git commit -a "--author=cpprefjp-autoupdate <shigemasa7watanabe@gmail.com>" -m "update automatically"
+  git config --global user.email "shigemasa7watanabe+cpprefjp@gmail.com"
+  git config --global user.name "cpprefjp-autoupdate"
+  git commit -a -m "update automatically"
   git push origin2 master
 popd


### PR DESCRIPTION
今まで自分が管理してたさくらVPSのサーバを使ってビルドしていましたが、それを GitHub Actions で行うようにしました。

- site の master ブランチへの push か、毎日 23:30 をトリガーにビルドが走ります。
  - デイリーを用意しているのは site_generator や kunai が更新された時に反映する用です。
- サイトをビルドした後、cpprefjp/cpprefjp.github.io に自動的に push します。
- cpprefjp.github.io に push するための秘密鍵は GitHub の Secrets に保存していて、公開鍵は cpprefjp.github.io のデプロイキーとして登録しています。
  - 秘密鍵は手元でも削除したので、もし何かの理由で使えなくなったら登録し直す必要があります。
