### PR TITLE
update commentary of std::bad_weak_ptr gcc supports

### DIFF
--- a/reference/functional/bad_function_call.md
+++ b/reference/functional/bad_function_call.md
@@ -47,7 +47,7 @@ bad function call
 
 ### 処理系
 - [Clang](/implementation.md#clang): ??
-- [GCC](/implementation.md#gcc): 4.4, 4.7.2(what()が"std::bad_weak_ptr"を返すので規格違反。バグ報告済み: [#55847](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55847)。4.7.3で修正されている。)
+- [GCC](/implementation.md#gcc): 4.4
 - [ICC](/implementation.md#icc): ??
 - [Visual C++](/implementation.md#visual_cpp): 2010
 

--- a/reference/memory/bad_weak_ptr.md
+++ b/reference/memory/bad_weak_ptr.md
@@ -47,9 +47,9 @@ int main() {
 * sp.reset[link shared_ptr/reset.md]
 * std::exception[link /reference/exception/exception.md]
 
-### 出力(GCC 4.7での出力。規格上は"bad_weak_ptr"と出力されるのが正しい)
+### 出力
 ```
-std::bad_weak_ptr
+bad_weak_ptr
 ```
 
 ## バージョン
@@ -58,7 +58,7 @@ std::bad_weak_ptr
 
 ### 処理系
 - [Clang](/implementation.md#clang): ??
-- [GCC](/implementation.md#gcc): 4.4, 4.7.2(`what()`が`"std::bad_weak_ptr"`を返すので規格違反。バグ報告済み。[#55847](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55847))
+- [GCC](/implementation.md#gcc): 4.4, 4.7.2(what()が"std::bad_weak_ptr"を返すので規格違反。バグ報告済み: [#55847](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55847)。4.7.3で修正されている。)
 - [ICC](/implementation.md#icc): ??
 - [Visual C++](/implementation.md#visual_cpp): 2008 (TR1), 2010, 2012, 2013
     - 2010までは`what()`が`"tr1::bad_weak_ptr"`を返す。


### PR DESCRIPTION
gcc 4.7.2のstd::bad_weak_ptrのwhat()が規格違反だった件について、十分時間が経っているので、バージョン内の記載のみに変更。

std::bad_function_callはそもそもstd::bad_weak_ptrと無関係のはず。