### PR TITLE
本来存在しないテンプレート引数を削除

### DIFF
--- a/reference/concepts/totally_ordered.md
+++ b/reference/concepts/totally_ordered.md
@@ -6,7 +6,7 @@
 
 ```cpp
 namespace std {
-  template<class T, class U>
+  template<class T>
   concept totally_ordered =
     equality_comparable<T> &&
     partially-ordered-with<T, T>;


### PR DESCRIPTION
`totally_ordered`の方にもテンプレート引数`U`があったので、消しました。