### PR TITLE
fix the direction of comparison in the example

### DIFF
--- a/reference/algorithm/max_element.md
+++ b/reference/algorithm/max_element.md
@@ -46,21 +46,28 @@ namespace std {
 
 ## 例
 ```cpp example
-#include <cassert>
 #include <algorithm>
+#include <cassert>
+#include <utility>
 #include <vector>
 
 int main()
 {
-  std::vector<int> v = {3, 1, 4};
+  // (1)
+  std::vector<int> v1 = {3, 1, 4};
 
-  decltype(v)::iterator i = std::max_element(v.begin(), v.end());
-  assert(*i == 4);
+  decltype(v1)::iterator v1_max_element = std::max_element(v1.begin(), v1.end());
+  assert(*v1_max_element == 4);
 
-  decltype(v)::iterator j = std::max_element(v.begin(), v.end(), [](int a, int b) {
-                              return a > b;
-                            });
-  assert(*j == 1);
+
+  // (2)
+  std::vector<std::pair<int, int>> v2 = {{0, 3}, {1, 1}, {2, 4}};
+
+  decltype(v2)::iterator v2_max_element = std::max_element(v2.begin(), v2.end(), [](const auto& a, const auto& b) {
+    return a.second < b.second;
+  });
+  assert(v2_max_element->first == 2);
+  assert(v2_max_element->second == 4);
 }
 ```
 * std::max_element[color ff0000]

--- a/reference/algorithm/min_element.md
+++ b/reference/algorithm/min_element.md
@@ -60,7 +60,7 @@ int main()
 
 
   // (2)
-  std::vector<std::pair<int, int>> v2 = {std::make_pair(0, 3), std::make_pair(1, 1), std::make_pair(2, 4)};
+  std::vector<std::pair<int, int>> v2 = {{0, 3}, {1, 1}, {2, 4}};
 
   decltype(v2)::iterator v2_min_element = std::min_element(v2.begin(), v2.end(), [](const auto& a, const auto& b) {
     return a.second < b.second;

--- a/reference/algorithm/min_element.md
+++ b/reference/algorithm/min_element.md
@@ -45,21 +45,28 @@ namespace std {
 
 ## 例
 ```cpp example
-#include <cassert>
 #include <algorithm>
+#include <cassert>
+#include <utility>
 #include <vector>
 
 int main()
 {
-  std::vector<int> v = {3, 1, 4};
+  // (1)
+  std::vector<int> v1 = {3, 1, 4};
 
-  decltype(v)::iterator i = std::min_element(v.begin(), v.end());
-  assert(*i == 1);
+  decltype(v1)::iterator v1_min_element = std::min_element(v1.begin(), v1.end());
+  assert(*v1_min_element == 1);
 
-  decltype(v)::iterator j = std::min_element(v.begin(), v.end(), [](int a, int b) {
-                              return a < b;
-                            });
-  assert(*j == 4);
+
+  // (2)
+  std::vector<std::pair<int, int>> v2 = {std::make_pair(0, 3), std::make_pair(1, 1), std::make_pair(2, 4)};
+
+  decltype(v2)::iterator v2_min_element = std::min_element(v2.begin(), v2.end(), [](const auto& a, const auto& b) {
+    return a.second < b.second;
+  });
+  assert(v2_min_element->first == 1);
+  assert(v2_min_element->second == 1);
 }
 ```
 * std::min_element[color ff0000]

--- a/reference/algorithm/min_element.md
+++ b/reference/algorithm/min_element.md
@@ -57,7 +57,7 @@ int main()
   assert(*i == 1);
 
   decltype(v)::iterator j = std::min_element(v.begin(), v.end(), [](int a, int b) {
-                              return a > b;
+                              return a < b;
                             });
   assert(*j == 4);
 }


### PR DESCRIPTION
comp argument of std::min_element expects the function that takes (a, b) and return true if a < b.
Of course, a > b is also valid (compilable), but it might be not appropriate for an example.