### PR TITLE
fix some typos and incorrect links

### DIFF
--- a/reference/initializer_list/initializer_list/begin.md
+++ b/reference/initializer_list/initializer_list/begin.md
@@ -56,5 +56,5 @@ int main()
 
 
 ## 参照
-- [N3469 Constexpr Library Additions: chrono, v3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3469.html)
+- [N2235 Generalized Constant Expressions — Revision 5](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf)
 

--- a/reference/initializer_list/initializer_list/begin_free.md
+++ b/reference/initializer_list/initializer_list/begin_free.md
@@ -60,5 +60,5 @@ int main()
 
 ## 参照
 - [N3257 Range-based for statements and ADL](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3257.pdf)
-- [N3469 Constexpr Library Additions: chrono, v3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3469.html)
+- [N2235 Generalized Constant Expressions — Revision 5](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf)
 

--- a/reference/initializer_list/initializer_list/end.md
+++ b/reference/initializer_list/initializer_list/end.md
@@ -61,5 +61,5 @@ int main()
 
 
 ## 参照
-- [N3469 Constexpr Library Additions: chrono, v3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3469.html)
+- [N2235 Generalized Constant Expressions — Revision 5](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf)
 

--- a/reference/initializer_list/initializer_list/end_free.md
+++ b/reference/initializer_list/initializer_list/end_free.md
@@ -62,5 +62,5 @@ int main()
 
 ## 参照
 - [N3257 Range-based for statements and ADL](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2011/n3257.pdf)
-- [N3469 Constexpr Library Additions: chrono, v3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3469.html)
+- [N2235 Generalized Constant Expressions — Revision 5](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf)
 

--- a/reference/initializer_list/initializer_list/op_constructor.md
+++ b/reference/initializer_list/initializer_list/op_constructor.md
@@ -42,5 +42,5 @@ int main()
 
 
 ## 参照
-- [N3469 Constexpr Library Additions: chrono, v3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3469.html)
+- [N2235 Generalized Constant Expressions — Revision 5](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf)
 

--- a/reference/initializer_list/initializer_list/size.md
+++ b/reference/initializer_list/initializer_list/size.md
@@ -54,5 +54,5 @@ int main()
 
 
 ## 参照
-- [N3469 Constexpr Library Additions: chrono, v3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3469.html)
+- [N2235 Generalized Constant Expressions — Revision 5](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2235.pdf)
 

--- a/reference/iomanip/resetiosflags.md
+++ b/reference/iomanip/resetiosflags.md
@@ -42,7 +42,7 @@ int main()
   std::cout << f << '\n';
 }
 ```
-* std::setw[color ff0000]
+* std::resetiosflags[color ff0000]
 
 
 ## 出力例

--- a/reference/iomanip/setfill.md
+++ b/reference/iomanip/setfill.md
@@ -1,11 +1,12 @@
 # setfill
 * iomanip[meta header]
 * std[meta namespace]
-* function[meta id-type]
+* function template[meta id-type]
 
 ```cpp
 namespace std {
-  unspecified setfill(char_type c);
+  template <class CharT>
+  unspecified setfill(CharT c);
 }
 ```
 * unspecified[italic]

--- a/reference/iomanip/setiosflags.md
+++ b/reference/iomanip/setiosflags.md
@@ -41,7 +41,7 @@ int main()
   std::cout << f << '\n';
 }
 ```
-* std::setw[color ff0000]
+* std::setiosflags[color ff0000]
 
 
 ## 出力例


### PR DESCRIPTION
・std::setfill() をfunction templateに変更。
・std::resetiosflags()とstd::setiosflags()のハイライトを修正。
・std::initializer_listの６項目がchronoに関する提案をリンクしてしまっていたのを修正。