### PR TITLE
variant関連の修正

### DIFF
--- a/reference/variant/variant/emplace.md
+++ b/reference/variant/variant/emplace.md
@@ -7,18 +7,28 @@
 
 ```cpp
 template <class T, class... Args>
-T& emplace(Args&&... args);                              // (1)
+T& emplace(Args&&... args);                                        // (1) C++17
+template <class T, class... Args>
+constexpr T& emplace(Args&&... args);                              // (1) C++23
 
 template <class T, class U, class... Args>
-T& emplace(std::initializer_list<U> il, Args&&... args); // (2)
+T& emplace(std::initializer_list<U> il, Args&&... args);           // (2) C++17
+template <class T, class U, class... Args>
+constexpr T& emplace(std::initializer_list<U> il, Args&&... args); // (2) C++23
 
 template <std::size_t I, class... Args>
 variant_alternative_t<I, variant<Types...>>&
-  emplace(Args&&... args);                               // (3)
+  emplace(Args&&... args);                                         // (3) C++17
+template <std::size_t I, class... Args>
+constexpr variant_alternative_t<I, variant<Types...>>&
+  emplace(Args&&... args);                                         // (3) C++23
 
 template <std::size_t I, class U, class... Args>
 variant_alternative_t<I, variant<Types...>>&
-  emplace(std::initializer_list<U> il, Args&&... args);  // (4)
+  emplace(std::initializer_list<U> il, Args&&... args);            // (4) C++17
+template <std::size_t I, class U, class... Args>
+constexpr variant_alternative_t<I, variant<Types...>>&
+  emplace(std::initializer_list<U> il, Args&&... args);            // (4) C++23
 ```
 * variant_alternative_t[link /reference/variant/variant_alternative.md]
 
@@ -177,3 +187,6 @@ int main()
 - [Clang](/implementation.md#clang): 4.0.1
 - [GCC](/implementation.md#gcc): 7.3
 - [Visual C++](/implementation.md#visual_cpp): ??
+
+## 参照
+- [P2231R1 Missing `constexpr` in `std::optional` and `std::variant`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2231r1.html)

--- a/reference/variant/variant/op_assign.md
+++ b/reference/variant/variant/op_assign.md
@@ -10,7 +10,9 @@ constexpr variant& operator=(const variant& rhs);              // (1)
 constexpr variant& operator=(variant&& t) noexcept(see below); // (2)
 
 template <class T>
-variant& operator=(T&& rhs) noexcept(see below);               // (3)
+variant& operator=(T&& rhs) noexcept(see below);               // (3) C++17
+template <class T>
+constexpr variant& operator=(T&& rhs) noexcept(see below);     // (3) C++23
 ```
 
 ## 概要
@@ -193,3 +195,4 @@ int main()
 ## 参照
 - [P0608R3 A sane variant converting constructor](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0608r3.html)
 - [P0602R4 `variant` and `optional` should propagate copy/move triviality](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0602r4.html)
+- [P2231R1 Missing `constexpr` in `std::optional` and `std::variant`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2231r1.html)

--- a/reference/variant/variant/op_constructor.md
+++ b/reference/variant/variant/op_constructor.md
@@ -30,57 +30,11 @@ template <size_t I, class U, class... Args>
 constexpr explicit variant(in_place_index_t<I>,
                            initializer_list<U> il,
                            Args&&... args);              // (8)
-
-template <class Alloc>
-variant(allocator_arg_t,
-        const Alloc& a);                                 // (9)
-
-template <class Alloc>
-variant(allocator_arg_t,
-        const Alloc& a,
-        const variant& other);                           // (10)
-
-template <class Alloc>
-variant(allocator_arg_t,
-        const Alloc& a,
-        variant&& other);                                // (11)
-
-template <class Alloc, class T>
-variant(allocator_arg_t,
-        const Alloc& a,
-        T&& x);                                          // (12)
-
-template <class Alloc, class T, class... Args>
-variant(allocator_arg_t,
-        const Alloc& a,
-        in_place_type_t<T> il,
-        Args&&... args);                                 // (13)
-
-template <class Alloc, class T, class U, class... Args>
-variant(allocator_arg_t,
-        const Alloc& a,
-        in_place_type_t<T>,
-        initializer_list<U> il,
-        Args&&... args);                                 // (14)
-
-template <class Alloc, size_t I, class... Args>
-variant(allocator_arg_t,
-       const Alloc& a,
-       in_place_index_t<I>,
-       Args&&... args);                                  // (15)
-
-template <class Alloc, size_t I, class U, class... Args>
-variant(allocator_arg_t,
-        const Alloc& a,
-        in_place_index_t<I>,
-        initializer_list<U> il,
-        Args&&... args);                                 // (16)
 ```
 * size_t[link /reference/cstddef/size_t.md]
 * initializer_list[link /reference/initializer_list/initializer_list.md]
 * in_place_type_t[link /reference/utility/in_place_type_t.md]
 * in_place_index_t[link /reference/utility/in_place_index_t.md]
-* allocator_arg_t[link /reference/memory/allocator_arg_t.md]
 
 ## 概要
 `variant`オブジェクトを構築する。
@@ -93,7 +47,6 @@ variant(allocator_arg_t,
 - (6) : 候補型のうち、指定した型のコンストラクタ引数`il`と`args...`を受け取ってコンストラクタ内でそのオブジェクトを構築して保持する
 - (7) : 候補型のうち、指定したインデックスの型のコンストラクタ引数を受け取ってコンストラクタ内でそのオブジェクトを構築して保持する
 - (8) : 候補型のうち、指定したインデックスの型のコンストラクタ引数`il`と`args...`を受け取ってコンストラクタ内でそのオブジェクトを構築して保持する
-- (9)-(16) : (1)-(8)のuses-allocator構築版
 
 
 ## テンプレートパラメータ制約
@@ -146,8 +99,6 @@ variant(allocator_arg_t,
     - [`std::forward`](/reference/utility/forward.md)`<Args>(args)...`をコンストラクタ引数として`Ti`型オブジェクトを直接構築して`*this`に保持する
 - (8) :
     - `il`と[`std::forward`](/reference/utility/forward.md)`<Args>(args)...`をコンストラクタ引数として`Ti`型オブジェクトを直接構築して`*this`に保持する
-- (9)-(16) :
-    - uses-allocator構築すること以外は、対応するコンストラクタと等価
 
 
 ## 事後条件
@@ -410,5 +361,6 @@ int main()
 
 
 ## 参照
+- [LWG Issue 2901 Variants cannot properly support allocators](https://cplusplus.github.io/LWG/issue2901)
 - [P0608R3 A sane variant converting constructor](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0608r3.html)
 - [P0602R4 `variant` and `optional` should propagate copy/move triviality](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0602r4.html)

--- a/reference/variant/variant/op_destructor.md
+++ b/reference/variant/variant/op_destructor.md
@@ -6,7 +6,8 @@
 * cpp17[meta cpp]
 
 ```cpp
-~variant();
+~variant();            // C++17
+constexpr ~variant();  // C++23
 ```
 
 ## 概要
@@ -34,3 +35,6 @@
 
 ## 関連項目
 - [`std::is_trivially_destructible`](/reference/type_traits/is_trivially_destructible.md)
+
+## 参照
+- [P2231R1 Missing `constexpr` in `std::optional` and `std::variant`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2231r1.html)

--- a/reference/variant/variant/swap.md
+++ b/reference/variant/variant/swap.md
@@ -6,7 +6,8 @@
 * cpp17[meta cpp]
 
 ```cpp
-void swap(variant& rhs) noexcept(see below);
+void swap(variant& rhs) noexcept(see below);            // C++17
+constexpr void swap(variant& rhs) noexcept(see below);  // C++23
 ```
 
 ## 概要
@@ -69,3 +70,6 @@ int main()
 - [Clang](/implementation.md#clang): 4.0.1
 - [GCC](/implementation.md#gcc): 7.3
 - [Visual C++](/implementation.md#visual_cpp): ??
+
+## 参照
+- [P2231R1 Missing `constexpr` in `std::optional` and `std::variant`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2231r1.html)

--- a/reference/variant/variant/swap_free.md
+++ b/reference/variant/variant/swap_free.md
@@ -7,7 +7,9 @@
 ```cpp
 namespace std {
   template <class... Types>
-  void swap(variant<Types...>& x, variant<Types...>& y) noexcept(see below);
+  void swap(variant<Types...>& x, variant<Types...>& y) noexcept(see below);            // C++17
+  template <class... Types>
+  constexpr void swap(variant<Types...>& x, variant<Types...>& y) noexcept(see below);  // C++23
 }
 ```
 
@@ -71,3 +73,6 @@ int main()
 - [Clang](/implementation.md#clang): 4.0.1
 - [GCC](/implementation.md#gcc): 7.3
 - [Visual C++](/implementation.md#visual_cpp): ??
+
+## 参照
+- [P2231R1 Missing `constexpr` in `std::optional` and `std::variant`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2231r1.html)


### PR DESCRIPTION
- DR LWG 2901によってアロケータサポートが削除されたのを反映
    - という歴史的経緯は記載したほうが良い？現行は単に削除してあります
- ~~C++17では代入演算子はtrivialにならないっぽいのでC++20以降であることを明記~~ これは嘘
- `constexpr` が ~~付いてないとこについてたりC++20/~~ 23以降付くやつ ~~とか~~ があったので適宜 ~~修正~~ **追加**
    - C++20以降付くのではなくC++17に対するDRとして付いたので元の記述が正しい