### PR TITLE
from_charsのエラーケースでの戻り値の説明を修正

### DIFF
--- a/reference/charconv/from_chars.md
+++ b/reference/charconv/from_chars.md
@@ -68,11 +68,12 @@ C++標準はこれら関数の実装の詳細について何も規定しない�
 - 成功した場合
     - `ptr` : 指定されたパターンに一致しなかった最初の文字の位置。全てが一致した場合は`ptr == last`
     - `ec` : `ec == errc{}`
-- 失敗した場合
+- パターンにマッチする文字列が見つからない場合
     - `ptr` : `ptr == first`
-    - `ec` : 
-        - パターンにマッチする文字列が見つからない場合、`ec == ` [`errc::invalid_argument`](/reference/system_error/errc.md)
-        - 変換した結果の値が`value`の型では表現できない場合、`ec == ` [`errc::result_out_of_range`](/reference/system_error/errc.md)
+    - `ec` : `ec == ` [`errc::invalid_argument`](/reference/system_error/errc.md)
+- 変換した結果の値が`value`の型では表現できない場合
+    - `ptr` : 指定されたパターンに一致しなかった最初の文字の位置
+    - `ec` : `ec == ` [`errc::result_out_of_range`](/reference/system_error/errc.md)
 
 ## 例外
 投げない。


### PR DESCRIPTION
`from_chars()` の戻り値の説明に、失敗した場合は `ptr == first` になると書かれています。
`ec` が `errc::invalid_argument` になるケースではそうなりますが、 `ec` が `errc::result_out_of_range` になるケースでは `ptr` は `first` と異なる値になるのが正しいと思ったのでpull requestを作成します。

説明の場合分けを次の3つに分けるように変更してみましたがいかがでしょうか。

* 成功した場合
* パターンにマッチする文字列が見つからない場合
* 変換した結果の値がvalueの型では表現できない場合

動作確認用コードとGCC8での実行結果も示しておきます。

```c++
#include <charconv>
#include <iostream>
#include <iterator>
#include <system_error>

int main()
{
  const char s[] = "012345678901234567890123456789";
  const char* first = std::begin(s);
  const char* last = std::end(s);
  int v = 0;
  const auto [ptr, ec] = std::from_chars(first, last, v);
  std::cout << "v = " << v << std::endl;
  std::cout << "ptr - first = " << (ptr - first) << std::endl;
  std::cout << "ec = " << std::make_error_code(ec).message() << std::endl;
}
```

```
v = 0
ptr - first = 30
ec = Numerical result out of range
```

参考: https://timsong-cpp.github.io/cppwp/charconv.from.chars
