### PR TITLE
add comments regarding std::integral_constant

### DIFF
--- a/reference/type_traits/alignment_of.md
+++ b/reference/type_traits/alignment_of.md
@@ -28,6 +28,10 @@ namespace std {
 `alignof(T)`で得られた[`std::size_t`](/reference/cstddef/size_t.md)型の値を、メンバ定数`value`として定義する。
 
 
+## 備考
+`alignment_of`は[`integral_constant`](integral_constant.md)から派生する。
+
+
 ## 例
 ```cpp example
 #include <type_traits>

--- a/reference/type_traits/extent.md
+++ b/reference/type_traits/extent.md
@@ -25,6 +25,10 @@ namespace std {
 - 型`T`が配列型ではない、もしくは配列の次元数が`I`以下の場合、値`0`をメンバ定数`value`として定義する。
 
 
+## 備考
+`extent`は[`integral_constant`](integral_constant.md)から派生する。
+
+
 ## 例
 ```cpp example
 #include <type_traits>

--- a/reference/type_traits/rank.md
+++ b/reference/type_traits/rank.md
@@ -24,6 +24,10 @@ namespace std {
 型`T`が配列型である場合、配列の次元数となる整数値をメンバ定数`value`の値として定義する。配列型でなければ`0`をメンバ定数`value`の値として定義する。
 
 
+## 備考
+`rank`は[`integral_constant`](integral_constant.md)から派生する。
+
+
 ## 例
 ```cpp example
 #include <type_traits>


### PR DESCRIPTION
std::alignment_of, std::extent, std::rank の各クラスが、std::integral_constantから派生していることについて記載がなかったので、「備考」として追記しました。