### PR TITLE
fix: std::byteはaligned_storagedがdeprecatedになったこともあり、利用が増えると思われる

### DIFF
--- a/GLOBAL_QUALIFY_LIST.txt
+++ b/GLOBAL_QUALIFY_LIST.txt
@@ -65,6 +65,7 @@
 * <condition_variable>[link /reference/condition_variable.md]
     * std::condition_variable[link /reference/condition_variable/condition_variable.md]
 * <cstddef>[link /reference/cstddef.md]
+    * std::byte[link /reference/cstddef/byte.md]
     * std::nullptr_t[link /reference/cstddef/nullptr_t.md]
     * std::size_t[link /reference/cstddef/size_t.md]
 * <cstdint>[link /reference/cstdint.md]


### PR DESCRIPTION
ref:
- https://cpprefjp.github.io/reference/type_traits/aligned_storage.html
- #768