### PR TITLE
typoの修正と文面の追加

### DIFF
--- a/lang/cpp20.md
+++ b/lang/cpp20.md
@@ -336,7 +336,7 @@ C++20とは、2020年中に改訂される予定の、C++バージョンの通�
     - [`max_size()`](/reference/memory/allocator/max_size.md)メンバ関数
     - [`construct()`](/reference/memory/allocator/construct.md)メンバ関数
     - [`destroy()`](/reference/memory/allocator/destroy.md)メンバ関数
-- C++11で[`allocator_traits`](/reference/memory/allocator_traits.md)クラスが導入されたことでC++17から非推奨化されていた、要素型を再束縛するための`allocator<void>`特殊化を非推奨化
+- C++11で[`allocator_traits`](/reference/memory/allocator_traits.md)クラスが導入されたことでC++17から非推奨化されていた、要素型を再束縛するための`allocator<void>`特殊化を削除
 - C++17で非推奨化されていた、`constexpr`で扱える型の分類である[`is_literal_type`](/reference/type_traits/is_literal_type.md)型特性を削除
 - C++17で非推奨化されていた、一時的なメモリ確保のための[`std::get_temporary_buffer()`](/reference/memory/get_temporary_buffer.md)関数と[`std::return_temporary_buffer()`](/reference/memory/return_temporary_buffer.md)関数を削除
 - C++17で非推奨化されていた[`raw_storage_iterator`](/reference/memory/raw_storage_iterator.md)クラスを削除

--- a/lang/cpp20.md
+++ b/lang/cpp20.md
@@ -344,7 +344,7 @@ C++20とは、2020年中に改訂される予定の、C++バージョンの通�
     - [`not1()`](/reference/functional/negators.md)関数
     - [`not2()`](/reference/functional/negators.md)関数
     - [`unary_negate`](/reference/functional/negators.md)クラス
-    - [`binary_nagate`](/reference/functional/negators.md)クラス
+    - [`binary_negate`](/reference/functional/negators.md)クラス
     - 標準関数オブジェクトの`result_type`、`argument_type`、`first_argument_type`、`second_argument_type`型
 - C++17から非推奨化されていた[`shared_ptr`](/reference/memory/shared_ptr.md)`::`[`unique()`](/reference/memory/shared_ptr/unique.md)を削除
 - [`invoke_result`](/reference/type_traits/invoke_result.md)の追加にともない、C++17から非推奨化されていた[`result_of`](/reference/type_traits/result_of.md)を削除

--- a/lang/cpp20.md
+++ b/lang/cpp20.md
@@ -314,7 +314,7 @@ C++20とは、2020年中に改訂される予定の、C++バージョンの通�
 
 
 ### 機能の非推奨化
-- 一貫比較非機能によって比較演算子の定義が容易になったため、不要になった演算子の簡潔定義機能である[`std::rel_ops`](/reference/utility/rel_ops.md)を非推奨化
+- 一貫比較機能によって比較演算子の定義が容易になったため、不要になった演算子の簡潔定義機能である[`std::rel_ops`](/reference/utility/rel_ops.md)を非推奨化
 - [`std::basic_string`](/reference/string/basic_string.md)`::`[`reserve()`](/reference/string/basic_string/reserve.md)メンバ関数が、メモリの縮小をしなくなったため、デフォルト引数`0`を非推奨可
 - [`std::atomic`](/reference/atomic/atomic.md)クラスと[`std::atomic_flag`](/reference/atomic/atomic_flag.md)クラスのデフォルトコンストラクタが値初期化するようになったため、不要になった以下のアトミックオブジェクトの初期化機能を非推奨化：
     - [`std::atomic_init()`](/reference/atomic/atomic_init.md)関数

--- a/reference/memory/allocator_traits.md
+++ b/reference/memory/allocator_traits.md
@@ -49,7 +49,7 @@ namespace std {
 | `propagate_on_container_move_assignment` | コンテナのムーブ代入時に、アロケータオブジェクトをコピー(伝播)するか否か。<br/>`Alloc`がメンバ型`propagate_on_container_move_assignment`を持っていればそれを使用し、そうでなければ[`false_type`](/reference/type_traits/false_type.md)を使用する。 | C++11 |
 | `propagate_on_container_swap` | コンテナの交換時に、アロケータオブジェクトをコピー(伝播)するか否か。<br/>`Alloc`がメンバ型`propagate_on_container_swap`を持っていればそれを使用し、そうでなければ[`false_type`](/reference/type_traits/false_type.md)を使用する。 | C++11 |
 | `is_always_equal` | `Alloc::is_always_equal`が存在する場合は`Alloc::is_always_equal`。それ以外の場合は`is_empty<Alloc>::type`。 | C++17 |
-| `rebind_alloc<U>` | 型`U`を確保するようにアロケータ型を再束縛する。<br/> `Alloc::rebind<U>::other`が有効ならそれを使用し、そうでなければ`Alloc<U, Args>`を使用する。`Alloc`がクラステンプレートでない場合、`rebind_alloc`の使用は不適格となる。 | C++11 |
+| `rebind_alloc<U>` | 型`U`を確保するようにアロケータ型を再束縛する。<br/> `Alloc::rebind<U>::other`が有効ならそれを使用し、そうでなければ`Alloc<U, Args>`を使用する(ここで、`Args`は0個以上の型引数で、`Alloc`が`Alloc<T, Args>`だった際の`Args`である)。`Alloc`がクラステンプレートでない場合、`rebind_alloc`の使用は不適格となる。 | C++11 |
 | `rebind_traits<U>` | 再束縛した型`U`に対する`allocator_traits`。`allocator_traits<rebind_alloc<U>>` | C++11 |
 
 

--- a/reference/memory/allocator_traits.md
+++ b/reference/memory/allocator_traits.md
@@ -49,7 +49,7 @@ namespace std {
 | `propagate_on_container_move_assignment` | コンテナのムーブ代入時に、アロケータオブジェクトをコピー(伝播)するか否か。<br/>`Alloc`がメンバ型`propagate_on_container_move_assignment`を持っていればそれを使用し、そうでなければ[`false_type`](/reference/type_traits/false_type.md)を使用する。 | C++11 |
 | `propagate_on_container_swap` | コンテナの交換時に、アロケータオブジェクトをコピー(伝播)するか否か。<br/>`Alloc`がメンバ型`propagate_on_container_swap`を持っていればそれを使用し、そうでなければ[`false_type`](/reference/type_traits/false_type.md)を使用する。 | C++11 |
 | `is_always_equal` | `Alloc::is_always_equal`が存在する場合は`Alloc::is_always_equal`。それ以外の場合は`is_empty<Alloc>::type`。 | C++17 |
-| `rebind_alloc<U>` | 型`U`を確保するようにアロケータ型を再束縛する。<br/> `Alloc::rebind<U>::other`が有効ならそれを使用し、そうでなければ`Alloc<U, Args`>を使用する。`Alloc`がクラステンプレートでない場合、`rebind_alloc`の使用は不適格となる。 | C++11 |
+| `rebind_alloc<U>` | 型`U`を確保するようにアロケータ型を再束縛する。<br/> `Alloc::rebind<U>::other`が有効ならそれを使用し、そうでなければ`Alloc<U, Args>`を使用する。`Alloc`がクラステンプレートでない場合、`rebind_alloc`の使用は不適格となる。 | C++11 |
 | `rebind_traits<U>` | 再束縛した型`U`に対する`allocator_traits`。`allocator_traits<rebind_alloc<U>>` | C++11 |
 
 


### PR DESCRIPTION
@wx257osn2  複数の問題を解決するPRを作るな

- C++20の言語機能のページのtypoを3件修正
- `allocator_traits` のコードハイライトの範囲を修正
- `allocator_traits::rebind_alloc` の `Args` についての説明を追加