### PR TITLE
remove unnecessary comment in samples

### DIFF
--- a/reference/iterator/ssize.md
+++ b/reference/iterator/ssize.md
@@ -44,7 +44,6 @@ int main()
   int ar[] = {1, 2, 3};
 
   // コンテナの要素数を取得。
-  // ptrdiff_tは、多くの環境ではintだと思ってよい
   std::ptrdiff_t n1 = std::ssize(v);
   assert(n1 == 3);
 

--- a/reference/ranges/ssize.md
+++ b/reference/ranges/ssize.md
@@ -39,7 +39,6 @@ int main()
   int ar[] = {1, 2, 3};
 
   // コンテナの要素数を取得。
-  // ptrdiff_tは、多くの環境ではintだと思ってよい
   std::ptrdiff_t n1 = std::ranges::ssize(v);
   assert(n1 == 3);
 


### PR DESCRIPTION
コメントの内容がミスリーディングかな、と思えました。ptrdiff_tについてssize()のサンプルで言及する必要もないので、削除するのが良いと考えました。