### PR TITLE
std::ends の実装例の誤記 endl を ends に修正

### DIFF
--- a/reference/ostream/ends.md
+++ b/reference/ostream/ends.md
@@ -26,7 +26,7 @@ namespace std {
 ```cpp
 namespace std {
   template<class CharT, class Traits>
-  basic_ostream<CharT, Traits>& endl(basic_ostream<CharT, Traits>& os) {
+  basic_ostream<CharT, Traits>& ends(basic_ostream<CharT, Traits>& os) {
     return os.put(CharT());
   }
 }


### PR DESCRIPTION
初めまして。
KodaiYMと申します。いつもこちらのサイトでお世話になってます。

std::ends のページの実装例で、関数名が「endl」と誤記されていて気になったので、
(pull request の練習も兼ねて)ends に修正しました。

よろしくお願いします。
