### PR TITLE
erase/erase_ifの戻り値型を修正

### DIFF
--- a/reference/deque/deque/erase_free.md
+++ b/reference/deque/deque/erase_free.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class T, class Allocator, class U>
-  void erase(deque<T, Allocator>& c, const U& value);
+  typename deque<T, Allocator>::size_type erase(deque<T, Allocator>& c, const U& value);
 }
 ```
 

--- a/reference/deque/deque/erase_if_free.md
+++ b/reference/deque/deque/erase_if_free.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class T, class Allocator, class Predicate>
-  void erase_if(deque<T, Allocator>& c, Predicate pred);
+  typename deque<T, Allocator>::size_type erase_if(deque<T, Allocator>& c, Predicate pred);
 }
 ```
 

--- a/reference/forward_list/forward_list/erase_free.md
+++ b/reference/forward_list/forward_list/erase_free.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class T, class Allocator, class U>
-  void erase(forward_list<T, Allocator>& c, const U& value);
+  typename forward_list<T, Allocator>::size_type erase(forward_list<T, Allocator>& c, const U& value);
 }
 ```
 

--- a/reference/forward_list/forward_list/erase_if_free.md
+++ b/reference/forward_list/forward_list/erase_if_free.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class T, class Allocator, class Predicate>
-  void erase_if(forward_list<T, Allocator>& c, Predicate pred);
+  typename forward_list<T, Allocator>::size_type erase_if(forward_list<T, Allocator>& c, Predicate pred);
 }
 ```
 

--- a/reference/forward_list/forward_list/erase_if_free.md
+++ b/reference/forward_list/forward_list/erase_if_free.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class T, class Allocator, class Predicate>
-  void erase_if(list<T, Allocator>& c, Predicate pred);
+  void erase_if(forward_list<T, Allocator>& c, Predicate pred);
 }
 ```
 

--- a/reference/list/list/erase_free.md
+++ b/reference/list/list/erase_free.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class T, class Allocator, class U>
-  void erase(list<T, Allocator>& c, const U& value);
+  typename list<T, Allocator>::size_type erase(list<T, Allocator>& c, const U& value);
 }
 ```
 

--- a/reference/list/list/erase_if_free.md
+++ b/reference/list/list/erase_if_free.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class T, class Allocator, class Predicate>
-  void erase_if(list<T, Allocator>& c, Predicate pred);
+  typename list<T, Allocator>::size_type erase_if(list<T, Allocator>& c, Predicate pred);
 }
 ```
 

--- a/reference/string/basic_string/erase_free.md
+++ b/reference/string/basic_string/erase_free.md
@@ -7,7 +7,8 @@
 ```cpp
 namespace std {
   template <class CharT, class Traits, class Allocator, class U>
-  void erase(basic_string<CharT, Traits, Allocator>& c, const U& value);
+  typename basic_string<CharT, Traits, Allocator>::size_type
+    erase(basic_string<CharT, Traits, Allocator>& c, const U& value);
 }
 ```
 

--- a/reference/string/basic_string/erase_if_free.md
+++ b/reference/string/basic_string/erase_if_free.md
@@ -7,7 +7,8 @@
 ```cpp
 namespace std {
   template <class CharT, class Traits, class Allocator, class Predicate>
-  void erase_if(basic_string<CharT, Traits, Allocator>& c, Predicate pred);
+  typename basic_string<CharT, Traits, Allocator>::size_type
+    erase_if(basic_string<CharT, Traits, Allocator>& c, Predicate pred);
 }
 ```
 

--- a/reference/vector/vector/erase_free.md
+++ b/reference/vector/vector/erase_free.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class T, class Allocator, class U>
-  void erase(vector<T, Allocator>& c, const U& value);
+  typename vector<T, Allocator>::size_type erase(vector<T, Allocator>& c, const U& value);
 }
 ```
 

--- a/reference/vector/vector/erase_if_free.md
+++ b/reference/vector/vector/erase_if_free.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class T, class Allocator, class Predicate>
-  void erase_if(vector<T, Allocator>& c, Predicate pred);
+  typename vector<T, Allocator>::size_type erase_if(vector<T, Allocator>& c, Predicate pred);
 }
 ```
 


### PR DESCRIPTION
https://twitter.com/uchan_nos/status/1328232995568963584

`map` 用の `std::erase_if` の変更などを見る限り， 4940a0396f240235951c227aec58ec85e1d12f0b での変更漏れと思われる

ついでに `forward_list` 用の `std::erase_if` の引数が `list` になっていたので修正