### PR TITLE
static_assertのメッセージにあるtypoの修正

### DIFF
--- a/reference/type_traits/is_abstract.md
+++ b/reference/type_traits/is_abstract.md
@@ -52,7 +52,7 @@ static_assert(std::is_same<std::is_abstract<non_abstract_class>::type, std::fals
 static_assert(std::is_abstract<non_abstract_class>() == false, "is_abstract<non_abstract_class>() == false");
 
 static_assert(std::is_abstract<const volatile abstract_class>::value == true, "value == true, const volatile abstract_class is abstract");
-static_assert(std::is_abstract<abstract_class&>::value == false, "value == true, abstract_class& is not abstract");
+static_assert(std::is_abstract<abstract_class&>::value == false, "value == false, abstract_class& is not abstract");
 
 int main(){}
 ```

--- a/reference/type_traits/is_abstract.md
+++ b/reference/type_traits/is_abstract.md
@@ -51,8 +51,8 @@ static_assert(std::is_same<std::is_abstract<non_abstract_class>::value_type, boo
 static_assert(std::is_same<std::is_abstract<non_abstract_class>::type, std::false_type>::value, "type == false_type");
 static_assert(std::is_abstract<non_abstract_class>() == false, "is_abstract<non_abstract_class>() == false");
 
-static_assert(std::is_abstract<const volatile abstract_class>::value == true, "value == true, const volatile abstract_class is abstract");
-static_assert(std::is_abstract<abstract_class&>::value == false, "value == false, abstract_class& is not abstract");
+static_assert(std::is_abstract<const volatile abstract_class>::value == true, "const volatile abstract_class is abstract");
+static_assert(std::is_abstract<abstract_class&>::value == false, "abstract_class& is not abstract");
 
 int main(){}
 ```

--- a/reference/type_traits/is_const.md
+++ b/reference/type_traits/is_const.md
@@ -41,7 +41,7 @@ static_assert(std::is_same<std::is_const<int>::type, std::false_type>::value, "t
 static_assert(std::is_const<int>() == false, "is_const<int>() == false");
 
 static_assert(std::is_const<const volatile int>::value == true, "value == true, const volatile int is const-qualified");
-static_assert(std::is_const<const int&>::value == false, "value == true, const int& is not const-qualified");
+static_assert(std::is_const<const int&>::value == false, "value == false, const int& is not const-qualified");
 
 int main(){}
 ```

--- a/reference/type_traits/is_const.md
+++ b/reference/type_traits/is_const.md
@@ -40,8 +40,8 @@ static_assert(std::is_same<std::is_const<int>::value_type, bool>::value, "value_
 static_assert(std::is_same<std::is_const<int>::type, std::false_type>::value, "type == false_type");
 static_assert(std::is_const<int>() == false, "is_const<int>() == false");
 
-static_assert(std::is_const<const volatile int>::value == true, "value == true, const volatile int is const-qualified");
-static_assert(std::is_const<const int&>::value == false, "value == false, const int& is not const-qualified");
+static_assert(std::is_const<const volatile int>::value == true, "const volatile int is const-qualified");
+static_assert(std::is_const<const int&>::value == false, "const int& is not const-qualified");
 
 int main(){}
 ```

--- a/reference/type_traits/is_empty.md
+++ b/reference/type_traits/is_empty.md
@@ -61,7 +61,7 @@ static_assert(std::is_same<std::is_empty<non_empty_class>::type, std::false_type
 static_assert(std::is_empty<non_empty_class>() == false, "is_empty<non_empty_class>() == false");
 
 static_assert(std::is_empty<const volatile empty_class>::value == true, "value == true, const volatile empty_class is empty");
-static_assert(std::is_empty<empty_class&>::value == false, "value == true, empty_class& is not empty");
+static_assert(std::is_empty<empty_class&>::value == false, "value == false, empty_class& is not empty");
 
 int main(){}
 ```

--- a/reference/type_traits/is_empty.md
+++ b/reference/type_traits/is_empty.md
@@ -60,8 +60,8 @@ static_assert(std::is_same<std::is_empty<non_empty_class>::value_type, bool>::va
 static_assert(std::is_same<std::is_empty<non_empty_class>::type, std::false_type>::value, "type == false_type");
 static_assert(std::is_empty<non_empty_class>() == false, "is_empty<non_empty_class>() == false");
 
-static_assert(std::is_empty<const volatile empty_class>::value == true, "value == true, const volatile empty_class is empty");
-static_assert(std::is_empty<empty_class&>::value == false, "value == false, empty_class& is not empty");
+static_assert(std::is_empty<const volatile empty_class>::value == true, "const volatile empty_class is empty");
+static_assert(std::is_empty<empty_class&>::value == false, "empty_class& is not empty");
 
 int main(){}
 ```

--- a/reference/type_traits/is_pod.md
+++ b/reference/type_traits/is_pod.md
@@ -54,14 +54,14 @@ static_assert(std::is_same<std::is_pod<int&>::type, std::false_type>::value, "ty
 static_assert(std::is_pod<int&>() == false, "is_pod<int&>() == false");
 
 static_assert(std::is_pod<const volatile int>::value == true, "value == true, const volatile int is POD");
-static_assert(std::is_pod<int&>::value == false, "value == true, int& is not POD");
+static_assert(std::is_pod<int&>::value == false, "value == false, int& is not POD");
 
 struct POD_struct{};
 struct non_POD_struct {
   non_POD_struct() {}    // デフォルトコンストラクタが非トリビアル
 };
 static_assert(std::is_pod<POD_struct>::value == true, "value == true, POD_struct is POD");
-static_assert(std::is_pod<non_POD_struct>::value == false, "value == true, non_POD_struct is not POD");
+static_assert(std::is_pod<non_POD_struct>::value == false, "value == false, non_POD_struct is not POD");
 
 int main(){}
 ```

--- a/reference/type_traits/is_pod.md
+++ b/reference/type_traits/is_pod.md
@@ -53,15 +53,15 @@ static_assert(std::is_same<std::is_pod<int&>::value_type, bool>::value, "value_t
 static_assert(std::is_same<std::is_pod<int&>::type, std::false_type>::value, "type == false_type");
 static_assert(std::is_pod<int&>() == false, "is_pod<int&>() == false");
 
-static_assert(std::is_pod<const volatile int>::value == true, "value == true, const volatile int is POD");
-static_assert(std::is_pod<int&>::value == false, "value == false, int& is not POD");
+static_assert(std::is_pod<const volatile int>::value == true, "const volatile int is POD");
+static_assert(std::is_pod<int&>::value == false, "int& is not POD");
 
 struct POD_struct{};
 struct non_POD_struct {
   non_POD_struct() {}    // デフォルトコンストラクタが非トリビアル
 };
-static_assert(std::is_pod<POD_struct>::value == true, "value == true, POD_struct is POD");
-static_assert(std::is_pod<non_POD_struct>::value == false, "value == false, non_POD_struct is not POD");
+static_assert(std::is_pod<POD_struct>::value == true, "POD_struct is POD");
+static_assert(std::is_pod<non_POD_struct>::value == false, "non_POD_struct is not POD");
 
 int main(){}
 ```

--- a/reference/type_traits/is_polymorphic.md
+++ b/reference/type_traits/is_polymorphic.md
@@ -49,8 +49,8 @@ static_assert(std::is_same<std::is_polymorphic<non_polymorphic_class>::value_typ
 static_assert(std::is_same<std::is_polymorphic<non_polymorphic_class>::type, std::false_type>::value, "type == false_type");
 static_assert(std::is_polymorphic<non_polymorphic_class>() == false, "is_polymorphic<non_polymorphic_class>() == false");
 
-static_assert(std::is_polymorphic<const volatile polymorphic_class>::value == true, "value == true, const volatile polymorphic_class is polymorphic");
-static_assert(std::is_polymorphic<polymorphic_class&>::value == false, "value == false, polymorphic_class& is not polymorphic");
+static_assert(std::is_polymorphic<const volatile polymorphic_class>::value == true, "const volatile polymorphic_class is polymorphic");
+static_assert(std::is_polymorphic<polymorphic_class&>::value == false, "polymorphic_class& is not polymorphic");
 
 int main(){}
 ```

--- a/reference/type_traits/is_polymorphic.md
+++ b/reference/type_traits/is_polymorphic.md
@@ -50,7 +50,7 @@ static_assert(std::is_same<std::is_polymorphic<non_polymorphic_class>::type, std
 static_assert(std::is_polymorphic<non_polymorphic_class>() == false, "is_polymorphic<non_polymorphic_class>() == false");
 
 static_assert(std::is_polymorphic<const volatile polymorphic_class>::value == true, "value == true, const volatile polymorphic_class is polymorphic");
-static_assert(std::is_polymorphic<polymorphic_class&>::value == false, "value == true, polymorphic_class& is not polymorphic");
+static_assert(std::is_polymorphic<polymorphic_class&>::value == false, "value == false, polymorphic_class& is not polymorphic");
 
 int main(){}
 ```

--- a/reference/type_traits/is_signed.md
+++ b/reference/type_traits/is_signed.md
@@ -42,12 +42,12 @@ static_assert(std::is_same<std::is_signed<unsigned int>::value_type, bool>::valu
 static_assert(std::is_same<std::is_signed<unsigned int>::type, std::false_type>::value, "type == false_type");
 static_assert(std::is_signed<unsigned int>() == false, "is_signed<unsigned int>() == false");
 
-static_assert(std::is_signed<const volatile int>::value == true, "value == true, const volatile int is signed");
-static_assert(std::is_signed<int&>::value == false, "value == false, int& is not signed");
+static_assert(std::is_signed<const volatile int>::value == true, "const volatile int is signed");
+static_assert(std::is_signed<int&>::value == false, "int& is not signed");
 
 class c{};
-static_assert(std::is_signed<float>::value == true, "value == true, float is signed");
-static_assert(std::is_signed<c>::value == false, "value == false, class is not signed");
+static_assert(std::is_signed<float>::value == true, "float is signed");
+static_assert(std::is_signed<c>::value == false, "class is not signed");
 
 int main(){}
 ```

--- a/reference/type_traits/is_signed.md
+++ b/reference/type_traits/is_signed.md
@@ -43,11 +43,11 @@ static_assert(std::is_same<std::is_signed<unsigned int>::type, std::false_type>:
 static_assert(std::is_signed<unsigned int>() == false, "is_signed<unsigned int>() == false");
 
 static_assert(std::is_signed<const volatile int>::value == true, "value == true, const volatile int is signed");
-static_assert(std::is_signed<int&>::value == false, "value == true, int& is not signed");
+static_assert(std::is_signed<int&>::value == false, "value == false, int& is not signed");
 
 class c{};
 static_assert(std::is_signed<float>::value == true, "value == true, float is signed");
-static_assert(std::is_signed<c>::value == false, "value == true, class is not signed");
+static_assert(std::is_signed<c>::value == false, "value == false, class is not signed");
 
 int main(){}
 ```

--- a/reference/type_traits/is_trivial.md
+++ b/reference/type_traits/is_trivial.md
@@ -45,7 +45,7 @@ static_assert(std::is_same<std::is_trivial<int&>::type, std::false_type>::value,
 static_assert(std::is_trivial<int&>() == false, "is_trivial<int&>() == false");
 
 static_assert(std::is_trivial<const volatile int>::value == true, "value == true, const volatile int is trivial");
-static_assert(std::is_trivial<int&>::value == false, "value == true, int& is not trivial");
+static_assert(std::is_trivial<int&>::value == false, "value == false, int& is not trivial");
 
 class trivial_class{};
 struct non_trivial_class {
@@ -53,8 +53,8 @@ struct non_trivial_class {
 };
 static_assert(std::is_trivial<trivial_class>::value == true, "value == true, trivial_class is trivial");
 static_assert(std::is_trivial<trivial_class&>::value == true, "value == true, trivial_class& is trivial");
-static_assert(std::is_trivial<non_trivial_class>::value == false, "value == true, non_trivial_class is not trivial");
-static_assert(std::is_trivial<non_trivial_class&>::value == false, "value == true, non_trivial_class& is not trivial");
+static_assert(std::is_trivial<non_trivial_class>::value == false, "value == false, non_trivial_class is not trivial");
+static_assert(std::is_trivial<non_trivial_class&>::value == false, "value == false, non_trivial_class& is not trivial");
 
 int main(){}
 ```

--- a/reference/type_traits/is_trivial.md
+++ b/reference/type_traits/is_trivial.md
@@ -44,17 +44,17 @@ static_assert(std::is_same<std::is_trivial<int&>::value_type, bool>::value, "val
 static_assert(std::is_same<std::is_trivial<int&>::type, std::false_type>::value, "type == false_type");
 static_assert(std::is_trivial<int&>() == false, "is_trivial<int&>() == false");
 
-static_assert(std::is_trivial<const volatile int>::value == true, "value == true, const volatile int is trivial");
-static_assert(std::is_trivial<int&>::value == false, "value == false, int& is not trivial");
+static_assert(std::is_trivial<const volatile int>::value == true, "const volatile int is trivial");
+static_assert(std::is_trivial<int&>::value == false, "int& is not trivial");
 
 class trivial_class{};
 struct non_trivial_class {
   non_trivial_class() {}    // デフォルトコンストラクタが非トリビアル
 };
-static_assert(std::is_trivial<trivial_class>::value == true, "value == true, trivial_class is trivial");
-static_assert(std::is_trivial<trivial_class&>::value == true, "value == true, trivial_class& is trivial");
-static_assert(std::is_trivial<non_trivial_class>::value == false, "value == false, non_trivial_class is not trivial");
-static_assert(std::is_trivial<non_trivial_class&>::value == false, "value == false, non_trivial_class& is not trivial");
+static_assert(std::is_trivial<trivial_class>::value == true, "trivial_class is trivial");
+static_assert(std::is_trivial<trivial_class&>::value == true, "trivial_class& is trivial");
+static_assert(std::is_trivial<non_trivial_class>::value == false, "non_trivial_class is not trivial");
+static_assert(std::is_trivial<non_trivial_class&>::value == false, "non_trivial_class& is not trivial");
 
 int main(){}
 ```

--- a/reference/type_traits/is_unsigned.md
+++ b/reference/type_traits/is_unsigned.md
@@ -42,12 +42,12 @@ static_assert(std::is_same<std::is_unsigned<int>::value_type, bool>::value, "val
 static_assert(std::is_same<std::is_unsigned<int>::type, std::false_type>::value, "type == false_type");
 static_assert(std::is_unsigned<int>() == false, "is_unsigned<int>() == false");
 
-static_assert(std::is_unsigned<const volatile unsigned int>::value == true, "value == true, const volatile unsigned int is unsigned");
-static_assert(std::is_unsigned<unsigned int&>::value == false, "value == false, unsigned int& is not unsigned");
+static_assert(std::is_unsigned<const volatile unsigned int>::value == true, "const volatile unsigned int is unsigned");
+static_assert(std::is_unsigned<unsigned int&>::value == false, "unsigned int& is not unsigned");
 
 class c{};
-static_assert(std::is_unsigned<float>::value == false, "value == false, float is not unsigned");
-static_assert(std::is_unsigned<c>::value == false, "value == false, class is not unsigned");
+static_assert(std::is_unsigned<float>::value == false, "float is not unsigned");
+static_assert(std::is_unsigned<c>::value == false, "class is not unsigned");
 
 int main(){}
 ```

--- a/reference/type_traits/is_unsigned.md
+++ b/reference/type_traits/is_unsigned.md
@@ -43,11 +43,11 @@ static_assert(std::is_same<std::is_unsigned<int>::type, std::false_type>::value,
 static_assert(std::is_unsigned<int>() == false, "is_unsigned<int>() == false");
 
 static_assert(std::is_unsigned<const volatile unsigned int>::value == true, "value == true, const volatile unsigned int is unsigned");
-static_assert(std::is_unsigned<unsigned int&>::value == false, "value == true, unsigned int& is not unsigned");
+static_assert(std::is_unsigned<unsigned int&>::value == false, "value == false, unsigned int& is not unsigned");
 
 class c{};
-static_assert(std::is_unsigned<float>::value == false, "value == true, float is not unsigned");
-static_assert(std::is_unsigned<c>::value == false, "value == true, class is not unsigned");
+static_assert(std::is_unsigned<float>::value == false, "value == false, float is not unsigned");
+static_assert(std::is_unsigned<c>::value == false, "value == false, class is not unsigned");
 
 int main(){}
 ```

--- a/reference/type_traits/is_volatile.md
+++ b/reference/type_traits/is_volatile.md
@@ -41,7 +41,7 @@ static_assert(std::is_same<std::is_volatile<int>::type, std::false_type>::value,
 static_assert(std::is_volatile<int>() == false, "is_volatile<int>() == false");
 
 static_assert(std::is_volatile<const volatile int>::value == true, "value == true, const volatile int is volatile-qualified");
-static_assert(std::is_volatile<volatile int&>::value == false, "value == true, volatile int& is not volatile-qualified");
+static_assert(std::is_volatile<volatile int&>::value == false, "value == false, volatile int& is not volatile-qualified");
 
 int main(){}
 ```

--- a/reference/type_traits/is_volatile.md
+++ b/reference/type_traits/is_volatile.md
@@ -40,8 +40,8 @@ static_assert(std::is_same<std::is_volatile<int>::value_type, bool>::value, "val
 static_assert(std::is_same<std::is_volatile<int>::type, std::false_type>::value, "type == false_type");
 static_assert(std::is_volatile<int>() == false, "is_volatile<int>() == false");
 
-static_assert(std::is_volatile<const volatile int>::value == true, "value == true, const volatile int is volatile-qualified");
-static_assert(std::is_volatile<volatile int&>::value == false, "value == false, volatile int& is not volatile-qualified");
+static_assert(std::is_volatile<const volatile int>::value == true, "const volatile int is volatile-qualified");
+static_assert(std::is_volatile<volatile int&>::value == false, "volatile int& is not volatile-qualified");
 
 int main(){}
 ```


### PR DESCRIPTION
気づいたので直しましたが、この部分には`value == (true|false)`を含まないようにしているページもあるようなので、単に消すだけでも良かったかもしれません。