### PR TITLE
Fixed typo msvc version (暗黙のラムダキャプチャを簡略化)

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -179,7 +179,7 @@
 | [指示付き初期化](/lang/cpp20/designated_initialization.md) | | 8 | 6.0 (partial) | | 2019 Update 1 |
 | [コンセプト](/lang/cpp20/concepts.md) | テンプレートパラメータに対する制約を行う | 10 | 10.0 (partial) | | 2019 Update 3 |
 | [初期化式をともなう範囲for文](/lang/cpp20/range-based_for_statements_with_initializer.md) | 範囲for文スコープで使用する変数の初期化のための構文を追加 | 9 | 8.0 | | 2019 Update 5 |
-| [暗黙のラムダキャプチャを簡略化](/lang/cpp20/simplifying_implicit_lambda_capture.md.nolink) | | 8 | | | 2019 Update 4 |
+| [暗黙のラムダキャプチャを簡略化](/lang/cpp20/simplifying_implicit_lambda_capture.md.nolink) | | 8 | | | 2019 Update 2 |
 | [関数テンプレートに明示的に型指定した場合にADLで見つからない問題を修正](/lang/cpp20/adl_and_function_templates_that_are_not_visible.md) | 名前空間内の関数テンプレートをテンプレート引数指定かつ非修飾・ADLで正しく呼び出せるよう修正 | 9 | 9.0 | | 2019 Update 1 |
 | [デフォルトのコピーコンストラクタと非`const`なコンストラクタが衝突する問題を修正](/lang/cpp20/resolving_const_mismatch_with_defaulted_copy_constructor.md.nolink) | | 9 | 8.0 | | partial |
 | [積極的でない`constexpr`関数のインスタンス化](/lang/cpp20/less_eager_instantiation_of_constexpr_functions.md.nolink) | | 9 | | | |


### PR DESCRIPTION
typoかと思われる項目ありましたのでPR出します〜

「暗黙のラムダキャプチャを簡素化」の項目のMSVCの対応バージョンのtypo

参考：https://docs.microsoft.com/ja-jp/cpp/overview/visual-cpp-language-conformance?view=msvc-160
P0409R2 Allowing lambda-capture [=, this] | VS 2019 16.2 20
