### PR TITLE
std::sortのサンプル修正

### DIFF
--- a/reference/algorithm/sort.md
+++ b/reference/algorithm/sort.md
@@ -112,11 +112,12 @@ int main()
 ```
 
 ### ユーザー定義型の配列を並べ替える (C++11)
-```cpp
+```cpp example
 #include <iostream>
 #include <vector>
 #include <string>
 #include <tuple>
+#include <algorithm>
 
 // 要素がひとつの場合
 struct MyInt {
@@ -186,6 +187,7 @@ Carol
 #include <iostream>
 #include <vector>
 #include <string>
+#include <algorithm>
 
 // 要素がひとつの場合
 struct MyInt {

--- a/reference/algorithm/sort.md
+++ b/reference/algorithm/sort.md
@@ -183,7 +183,7 @@ Carol
 
 
 ### ユーザー定義型の配列を並べ替える (C++20)
-```cpp
+```cpp example
 #include <iostream>
 #include <vector>
 #include <string>


### PR DESCRIPTION
# 修正内容

1. C++11/C++20のコード例にalgorithmヘッダを追加
2. C++11のコード例にexampleタグを追加 (C++20のコード例にはexampleタグは付与せず)

std::sortのC++11/C++20のコードサンプルを実行してみると、
コンパイルエラーとなり、ヘッダが漏れていることに気が付きました。

C++11の方はブラウザ上で実行できるかと思うので、
タグも付けておきました。