### PR TITLE
fix typo of enum name

### DIFF
--- a/reference/future/future_errc.md
+++ b/reference/future/future_errc.md
@@ -29,7 +29,7 @@ future操作に関するエラー値。
 
 | 列挙値 | 説明 | 対応バージョン |
 |-----------------------------|----------------------------|-------|
-| `broken_primise`            | 共有状態の準備ができていない | C++11 |
+| `broken_promise`            | 共有状態の準備ができていない | C++11 |
 | `future_already_retrieved`  | すでに[`promise`](promise.md)オブジェクトから[`future`](future.md)オブジェクトを取り出している | C++11 |
 | `promise_already_satisfied` | [`promise`](promise.md)オブジェクトに、すでに値もしくは例外オブジェクトが設定されている | C++11 |
 | `no_state`                  | [`promise`](promise.md)オブジェクトが共有状態を持っていない | C++11 |


### PR DESCRIPTION
broken_primise -> broken_promise