### PR TITLE
fix(wide-io): wchar_t型がUnicodeであるとは限らないため避ける。また描画側についての記述を追記

### DIFF
--- a/reference/iostream/cout.md
+++ b/reference/iostream/cout.md
@@ -95,14 +95,16 @@ int main()
 
 このように求める結果を得るためのlocaleの設定は処理系によって大きく異なる。
 
-#### 端末のロケールなど
+#### 端末のロケールやフォントなど
 
-`wcout`自体はUnicodeを扱うが、結局`stdout`に出力するので、その標準出力を受け取って表示する端末のロケールやフォントなどの設定も考える必要がある。
+`wcout`を使ったとしても、結局`stdout`に出力するので、その標準出力を受け取って表示する端末のロケールやフォントなどの設定も考える必要がある。
 
 ##### Windows
-WindowsではコマンドプロンプトのデフォルトのロケールがUTF-8(65001)ではない事が多い(日本語利用者なら932になっている事が多い)ため、そのロケールで対応していないUnicodeコードポイントは当然変換できないので文字化けする。
+Windowsでは`wchar_t`型といえばUTF-16でエンコードされた文字を指す。もし標準出力を受け取って表示するコンソールのロケールがUTF-8(65001)であるならばUTF-16からUTF-8への変換は一対一対応するため変換段階において問題は起きない。
 
-またWindows10 1709より前では、`chcp 65001`などでUTF-8にしたときのフォントの指定に制約があり、実質日本語を表示することは不可能だった。
+しかしながらデフォルトのロケールがUTF-8(65001)ではない事が多い(日本語利用者なら932になっている事が多い)ため、そのロケールで対応していないUnicodeコードポイントは当然変換できないので文字化けする。`chcp 65001`などでUTF-8にすることができる。
+
+こうしてUTF-8としてコンソールが文字列を受け取ったとしてもそれを正しく表示できるとは限らない。まずフォントが表示したい文字をすべて含んでいなければならない。またそうしたフォントを使えるようになっていなければならない。Windows10 1709より前では、ロケールをUTF-8にしたときのフォントの指定に制約があり、実質日本語を表示することは不可能だった。次に、🍣🍺のような色のついた絵文字を表示するためには、フォントの対応に加えて、それをDirectWriteなどを用いて描画されることが前提となる。例えばコマンドプロンプトはGDIで描画するため原理上不可能である。Microsoftが開発している[Windows Terminal](https://github.com/microsoft/terminal)ではこうした描画側の問題を克服しようとしている。
 
 ## 出典
 
@@ -114,3 +116,4 @@ WindowsではコマンドプロンプトのデフォルトのロケールがUTF-
 - [標準出力に書き込む | 株式会社きじねこ](http://www.kijineko.co.jp/tech/cppsamples/stdout.html)
 - [c++で日本語の処理（ロケール周り） 7/8追記 - nullnull7の日記](http://nullnull.hatenablog.com/entry/20120629/1340935277)
 - [std::locale constructor modifies global locale via "setlocale()" | Microsoft Connect](http://web.archive.org/web/20100328154628/http://connect.microsoft.com:80/VisualStudio/feedback/details/492128/std-locale-constructor-modifies-global-locale-via-setlocale)
+- [ASCII.jp：Windows 10に“まとも”に使えるコンソール「WindowsTerminal」が登場する (2/2)](https://ascii.jp/elem/000/001/868/1868623/2/)

--- a/reference/iostream/cout.md
+++ b/reference/iostream/cout.md
@@ -64,15 +64,11 @@ int main()
 
 のようにして設定しないと何も表示されない。
 
-`std::locale("")`とすると本来はOSに設定されたロケールが設定されるはずが、MinGWやLinux環境で実行すると、"C"ロケールになってしまう問題がある。
-
-また、上記プログラムで`std::locale("ja")`の行のコメントアウトを外してを実行すると、以下のようなエラーが出力されてしまう。
+`std::locale("")`とすると本来はOSに設定されたロケールが設定されるはずが、MinGW環境でコンパイルし実行すると、以下のようなエラーが出力されてしまう。
 
 ```
 terminate called after throwing an instance of 'std::runtime_error'
   what():  locale::facet::_S_create_c_locale name not valid
-
-Aborted
 ```
 
 一方、以下のようなコードなら求める結果が得られる処理系もある。


### PR DESCRIPTION
- wchar_t型がUnicodeであるとは限らないため、「`wcout`自体はUnicodeを扱うが」という表現を避ける。
- 描画側について整理
- Windows Terminalが正式リリースではないものの[Microsoft Store](https://www.microsoft.com/ja-jp/p/windows-terminal-preview/9n0dx20hk701?ranMID=24542&ranEAID=TnL5HPStwNw&ranSiteID=TnL5HPStwNw-UDWMLG8.vwB2U4dqg2Flhw&epi=TnL5HPStwNw-UDWMLG8.vwB2U4dqg2Flhw&irgwc=1&OCID=AID681541_aff_7593_1243925&tduid=%28ir__zlyl9dwgqkkfr3dlkk0sohzx0m2xj1uvbfrd6e0v00%29%287593%29%281243925%29%28TnL5HPStwNw-UDWMLG8.vwB2U4dqg2Flhw%29%28%29&irclickid=_zlyl9dwgqkkfr3dlkk0sohzx0m2xj1uvbfrd6e0v00&activetab=pivot%3Aoverviewtab)で公開されて暫く経つため言及
- deef1b095e731268ac4af26099f15be3c0de000b で書いたCロケールになるバグの出典が探せない上に再現できないので除去
- MinGW環境での`locale::facet::_S_create_c_locale name not valid`は`std::locale("")`でも発生するので修正

ref:
- #560 