### PR TITLE
スマートポインタのswapで、ポインタが入れ替わることが明確になる例にした

### DIFF
--- a/reference/memory/shared_ptr/swap.md
+++ b/reference/memory/shared_ptr/swap.md
@@ -35,19 +35,24 @@ int main()
   std::shared_ptr<int> a(new int(3));
   std::shared_ptr<int> b(new int(1));
 
+  std::cout << a << std::endl;
+  std::cout << b << std::endl;
+
   // aとbを入れ替える
   a.swap(b);
 
-  std::cout << *a << std::endl;
-  std::cout << *b << std::endl;
+  std::cout << a << std::endl;
+  std::cout << b << std::endl;
 }
 ```
 * swap[color ff0000]
 
-### 出力
+### 出力例
 ```
-1
-3
+0x14ab010
+0x14ab060
+0x14ab060
+0x14ab010
 ```
 
 ## バージョン

--- a/reference/memory/shared_ptr/swap_free.md
+++ b/reference/memory/shared_ptr/swap_free.md
@@ -37,19 +37,24 @@ int main()
   std::shared_ptr<int> a(new int(3));
   std::shared_ptr<int> b(new int(1));
 
+  std::cout << a << std::endl;
+  std::cout << b << std::endl;
+
   // aとbを入れ替える
   std::swap(a, b);
 
-  std::cout << *a << std::endl;
-  std::cout << *b << std::endl;
+  std::cout << a << std::endl;
+  std::cout << b << std::endl;
 }
 ```
 * std::swap[color ff0000]
 
-### 出力
+### 出力例
 ```
-1
-3
+0x14ab010
+0x14ab060
+0x14ab060
+0x14ab010
 ```
 
 ## バージョン

--- a/reference/memory/unique_ptr/swap.md
+++ b/reference/memory/unique_ptr/swap.md
@@ -35,19 +35,24 @@ int main()
   std::unique_ptr<int> a(new int(3));
   std::unique_ptr<int> b(new int(1));
 
+  std::cout << a << std::endl;
+  std::cout << b << std::endl;
+
   // aとbを入れ替える
   a.swap(b);
 
-  std::cout << *a << std::endl;
-  std::cout << *b << std::endl;
+  std::cout << a << std::endl;
+  std::cout << b << std::endl;
 }
 ```
 * swap[color ff0000]
 
-### 出力
+### 出力例
 ```
-1
-3
+0x14ab010
+0x14ab060
+0x14ab060
+0x14ab010
 ```
 
 ## バージョン

--- a/reference/memory/unique_ptr/swap_free.md
+++ b/reference/memory/unique_ptr/swap_free.md
@@ -33,19 +33,24 @@ int main()
   std::unique_ptr<int> a(new int(3));
   std::unique_ptr<int> b(new int(1));
 
+  std::cout << a << std::endl;
+  std::cout << b << std::endl;
+
   // aとbを入れ替える
   std::swap(a, b);
 
-  std::cout << *a << std::endl;
-  std::cout << *b << std::endl;
+  std::cout << a << std::endl;
+  std::cout << b << std::endl;
 }
 ```
 * std::swap[color ff0000]
 
-### 出力
+### 出力例
 ```
-1
-3
+0x14ab010
+0x14ab060
+0x14ab060
+0x14ab010
 ```
 
 ## バージョン

--- a/reference/memory/weak_ptr/swap.md
+++ b/reference/memory/weak_ptr/swap.md
@@ -38,25 +38,35 @@ int main()
   std::shared_ptr<int> sp2(new int(2));
   std::weak_ptr<int> wp2 = sp2;
 
+  if (std::shared_ptr<int> r = wp1.lock()) {
+    std::cout << r << std::endl;
+  }
+
+  if (std::shared_ptr<int> r = wp2.lock()) {
+    std::cout << r << std::endl;
+  }
+
   // wp1とwp2を入れ替える
   wp1.swap(wp2);
 
   if (std::shared_ptr<int> r = wp1.lock()) {
-    std::cout << *r << std::endl;
+    std::cout << r << std::endl;
   }
 
   if (std::shared_ptr<int> r = wp2.lock()) {
-    std::cout << *r << std::endl;
+    std::cout << r << std::endl;
   }
 }
 ```
 * swap[color ff0000]
 * lock()[link lock.md]
 
-### 出力
+### 出力例
 ```
-2
-1
+0x14ab010
+0x14ab060
+0x14ab060
+0x14ab010
 ```
 
 ## バージョン

--- a/reference/memory/weak_ptr/swap_free.md
+++ b/reference/memory/weak_ptr/swap_free.md
@@ -40,25 +40,35 @@ int main()
   std::shared_ptr<int> sp2(new int(2));
   std::weak_ptr<int> wp2 = sp2;
 
+  if (std::shared_ptr<int> r = wp1.lock()) {
+    std::cout << r << std::endl;
+  }
+
+  if (std::shared_ptr<int> r = wp2.lock()) {
+    std::cout << r << std::endl;
+  }
+
   // wp1とwp2を入れ替える
   std::swap(wp1, wp2);
 
   if (std::shared_ptr<int> r = wp1.lock()) {
-    std::cout << *r << std::endl;
+    std::cout << r << std::endl;
   }
 
   if (std::shared_ptr<int> r = wp2.lock()) {
-    std::cout << *r << std::endl;
+    std::cout << r << std::endl;
   }
 }
 ```
 * std::swap[color ff0000]
 * lock()[link lock.md]
 
-### 出力
+### 出力例
 ```
-2
-1
+0x14ab010
+0x14ab060
+0x14ab060
+0x14ab010
 ```
 
 ## バージョン


### PR DESCRIPTION
現状の例だと「値が交換されている」ことを確かめているように見えるので、ポインタ自体の値を出力することで、「ポインタが交換されている」ことが明確になるかと思います。

出力が実行毎に変わってしまいますが、[shared_ptr::operator<<](https://github.com/cpprefjp/site/blob/5b2e17205cdeaf56b0deb677e73674c613043fae/reference/memory/shared_ptr/op_ostream.md#%E5%87%BA%E5%8A%9B%E4%BE%8B)などが「出力例」として出しているので、それに習って「例」にも変更しています。