### PR TITLE
feat(ci): create issue when outerlink check detect outdated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*           text=auto
+*.sh        text eol=lf

--- a/.github/workflows/outer_link_check.yml
+++ b/.github/workflows/outer_link_check.yml
@@ -22,4 +22,8 @@ jobs:
       with:
         ref: master
     - name: check
-      run: python3 .github/workflows/script/link_check.py --check-outer-link
+      run: python3 .github/workflows/script/link_check.py --check-outer-link 2> check_result.txt
+    - name: print check check_result
+      run: cat check_result.txt
+    - name: create github issue when needed
+      run: .github/workflows/script/create_github_issue_when_not_empty.sh check_result.txt ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }}

--- a/.github/workflows/outer_link_check.yml
+++ b/.github/workflows/outer_link_check.yml
@@ -22,8 +22,9 @@ jobs:
       with:
         ref: master
     - name: check
-      run: python3 .github/workflows/script/link_check.py --check-outer-link 2> check_result.txt
-    - name: print check check_result
-      run: cat check_result.txt
+      run: |
+        { python3 .github/workflows/script/link_check.py --check-outer-link  3>&2 2>&1 1>&3 | tee check_result.txt; } 3>&2 2>&1 1>&3
     - name: create github issue when needed
       run: .github/workflows/script/create_github_issue_when_not_empty.sh check_result.txt ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }}
+    - name: detect link check check_result
+      run: test -f check_result.txt && test $(wc -l < check_result.txt) -eq 0

--- a/.github/workflows/script/create_github_issue_when_not_empty.sh
+++ b/.github/workflows/script/create_github_issue_when_not_empty.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ $# -ne 4 ] || [ ! -f "$1" ] || [[ "$3" != */* ]]; then
+    echo "invalid argument" 1>&2
+    echo "./create_github_issue_when_not_empty.sh [target file] [github token] [:owner/:repo] [current commit hash]" 1>&2
+    exit 1
+fi
+
+if [ "$(wc -l < "$1")" -eq 0 ]; then
+    exit 0
+fi
+curl --request POST \
+    --url "https://api.github.com/repos/$3/issues" \
+    --header "authorization: Bearer $2" \
+    --header 'content-type: application/json' \
+    -d @- << EOF 
+{
+    "title": "outer link check failed at $4",
+    "body": "The commit hash was: _$4_.\n\n$(cat "$1")"
+}
+EOF

--- a/.github/workflows/script/create_github_issue_when_not_empty.sh
+++ b/.github/workflows/script/create_github_issue_when_not_empty.sh
@@ -13,9 +13,9 @@ curl --request POST \
     --url "https://api.github.com/repos/$3/issues" \
     --header "authorization: Bearer $2" \
     --header 'content-type: application/json' \
-    -d @- << EOF 
+    -d @- << EOF
 {
     "title": "outer link check failed at $4",
-    "body": "The commit hash was: _$4_.\n\n$(cat "$1")"
+    "body": "The commit hash was: _$4_.\n\n$(perl -pe 's/\n/\\n/g' "$1" | cat)"
 }
 EOF

--- a/.github/workflows/script/create_github_issue_when_not_empty.sh
+++ b/.github/workflows/script/create_github_issue_when_not_empty.sh
@@ -16,6 +16,6 @@ curl --request POST \
     -d @- << EOF
 {
     "title": "outer link check failed at $4",
-    "body": "The commit hash was: _$4_.\n\n$(perl -pe 's/\n/\\n/g' "$1" | cat)"
+    "body": "The commit hash was: _$4_.\n\n$(perl -pe 's/\n/\\n/g' "$1")"
 }
 EOF


### PR DESCRIPTION
#749 にGithub Issueを作る機能を追加する。
shell scriptが動くのは確認しているが、Github Actions側の変数回り(` ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }}`)は
https://help.github.com/ja/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#example-calling-the-rest-api
を見ただけなので確証はない。