### PR TITLE
Fix typo in priority_queue description

### DIFF
--- a/reference/queue/priority_queue.md
+++ b/reference/queue/priority_queue.md
@@ -27,7 +27,7 @@ namespace std {
 
 この要件を満たすものとしては[`vector`](/reference/vector.md)と[`deque`](/reference/deque/deque.md)があり、デフォルトでは[`vector`](/reference/vector.md)が使用される。
 
-`queue`は2つのテンプレート引数を持つ。
+`priority_queue`は3つのテンプレート引数を持つ。
 
 各テンプレートパラメータの意味は以下の通りである。
 


### PR DESCRIPTION
以下を修正しました。typo のようです。

* `priority_queue` とすべきところを `queue` となっている点を修正
* `priority_queue` のテンプレート引数は、2つではなく3つなので文言修正(その後の説明でも3つ分説明がある)