### PR TITLE
fix typo in random/piecewise_constant_distribution.md

### DIFF
--- a/reference/random/piecewise_constant_distribution.md
+++ b/reference/random/piecewise_constant_distribution.md
@@ -48,7 +48,7 @@ namespace std {
 | [`intervals`](piecewise_constant_distribution/intervals.md) | 区間の数列を取得する             | C++11 |
 | [`densities`](piecewise_constant_distribution/densities.md) | 重み付けの数列を取得する         | C++11 |
 | [`param`](piecewise_constant_distribution/param.md)         | 分布のパラメータを取得／設定する | C++11 |
-| [`mix`](piecewise_constant_distribution/min.md)             | 下限を取得する                 | C++11 |
+| [`min`](piecewise_constant_distribution/min.md)             | 下限を取得する                 | C++11 |
 | [`max`](piecewise_constant_distribution/max.md)             | 上限を取得する                 | C++11 |
 
 


### PR DESCRIPTION
## 概要
`random/piecewise_constant_distribution.md`にて，`min`が`mix`と誤記されているのを見つけたので修正しました
## 根拠など
[C++ draft](http://eel.is/c++draft/rand.dist.samp.pconst#:~:text=result_type%20min()%20const%3B)