### PR TITLE
P2415R2 What is a view?に対応

### DIFF
--- a/reference/ranges/all.md
+++ b/reference/ranges/all.md
@@ -67,5 +67,5 @@ int main() {
 - [N4892 24 Ranges library](https://timsong-cpp.github.io/cppwp/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
 - [［C++］ `<ranges>`のviewを見る19 - owning_view](https://zenn.dev/onihusube/articles/fd07528b68ae0c)
-- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/P2415R2html)
+- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html)
   - 本論文はC++20に遡って適用されている

--- a/reference/ranges/all.md
+++ b/reference/ranges/all.md
@@ -67,3 +67,5 @@ int main() {
 - [N4892 24 Ranges library](https://timsong-cpp.github.io/cppwp/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
 - [［C++］ `<ranges>`のviewを見る19 - owning_view](https://zenn.dev/onihusube/articles/fd07528b68ae0c)
+- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/P2415R2html)
+  - 本論文はC++20に遡って適用されている

--- a/reference/ranges/owning_view.md
+++ b/reference/ranges/owning_view.md
@@ -171,5 +171,5 @@ namespace std::ranges {
 - [N4892 24 Ranges library](https://timsong-cpp.github.io/cppwp/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
 - [［C++］ `<ranges>`のviewを見る19 - owning_view](https://zenn.dev/onihusube/articles/fd07528b68ae0c)
-- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/P2415R2html)
+- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html)
   - 本論文はC++20に遡って適用されている

--- a/reference/ranges/owning_view.md
+++ b/reference/ranges/owning_view.md
@@ -171,3 +171,5 @@ namespace std::ranges {
 - [N4892 24 Ranges library](https://timsong-cpp.github.io/cppwp/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
 - [［C++］ `<ranges>`のviewを見る19 - owning_view](https://zenn.dev/onihusube/articles/fd07528b68ae0c)
+- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/P2415R2html)
+  - 本論文はC++20に遡って適用されている

--- a/reference/ranges/view.md
+++ b/reference/ranges/view.md
@@ -78,5 +78,5 @@ int main()
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
 - [P2325R3 Views should not be required to be default constructible](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2325r3.html)
   - 本論文はC++20に遡って適用されている
-- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/P2415R2html)
+- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html)
   - 本論文はC++20に遡って適用されている

--- a/reference/ranges/view.md
+++ b/reference/ranges/view.md
@@ -77,3 +77,6 @@ int main()
 - [N4861 24 Ranges library](https://timsong-cpp.github.io/cppwp/n4861/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
 - [P2325R3 Views should not be required to be default constructible](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2325r3.html)
+  - 本論文はC++20に遡って適用されている
+- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/P2415R2html)
+  - 本論文はC++20に遡って適用されている

--- a/reference/ranges/viewable_range.md
+++ b/reference/ranges/viewable_range.md
@@ -53,5 +53,5 @@ Rangeアダプタを適用するには、`viewable_range`である必要があ�
 - [N4861 24 Ranges library](https://timsong-cpp.github.io/cppwp/n4861/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
 - [LWG Issue 3481 `viewable_range` mishandles lvalue move-only views](https://cplusplus.github.io/LWG/lwg-defects.html#3481)
-- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/P2415R2html)
+- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html)
   - 本論文はC++20に遡って適用されている

--- a/reference/ranges/viewable_range.md
+++ b/reference/ranges/viewable_range.md
@@ -7,13 +7,21 @@
 ```cpp
 namespace std::ranges {
   template<class T>
-  concept viewable_range = range<T> && (borrowed_range<T> || view<remove_cvref_t<T>>);
+  concept viewable_range =
+    range<T> &&
+    ((view<remove_cvref_t<T>> && constructible_from<remove_cvref_t<T>, T>) ||
+     (!view<remove_cvref_t<T>> &&
+      (is_lvalue_reference_v<T> || (movable<remove_reference_t<T>> && !is-initializer-list<T>))));
 }
 ```
 * range[link range.md]
-* borrowed_range[link borrowed_range.md]
 * view[link view.md]
 * remove_cvref_t[link /reference/type_traits/remove_cvref.md]
+* constructible_from[link /reference/concepts/constructible_from.md]
+* is_lvalue_reference_v[link /reference/type_traits/is_lvalue_reference.md]
+* movable[link /reference/concepts/movable.md]
+* remove_reference_t[link /reference/type_traits/remove_reference.md]
+* is-initializer-list[italic]
 
 ## 概要
 `viewable_range`は、安全に[`view`](view.md)へ変換できるRangeを表すコンセプトである。
@@ -44,3 +52,6 @@ Rangeアダプタを適用するには、`viewable_range`である必要があ�
 ## 参照
 - [N4861 24 Ranges library](https://timsong-cpp.github.io/cppwp/n4861/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
+- [LWG Issue 3481 `viewable_range` mishandles lvalue move-only views](https://cplusplus.github.io/LWG/lwg-defects.html#3481)
+- [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/P2415R2html)
+  - 本論文はC++20に遡って適用されている


### PR DESCRIPTION
[P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html) の内容の中で、未執筆のものを記述しました。

- `viewable_range` コンセプトを修正しました。この際 [LWG Issue 3481 `viewable_range` mishandles lvalue move-only views](https://cplusplus.github.io/LWG/lwg-defects.html#3481) も参考文献に付与しました
- 関係するページの参考文献にP2415R2を追加しました。この際「本論文はC++20に遡って適用されている」ことを明記しました

@tetsurom 私がタイポ以外の変更を加えるのは今回が初めてになります。差し支えございませんでしたら、スタイル等についてレビューをお願いできますでしょうか。