### PR TITLE
rename before_cbegin.md to cbefore_begin.md.

### DIFF
--- a/reference/algorithm.md
+++ b/reference/algorithm.md
@@ -145,7 +145,6 @@ ranges::sort(pv, {}, &Parson::name);
 | 名前 | 説明 | 対応バージョン |
 |-----------------------------------------------------|------------------------------------------|-------|
 | [`copy`](algorithm/copy.md)                       | 指定された範囲の要素をコピーする         | |
-| [`copy`](algorithm/copy.md)                       | 指定された範囲の要素をコピーする         | |
 | [`copy_n`](algorithm/copy_n.md)                   | 指定された数の要素をコピーする           | C++11 |
 | [`copy_if`](algorithm/copy_if.md)                 | 条件を満たす要素のみをコピーする         | C++11 |
 | [`copy_backward`](algorithm/copy_backward.md)     | 指定された範囲の要素を後ろからコピーする | |

--- a/reference/array/array/crend.md
+++ b/reference/array/array/crend.md
@@ -14,7 +14,7 @@ constexpr const_reverse_iterator crend() const noexcept; // C++17
 
 先頭要素の前を指す読み取り専用逆イテレータを取得する。
 
-[`rend()`](rend.md)は非`const`な`array`オブジェクトに対して`reverse_iterator`を返し、`const`な`array`オブジェクトに対しては`const_reverse_iterator`を返すが、`cend()`は`const_reverse_iterator`を返すバージョンのみが提供されている。
+[`rend()`](rend.md)は非`const`な`array`オブジェクトに対して`reverse_iterator`を返し、`const`な`array`オブジェクトに対しては`const_reverse_iterator`を返すが、`crend()`は`const_reverse_iterator`を返すバージョンのみが提供されている。
 アルゴリズムにイテレータの組を渡す際、アルゴリズム内でデータの書き換えが起こらないというユーザーの意図を示す場合などに有用である。
 
 

--- a/reference/forward_list/forward_list.md
+++ b/reference/forward_list/forward_list.md
@@ -58,7 +58,7 @@ namespace std {
 | [`begin`](forward_list/begin.md) | 先頭要素を指すイテレータを取得する | C++11 |
 | [`end`](forward_list/end.md) | 末尾の次を指すイテレータを取得する | C++11 |
 | [`cbegin`](forward_list/cbegin.md) | 先頭要素を指す読み取り専用イテレータを取得する | C++11 |
-| [`cbefore_begin`](forward_list/before_cbegin.md) | 先頭要素の前を指す読み取り専用イテレータを取得する | C++11 |
+| [`cbefore_begin`](forward_list/cbefore_begin.md) | 先頭要素の前を指す読み取り専用イテレータを取得する | C++11 |
 | [`cend`](forward_list/cend.md) | 末尾の次を指す読み取り専用イテレータを取得する | C++11 |
 
 

--- a/reference/forward_list/forward_list/cbefore_begin.md
+++ b/reference/forward_list/forward_list/cbefore_begin.md
@@ -1,4 +1,4 @@
-# before_cbegin
+# cbefore_begin
 * forward_list[meta header]
 * std[meta namespace]
 * forward_list[meta class]

--- a/reference/vector/vector/crend.md
+++ b/reference/vector/vector/crend.md
@@ -12,7 +12,7 @@ const_reverse_iterator crend() const noexcept;
 ## 概要
 先頭要素の前を指す読み取り専用逆イテレータを取得する。
 
-[`rend`](rend.md)`()`は非`const`な`vector`オブジェクトに対して`reverse_iterator`を返し、`const`な`vector`オブジェクトに対しては`const_reverse_iterator`を返すが、`cend()`は`const_reverse_iterator`を返すバージョンのみが提供されている。
+[`rend`](rend.md)`()`は非`const`な`vector`オブジェクトに対して`reverse_iterator`を返し、`const`な`vector`オブジェクトに対しては`const_reverse_iterator`を返すが、`crend()`は`const_reverse_iterator`を返すバージョンのみが提供されている。
 
 アルゴリズムにイテレータの組を渡す際、アルゴリズム内でデータの書き換えが起こらないというユーザーの意図を示す場合などに有用である。
 


### PR DESCRIPTION
std::forward_list::cbefore_begin について、ファイル名とタイトルが間違っていたので修正しました。
他に細かな修正を３点行っています。