### PR TITLE
コードブロックに抜けているcppを追加

### DIFF
--- a/reference/iterator/istream_iterator.md
+++ b/reference/iterator/istream_iterator.md
@@ -3,7 +3,7 @@
 * std[meta namespace]
 * class template[meta id-type]
 
-```
+```cpp
 namespace std {
   template <class T, class CharT = char,
             class Traits = char_traits<CharT>, class Distance = ptrdiff_t>


### PR DESCRIPTION
一応全てのファイルが最初にC++のソースコードを表示しているという前提で`grep "```" -m 1`で調べてみましたが、他は大丈夫そうです（真ん中にあるブロックは見ていませんが）。