### PR TITLE
workaround(ci): takezawa氏のページを除外

### DIFF
--- a/.github/workflows/outer_link_check.yml
+++ b/.github/workflows/outer_link_check.yml
@@ -24,7 +24,7 @@ jobs:
         ref: master
     - name: check
       run: |
-        { python3 .github/workflows/script/link_check.py --check-outer-link  3>&2 2>&1 1>&3 | tee check_result.txt; } 3>&2 2>&1 1>&3
+        { python3 .github/workflows/script/link_check.py --check-outer-link  3>&2 2>&1 1>&3 | grep -v "http://cse.naro.affrc.go.jp/takezawa/r-tips/" | tee check_result.txt; } 3>&2 2>&1 1>&3
     - name: create github issue when needed
       run: .github/workflows/script/create_github_issue_when_not_empty.sh check_result.txt ${{ secrets.GITHUB_TOKEN }} ${{ github.repository }} ${{ github.sha }}
     - name: detect link check check_result


### PR DESCRIPTION
#916, #922 で論じたように、このページがやたらとリンクチェックに失敗するが実際には疎通できる。原因がよくわからないのでとりあえず無視する

https://github.com/cpprefjp/site/actions/runs/1491153185