### PR TITLE
bad_exception のサマリのtypo 方 -> 型

### DIFF
--- a/reference/exception.md
+++ b/reference/exception.md
@@ -7,7 +7,7 @@
 | 名前 | 説明 | 対応バージョン |
 |-------------------------------------------------|-----------------------------------------------|-------|
 | [`exception`](exception/exception.md)         | 標準例外の基底クラス(class) | |
-| [`bad_exception`](exception/bad_exception.md) | 関数で例外の型を制限し、指定外の方が送出された場合に発生させる(class) | |
+| [`bad_exception`](exception/bad_exception.md) | 関数で例外の型を制限し、指定外の型が送出された場合に発生させる(class) | |
 | [`nested_exception`](exception/nested_exception.md) | 例外構造をネストさせる場合に利用する例外クラス(class) | C++11 |
 | [`set_unexpected`](exception/set_unexpected.md) | 予想外の例外が発生した場合の処理を行う関数を設定する(function) | C++11から非推奨<br/> C++17で削除 |
 | [`get_unexpected`](exception/get_unexpected.md) | 予想外の例外が発生した場合の処理を行う関数を取得する(function) | C++11<br/> C++11から非推奨<br/> C++17で削除 |


### PR DESCRIPTION
飛び先の冒頭の表現に揃えます:

https://github.com/cpprefjp/site/blob/719664d66832cb1674c283967486cca5cf2d9f92/reference/exception/bad_exception.md#%E6%A6%82%E8%A6%81

> `bad_exception` クラスは、関数に対して例外の型を制限し、指定外の **型** を送出した場合に発生する例外である。

C++11以降を考えると、ここは全体をrewordした方が良いかもしれません。が、ちょっと良い表現が思いつきませんでした。。

```
関数で例外の型を制限し、指定外の型が送出された場合に発生する例外クラス(C++11以前)
または、std::current_exceptionの失敗を表現する例外クラス(C++11以降)
```