### PR TITLE
concepts: 例示コードの型のtypoを修正

### DIFF
--- a/lang/cpp20/concepts.md
+++ b/lang/cpp20/concepts.md
@@ -884,7 +884,7 @@ int main() {
 
     // 以下と同じ
     // template <class T, class U>
-    // auto f(T a, T b) { return a + b; }
+    // auto f(T a, U b) { return a + b; }
 
     f(1, 2);     // パラメータaとbの型はint
     f(0.1, 0.2); // パラメータaとbの型はdouble


### PR DESCRIPTION
autoパラメータの説明の例示コードについて、コメント中の `f` の第2引数の `T` は `U` の誤記だと思います。