### PR TITLE
algorithm.md: lexicographical_compare_three_way は C++20 から

### DIFF
--- a/reference/algorithm.md
+++ b/reference/algorithm.md
@@ -391,7 +391,7 @@ ranges::sort(pv, {}, &Parson::name);
 
 | 名前 | 説明 | 対応バージョン |
 |---------------------------------------------------------------------|---------------------------------|-------|
-| [`lexicographical_compare_three_way`](algorithm/lexicographical_compare_three_way.md) | 2つの範囲を辞書式順序で比較する | |
+| [`lexicographical_compare_three_way`](algorithm/lexicographical_compare_three_way.md) | 2つの範囲を辞書式順序で比較する | C++20 |
 
 
 ### 順列


### PR DESCRIPTION
規格書は確認していない。

https://cpprefjp.github.io/reference/algorithm/lexicographical_compare_three_way.html が C++20 と書かれている点と三方比較自体が、 C++20 からであるため正しいと考えている。