### PR TITLE
numeric_limits: リンク切れおよび{max,min}_exponentの説明間違いの修正

### DIFF
--- a/reference/limits/numeric_limits/digits.md
+++ b/reference/limits/numeric_limits/digits.md
@@ -30,7 +30,7 @@ static constexpr int digits; // C++11
 |---------------|-----------------------------------------------------|
 | `float`       | [`FLT_MANT_DIG`](/reference/cfloat/flt_mant_dig.md) |
 | `double`      | [`DBL_MANT_DIG`](/reference/cfloat/dbl_mant_dig.md) |
-| `long double` | [`LDBL_MANT_DIG`](/reference/cfloat/ldbl_dig.md)    |
+| `long double` | [`LDBL_MANT_DIG`](/reference/cfloat/ldbl_mant_dig.md)    |
 
 
 ## 例

--- a/reference/limits/numeric_limits/max_exponent.md
+++ b/reference/limits/numeric_limits/max_exponent.md
@@ -14,7 +14,7 @@ static constexpr int max_exponent;
 
 ## 概要
 浮動小数点数型において、型`T`の指数上限値を得る。  
-基数[`radix`](radix.md)を`max_exponent`の値で累乗した値が、型`T`で表現可能な正規化された値となる最大の正の値。  
+基数[`radix`](radix.md)を`max_exponent - 1`の値で累乗した値が、型`T`で表現可能な正規化された値となる最大の正の値。  
 浮動小数点数型以外は0になる。  
 
 対応するマクロを次の表に挙げる。

--- a/reference/limits/numeric_limits/max_exponent.md
+++ b/reference/limits/numeric_limits/max_exponent.md
@@ -21,9 +21,9 @@ static constexpr int max_exponent;
 
 | 型            | 対応するマクロ |
 |---------------|----------------|
-| `float`       | `FLT_MAX_EXP`  |
-| `double`      | `DBL_MAX_EXP`  |
-| `long double` | `LDBL_MAX_EXP` |
+| `float`       | [`FLT_MAX_EXP`](/reference/cfloat/flt_max_exp.md)   |
+| `double`      | [`DBL_MAX_EXP`](/reference/cfloat/dbl_max_exp.md)   |
+| `long double` | [`LDBL_MAX_EXP`](/reference/cfloat/ldbl_max_exp.md) |
 
 
 ## 例

--- a/reference/limits/numeric_limits/min_exponent.md
+++ b/reference/limits/numeric_limits/min_exponent.md
@@ -21,9 +21,9 @@ static constexpr int min_exponent;
 
 | 型            | 対応するマクロ |
 |---------------|----------------|
-| `float`       | `FLT_MIN_EXP`  |
-| `double`      | `DBL_MIN_EXP`  |
-| `long double` | `LDBL_MIN_EXP` |
+| `float`       | [`FLT_MIN_EXP`](/reference/cfloat/flt_min_exp.md)   |
+| `double`      | [`DBL_MIN_EXP`](/reference/cfloat/dbl_min_exp.md)   |
+| `long double` | [`LDBL_MIN_EXP`](/reference/cfloat/ldbl_min_exp.md) |
 
 
 ## 例

--- a/reference/limits/numeric_limits/min_exponent.md
+++ b/reference/limits/numeric_limits/min_exponent.md
@@ -14,7 +14,7 @@ static constexpr int min_exponent;
 
 ## 概要
 浮動小数点数型において、型`T`の指数下限値を得る。  
-基数[`radix`](radix.md)を`min_exponent`の値で累乗した値が、型`T`で表現可能な正規化された値となる最小の負の値。   
+基数[`radix`](radix.md)を`min_exponent - 1`の値で累乗した値が、型`T`で表現可能な正規化された値となる最小の負の値。   
 浮動小数点数以外は0となる。  
 
 対応するマクロを次の表に挙げる。


### PR DESCRIPTION
{max,min}_exponentは単に指数の最大値・最小値と誤解されがちですが、サンプルコード出力から推測されるとおりここから1引いた値が指数の最大値・最小値となります。（仕様の[numeric.limits.members]にも`one less than that integer`と明記されている）
なお同様のマクロがあるcfloatの説明文では1を引くことが既に書かれていました。