### PR TITLE
common_iteratorの説明にでてくる _v を v_ に変更

### DIFF
--- a/reference/iterator/common_iterator/op_arrow.md
+++ b/reference/iterator/common_iterator/op_arrow.md
@@ -34,9 +34,9 @@ indirectly_readable<const I> &&
 
 ## 戻り値
 
-`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`_v`に保持しているとして、次のいずれか
+`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`v_`に保持しているとして、次のいずれか
 
-- `I`がポインタ型であり、`get<I>(_v).operator->()`が呼び出し可能な場合 : `return get<I>(_v);`
+- `I`がポインタ型であり、`get<I>(v_).operator->()`が呼び出し可能な場合 : `return get<I>(v_);`
 
 - [`iter_reference_t`](/reference/iterator/iter_reference_t.md)`<I>`が参照型の場合 : 以下と等価  
     ```cpp
@@ -45,7 +45,7 @@ indirectly_readable<const I> &&
     ```
     * addressof[link /reference/memory/addressof.md]
 
-- それ以外の場合 : `return proxy(*get<I>(_v));`  
+- それ以外の場合 : `return proxy(*get<I>(v_));`  
     `proxy`は次のように定義される説明専用のクラス。  
     ```cpp
     class proxy {

--- a/reference/iterator/common_iterator/op_assign.md
+++ b/reference/iterator/common_iterator/op_assign.md
@@ -24,9 +24,9 @@ common_iterator& operator=(const common_iterator<I2, S2>& x);
 
 ## 効果
 
-`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`_v`に保持しており、`i = x.v_.`[`index()`](/reference/variant/variant/index.md)として、次のどちらか
+`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`v_`に保持しており、`i = x.v_.`[`index()`](/reference/variant/variant/index.md)として、次のどちらか
 
-- `i == _v.index()`が`true`である場合 : `get<i>(v_) = get<i>(x.v_)`
+- `i == v_.index()`が`true`である場合 : `get<i>(v_) = get<i>(x.v_)`
 - それ以外の場合 : `v_.`[`emplace`](/reference/variant/variant/emplace.md)`<i>(get<i>(x.v_))`
 
 ## 戻り値

--- a/reference/iterator/common_iterator/op_constructor.md
+++ b/reference/iterator/common_iterator/op_constructor.md
@@ -30,12 +30,12 @@ constexpr common_iterator(const common_iterator<I2, S2>& x);  // (4)
 
 ## 効果
 
-`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`_v`に保持するとする。
+`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`v_`に保持するとする。
 
-- (1) : `_v`をデフォルト構築（`I`をデフォルト構築して初期化）する。
-- (2) : `v_{`[`in_place_type`](/reference/utility/in_place_type_t.md)`<I>, std::move(i)}`が行われたかのように`_v`を初期化する。
-- (3) : `v_{`[`in_place_type`](/reference/utility/in_place_type_t.md)`<S>, std::move(s)}`が行われたかのように`_v`を初期化する。
-- (4) : `i = x.v_.`[`index()`](/reference/variant/variant/index.md)として、`v_{`[`in_place_index`](/reference/utility/in_place_index_t.md)`<i>, get<i>(x.v_)}`が行われたかのように`_v`を初期化する。
+- (1) : `v_`をデフォルト構築（`I`をデフォルト構築して初期化）する。
+- (2) : `v_{`[`in_place_type`](/reference/utility/in_place_type_t.md)`<I>, std::move(i)}`が行われたかのように`v_`を初期化する。
+- (3) : `v_{`[`in_place_type`](/reference/utility/in_place_type_t.md)`<S>, std::move(s)}`が行われたかのように`v_`を初期化する。
+- (4) : `i = x.v_.`[`index()`](/reference/variant/variant/index.md)として、`v_{`[`in_place_index`](/reference/utility/in_place_index_t.md)`<i>, get<i>(x.v_)}`が行われたかのように`v_`を初期化する。
 
 ## 例
 ```cpp example

--- a/reference/iterator/common_iterator/op_deref.md
+++ b/reference/iterator/common_iterator/op_deref.md
@@ -20,7 +20,7 @@ decltype(auto) operator*() const requires dereferenceable<const I>;
 
 ## 戻り値
 
-`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`_v`に保持しているとして、以下と等価。
+`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`v_`に保持しているとして、以下と等価。
 
 `return *get<I>(v_);`
 

--- a/reference/iterator/common_iterator/op_equal.md
+++ b/reference/iterator/common_iterator/op_equal.md
@@ -33,7 +33,7 @@ namespace std {
 
 ## 戻り値
 
-`I, S`（`I2, S2`）の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`_v`に保持しており、`i = x.v_.`[`index()`](/reference/variant/variant/index.md)、`j = y.v_.`[`index()`](/reference/variant/variant/index.md)として
+`I, S`（`I2, S2`）の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`v_`に保持しており、`i = x.v_.`[`index()`](/reference/variant/variant/index.md)、`j = y.v_.`[`index()`](/reference/variant/variant/index.md)として
 
 - (1)
     - `i == j`の場合 : `true`

--- a/reference/iterator/common_iterator/op_increment.md
+++ b/reference/iterator/common_iterator/op_increment.md
@@ -19,7 +19,7 @@ decltype(auto) operator++(int);   // (2)
 
 ## 効果
 
-`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`_v`に保持しているとして
+`I, S`の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`v_`に保持しているとして
 
 - (1) : 以下と等価  
     ```cpp

--- a/reference/iterator/common_iterator/op_minus.md
+++ b/reference/iterator/common_iterator/op_minus.md
@@ -31,7 +31,7 @@ namespace std {
 
 ## 戻り値
 
-`I, S`（`I2, S2`）の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`_v`に保持しており、`i = x.v_.`[`index()`](/reference/variant/variant/index.md)、`j = y.v_.`[`index()`](/reference/variant/variant/index.md)として、次のどちらか。
+`I, S`（`I2, S2`）の値のどちらかを[`variant<I, S>`](/reference/variant/variant.md)型のメンバ変数`v_`に保持しており、`i = x.v_.`[`index()`](/reference/variant/variant/index.md)、`j = y.v_.`[`index()`](/reference/variant/variant/index.md)として、次のどちらか。
 
 - `i, j`がどちらも`1`の場合 : `0`
 - それ以外の場合 : `get<i>(x.v_) - get<j>(y.v_)`


### PR DESCRIPTION
`common_iterator`の説明の中に `_v` という変数名がいくつかでてきています。
これらはすべて `v_` が正しいのではないかと思い修正してみたのですがいかがでしょうか。