### PR TITLE
Fixed mistakes in ifstream and ofstream base class

### DIFF
--- a/reference/fstream/basic_ifstream.md
+++ b/reference/fstream/basic_ifstream.md
@@ -6,7 +6,7 @@
 ```cpp
 namespace std {
   template <class CharT, class Traits = char_traits<CharT>>
-  class basic_ifstream : public basic_iostream<CharT, Traits>;
+  class basic_ifstream : public basic_istream<CharT, Traits>;
 
   using ifstream  = basic_ifstream<char>;
   using wifstream = basic_ifstream<wchar_t>;

--- a/reference/fstream/basic_ofstream.md
+++ b/reference/fstream/basic_ofstream.md
@@ -6,7 +6,7 @@
 ```cpp
 namespace std {
   template <class CharT, class Traits = char_traits<CharT>>
-  class basic_ofstream : public basic_iostream<CharT, Traits>;
+  class basic_ofstream : public basic_ostream<CharT, Traits>;
 
   using ofstream  = basic_ofstream<char>;
   using wofstream = basic_ofstream<wchar_t>;


### PR DESCRIPTION
basic_ifstream と basic_ofstream の基本クラスを修正しました。
修正前
class basic_ifstream : public basic_iostream<charT,traits> {
class basic_ofstream : public basic_iostream<charT,traits> {

修正後
class basic_ifstream : public basic_istream<charT,traits> {
class basic_ofstream : public basic_ostream<charT,traits> {

C++11
27.9.1.6 Class template basic_ifstream
namespace std {
template <class charT, class traits = char_traits<charT> >
class basic_ifstream : public basic_istream<charT,traits> {
    ...
};
27.9.1.10 Class template basic_ofstream [ofstream]
namespace std {
template <class charT, class traits = char_traits<charT> >
class basic_ofstream : public basic_ostream<charT,traits> {
    ...
};

C++14
27.9.1.6 Class template basic_ifstream
namespace std {
template <class charT, class traits = char_traits<charT> >
class basic_ifstream : public basic_istream<charT,traits> {
    ...
};

C++20
29.9.3 Class template basic_ifstream
namespace std {
template<class charT, class traits = char_traits<charT>>
class basic_ifstream : public basic_istream<charT, traits> {
    ...
};
