### PR TITLE
fix some typos

### DIFF
--- a/reference/atomic/atomic/op_minus_assign.md
+++ b/reference/atomic/atomic/op_minus_assign.md
@@ -23,7 +23,7 @@ T operator-=(T operand) noexcept;          // (2) C++11
 以下と等価の式により、演算結果の値が返る：
 
 ```cpp
-return fetch_sub(operand) + operand;
+return fetch_sub(operand) - operand;
 ```
 * fetch_sub[link fetch_sub.md]
 

--- a/reference/bitset/bitset/op_constructor.md
+++ b/reference/bitset/bitset/op_constructor.md
@@ -67,7 +67,7 @@ bitset(
 - (3) : `pos > str.`[`size()`](/reference/string/basic_string/size.md)の場合、[`out_of_range`](/reference/stdexcept.md)例外を送出する。
 	- C++03 : `str`に`'0'`と`'1'`以外の文字が含まれていた場合、[`invalid_argument`](/reference/stdexcept.md)例外を送出する。
 	- C++11 : `str`に`zero`と`one`以外の文字が含まれていた場合、[`invalid_argument`](/reference/stdexcept.md)例外を送出する。
-
+- (4) : `str`に`zero`と`one`以外の文字が含まれていた場合、[`invalid_argument`](/reference/stdexcept.md)例外を送出する。
 
 
 ## 例

--- a/reference/memory/shared_ptr/op_less.md
+++ b/reference/memory/shared_ptr/op_less.md
@@ -26,8 +26,8 @@ namespace std {
 
 ## 戻り値
 - (1)
-    - C++11 : [`std::common_type`](/reference/type_traits/common_type.md)`<T*, U*>::type`を、`a`と`b`が持つポインタの共通の型`CT`とし、[`std::less`](/reference/functional/less.md)`<CT>(a.`[`get()`](get.md), b.`[`get()`](get.md)`)`で比較した結果を返す。
-    - C++17 :[`std::less`](/reference/functional/less.md)`<>(a.`[`get()`](get.md), b.`[`get()`](get.md)`)`で比較した結果を返す。
+    - C++11 : [`std::common_type`](/reference/type_traits/common_type.md)`<T*, U*>::type`を、`a`と`b`が持つポインタの共通の型`CT`とし、[`std::less`](/reference/functional/less.md)`<CT>(a.`[`get()`](get.md)`, b.`[`get()`](get.md)`)`で比較した結果を返す。
+    - C++17 :[`std::less`](/reference/functional/less.md)`<>(a.`[`get()`](get.md)`, b.`[`get()`](get.md)`)`で比較した結果を返す。
 - (2)
     - C++11 : [`std::less`](/reference/functional/less.md)`<T*>()(x.`[`get()`](get.md)`, nullptr)`で比較した結果を返す。
     - C++17 : [`std::less`](/reference/functional/less.md)`<typename shared_ptr<T>::element_type*>()(x.`[`get()`](get.md)`, nullptr)`で比較した結果を返す。

--- a/reference/memory/unique_ptr/op_less.md
+++ b/reference/memory/unique_ptr/op_less.md
@@ -25,7 +25,7 @@ namespace std {
 
 
 ## 戻り値
-- (1) : [`std::common_type`](/reference/type_traits/common_type.md)`<unique_ptr<T1, D1>::pointer, unique_ptr<T2, D2>::pointer>::type`を、`a`と`b`が持つポインタの共通の型`CT`とし、[`std::less`](/reference/functional/less.md)`<CT>(a.`[`get()`](get.md), b.`[`get()`](get.md)`)`で比較した結果を返す。
+- (1) : [`std::common_type`](/reference/type_traits/common_type.md)`<unique_ptr<T1, D1>::pointer, unique_ptr<T2, D2>::pointer>::type`を、`a`と`b`が持つポインタの共通の型`CT`とし、[`std::less`](/reference/functional/less.md)`<CT>(a.`[`get()`](get.md)`, b.`[`get()`](get.md)`)`で比較した結果を返す。
 
 - (2) : [`std::less`](/reference/functional/less.md)`<unique_ptr<T, D>::pointer>()(x.`[`get()`](get.md)`, nullptr)`で比較した結果を返す。
 


### PR DESCRIPTION
atomicのoperator-=：-を+に間違えていたので修正。
bitsetのconstructor：(4)の例外条件が抜けていたので追加。
unique_ptrとshared_ptrのoperator<：`が足りていない箇所があったので追加。