### PR TITLE
クラステンプレートの型推論を回避する例を修正

### DIFF
--- a/lang/cpp17/type_deduction_for_class_templates.md
+++ b/lang/cpp17/type_deduction_for_class_templates.md
@@ -203,11 +203,17 @@ int main()
 
 ### クラステンプレートの型推論を回避する例
 ```cpp
+// C++20 で追加された std::type_identity と同じことをするクラス
+template <class T>
+struct identity {
+  using type = T;
+};
+
 template <class T>
 struct X {
-  using T_ = T;
+  using T_ = typename identity<T>::type;
 
-  // テンプレートパラメータを直接使用せず、型の別名を付けてから使用する。
+  // テンプレートパラメータを直接使用せず、identityを介して使用する。
   // これによって、テンプレート引数を明示的に指定させられる
   X(T_) {}
 };


### PR DESCRIPTION
元の記述ではクラステンプレートの型推論を回避出来ていなかったため修正しました。
この修正は以下のpp.55--58を参考に記述しました。
[Class Template Argument Deduction - A New Abstraction - Zhihao Yuan - CppCon 2017](https://github.com/CppCon/CppCon2017/raw/master/Presentations/Class%20Template%20Argument%20Deduction%20-%20A%20New%20Abstraction/Class%20Template%20Argument%20Deduction%20-%20A%20New%20Abstraction%20-%20Zhihao%20Yuan%20-%20CppCon%202017.pdf)