### PR TITLE
basic_filebuf::open: fix openmode table

### DIFF
--- a/reference/fstream/basic_filebuf/open.md
+++ b/reference/fstream/basic_filebuf/open.md
@@ -23,7 +23,7 @@ basic_filebuf* open(const filesystem::path& s, ios_base::openmode mode); // (4) 
 
 まず`mode & ~ios_base::ate`の結果からファイルの開くモードが決定される。`fopen`のモード文字列との対応は以下の通り。
 
-| `binary` | `in` | `out` | `trunc` | `ate` | 対応する`fopen`のモード文字列 |
+| `binary` | `in` | `out` | `trunc` | `app` | 対応する`fopen`のモード文字列 |
 |----------|------|-------|---------|-------|--------------------|
 |          |      | ○     |         |       | `"w"`              |
 |          |      | ○     |         | ○     | `"a"`              |


### PR DESCRIPTION
テーブルの `ate` を `app` に修正します。
規格書は確認しておらず、 https://en.cppreference.com/w/cpp/io/basic_filebuf/open との比較によります。