### PR TITLE
値指向なコンセプトの説明文面を修正

### DIFF
--- a/reference/concepts/copyable.md
+++ b/reference/concepts/copyable.md
@@ -21,7 +21,7 @@ namespace std {
 
 ## 概要
 
-`copyable`は、任意の型`T`が[`movable`](./movable.md)であり、コピー構築・代入が可能であることを表すコンセプトである。
+`copyable`は、任意の型`T`が[`movable`](./movable.md)コンセプトを満たし、それに加えてコピー構築・代入が可能であることを表すコンセプトである。
 
 ## 例
 ```cpp example

--- a/reference/concepts/regular.md
+++ b/reference/concepts/regular.md
@@ -15,7 +15,7 @@ namespace std {
 
 ## 概要
 
-`regular`は、任意の型`T`が[`semiregular`](./semiregular.md)であり、等値比較可能であることを表すコンセプトである。
+`regular`は、任意の型`T`が[`semiregular`](./semiregular.md)コンセプトを満たし、それに加えて等値比較可能であることを表すコンセプトである。
 
 ## 正則性
 

--- a/reference/concepts/semiregular.md
+++ b/reference/concepts/semiregular.md
@@ -15,7 +15,7 @@ namespace std {
 
 ## 概要
 
-`semiregular`は、任意の型`T`が[`copyable`](./copyable.md)であり、デフォルト構築可能であることを表すコンセプトである。
+`semiregular`は、任意の型`T`が[`copyable`](./copyable.md)コンセプトを満たし、それに加えてデフォルト構築可能であることを表すコンセプトである。
 
 半正則（*semiregular*）な型とは`int`型などの[基本型](/reference/type_traits/is_fundamental.md)の様に扱うことができる型を表しているが、`==`による等値比較が必ずしも可能ではない。
 


### PR DESCRIPTION
元の文面だと同格修飾のようにも読めるため、前提条件であることが明らかになるように修正しました。

本プルリクエストに関連して、以下のことについてコメントをいただきたいです：

* [`movable`](https://cpprefjp.github.io/reference/concepts/movable.html)のページにある「必然的にswap可能であることを表す」の意味が分かりづらいと思うが、意図が不明で修正できなかった
    * 文章のどの部分から、どのような論理で、導かれるのかがよくわかりませんでした
        * 導かれるのであれば、文を分けて理由付きで説明したほうがよさそうです
    * わざわざコンセプトの条件に記載されているということは、特殊な条件下では満たされない、つまり「必然」ではないという可能性を示唆しているように思います
    * P0898R3に記載されている There need be no subsumption relationship between Movable<T> and is_object_v<T>. と関係があるのでしょうか