### PR TITLE
外部リンクチェックを週に一回チェックするようにした

### DIFF
--- a/.github/workflows/outer_link_check.yml
+++ b/.github/workflows/outer_link_check.yml
@@ -3,8 +3,8 @@ name: outer link check
 on:
   schedule:
     # UTC 表記
-    # 日本時間 23:30
-    - cron: "30 14 * * *"
+    # 日本時間 日曜23:30
+    - cron: "30 14 * * 0"
 
 jobs:
   build:


### PR DESCRIPTION
https://docs.github.com/ja/actions/reference/events-that-trigger-workflows#scheduled-events
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/crontab.html#tag_20_25_07

外部リンクチェックがときどき、相手側サーバーが落ちているのかなにかが原因でちょくちょく失敗するので、週に一回実行するようにしてみました。ほんとは「連続N日間失敗したら…」とかにするのがよさそうですが。

日曜日の23:30に実行するようにしてみたのですが、これで合ってますかね。
どなたかに確認していただきたいです。