### PR TITLE
ICXのリンクラベルを修正しました

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -288,7 +288,7 @@
 - Visual C++ (MSVC):
     - [Visual C++ 言語への準拠](https://docs.microsoft.com/ja-jp/cpp/visual-cpp-language-conformance)
     - [次リリース情報(VS2019,2022) - Change log](https://github.com/microsoft/STL/wiki/Changelog)
-- ICX: [C+23 Features Supported by Intel® C+ Compiler](https://www.intel.com/content/www/us/en/developer/articles/technical/c23-features-supported-by-intel-c-compiler.html)
+- ICX: [C++23 Features Supported by Intel® C++ Compiler](https://www.intel.com/content/www/us/en/developer/articles/technical/c23-features-supported-by-intel-c-compiler.html)
 
 [gcc]: ./implementation.md#gcc
 [clang]: ./implementation.md#clang


### PR DESCRIPTION
ICXのラベルの一部分がC+となっていた部分を、おそらくC++であるべきと仮定して編集しました