### PR TITLE
float_tとdouble_tのMSVC実装情報の修正

### DIFF
--- a/reference/cmath/double_t.md
+++ b/reference/cmath/double_t.md
@@ -24,8 +24,9 @@ namespace std {
 - [Clang](/implementation.md#clang):
 - [GCC](/implementation.md#gcc):
 - [ICC](/implementation.md#icc):
-- [Visual C++](/implementation.md#visual_cpp): 2013, 2015, 2017
-	- 2013では、常に`double`の別名。
-	- 2015で、ターゲットのCPUアーキテクチャが`x86`以外である場合、`double`の別名。
-	- 2015で、ターゲットのCPUアーキテクチャが`x86`で、SSE2を使用する場合（`/arch:SSE2`以上のコンパイラオプション）、`double`の別名。
-	- 2015で、ターゲットのCPUアーキテクチャが`x86`で、SSE2を使用しない場合（`/arch:IA32`や`/arch:SSE`コンパイラオプション）、`long double`からの別名。
+- [Visual C++](/implementation.md#visual_cpp): 2013, 2015, 2017, 2019, 2022
+	- 2013, 2015では、常に`double`の別名。
+	- 2017以降で、ターゲットのCPUアーキテクチャが`x86`以外である場合、`double`の別名。
+	- 2017以降で、ターゲットのCPUアーキテクチャが`x86`で、SSE2を使用する場合（`/arch:SSE2`以上のコンパイラオプション）、`double`の別名。
+	- 2017以降で、ターゲットのCPUアーキテクチャが`x86`で、`/fp:fast`コンパイラオプションが指定されている場合、`double`の別名。
+	- 2017以降で、ターゲットのCPUアーキテクチャが`x86`で、SSE2を使用せず（`/arch:IA32`や`/arch:SSE`コンパイラオプション）、`/fp:fast`コンパイラオプションが指定されていない場合、`long double`の別名。

--- a/reference/cmath/float_t.md
+++ b/reference/cmath/float_t.md
@@ -24,8 +24,9 @@ namespace std {
 - [Clang](/implementation.md#clang):
 - [GCC](/implementation.md#gcc):
 - [ICC](/implementation.md#icc):
-- [Visual C++](/implementation.md#visual_cpp): 2013, 2015, 2017
-	- 2013では、常に`float`の別名。
-	- 2015で、ターゲットのCPUアーキテクチャが`x86`以外である場合、`float`の別名。
-	- 2015で、ターゲットのCPUアーキテクチャが`x86`で、SSE2を使用する場合（`/arch:SSE2`以上のコンパイラオプション）、`float`の別名。
-	- 2015で、ターゲットのCPUアーキテクチャが`x86`で、SSE2を使用しない場合（`/arch:IA32`や`/arch:SSE`コンパイラオプション）、`long double`の別名。
+- [Visual C++](/implementation.md#visual_cpp): 2013, 2015, 2017, 2019, 2022
+	- 2013, 2015では、常に`float`の別名。
+	- 2017以降で、ターゲットのCPUアーキテクチャが`x86`以外である場合、`float`の別名。
+	- 2017以降で、ターゲットのCPUアーキテクチャが`x86`で、SSE2を使用する場合（`/arch:SSE2`以上のコンパイラオプション）、`float`の別名。
+	- 2017以降で、ターゲットのCPUアーキテクチャが`x86`で、`/fp:fast`コンパイラオプションが指定されている場合、`float`の別名。
+	- 2017以降で、ターゲットのCPUアーキテクチャが`x86`で、SSE2を使用せず（`/arch:IA32`や`/arch:SSE`コンパイラオプション）、`/fp:fast`コンパイラオプションが指定されていない場合、`long double`の別名。


### PR DESCRIPTION
[2015 RTM](https://download.microsoft.com/download/0/B/C/0BC321A4-013F-479C-84E6-4A2F90B11269/vs2015.com_enu.iso)、2015 Update 3、2017(15.9.49 191627048)、2019(16.11.16 192930145)、2022(17.2.5 193231332)で確認。