### PR TITLE
C++20でのallocatorクラスのsize_type型とdifference_type型の扱いを修正

### DIFF
--- a/lang/cpp20.md
+++ b/lang/cpp20.md
@@ -339,9 +339,7 @@ C++20とは、2020年中に改訂され、ISO/IEC 14882:2020で標準規格化�
 
 
 ### 機能の削除
-- C++11で[`allocator_traits`](/reference/memory/allocator_traits.md)クラスが導入されたことでC++17から非推奨化されていた、[`allocator`](/reference/memory/allocator.md)の以下のメンバを削除：
-    - `size_type`型
-    - `difference_type`型
+- C++11で[`allocator_traits`](/reference/memory/allocator_traits.md)クラスが導入されたことでC++17から非推奨化されていた、[`allocator`](/reference/memory/allocator.md)の以下のメンバを削除。なお、`size_type`型と`difference_type`型の非推奨は取り消された。
     - `pointer`型
     - `const_pointer`型
     - `reference`型

--- a/reference/memory/allocator.md
+++ b/reference/memory/allocator.md
@@ -56,8 +56,8 @@ C++11から：
 |-------------------|----------------------------------------------|-------|
 | `value_type`      | 要素の型 `T`                                 | |
 | `propagate_on_container_move_assignment` | コンテナのムーブ代入時に、アロケータの状態を伝播するか。 [`true_type`](/reference/type_traits/true_type.md) | C++14 |
-| `size_type`       | 要素数を表す符号なし整数型 `size_t`          | C++17から非推奨<br/> C++20で削除 |
-| `difference_type` | ポインタの差を表す符号付き整数型 `ptrdiff_t` | C++17から非推奨<br/> C++20で削除 |
+| `size_type`       | 要素数を表す符号なし整数型 `size_t`          | |
+| `difference_type` | ポインタの差を表す符号付き整数型 `ptrdiff_t` | |
 | `pointer`         | 要素のポインタ型 `T*`                        | C++17から非推奨<br/> C++20で削除 |
 | `const_pointer`   | 読み取り専用の要素のポインタ型 `const T*`    | C++17から非推奨<br/> C++20で削除 |
 | `reference`       | 要素の参照型 `T&`                            | C++17から非推奨<br/> C++20で削除 |
@@ -77,6 +77,7 @@ C++11から：
 ## 非推奨・削除の詳細
 C++17から`void`の特殊化版が非推奨となり、C++20で削除された。代わりに[`std::allocator_traits`](allocator_traits.md)クラスの`rebind`機能を使用すること。
 
+メンバ型の`size_type`と`difference_type`は、C++17で非推奨となったがC++20で非推奨が取り消された。
 
 ## 例
 ```cpp example


### PR DESCRIPTION
P0619R4 の次の記述によると、`allocator`クラスの`size_type`と`difference_type`はC++20で非推奨が取り消されているようです。

* https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0619r4.html#3.9
> Strong recommendation: Undeprecate std::allocator<T>::size_type and std::allocator<T>::difference_type, and remove the remaining deprecated parts from the C++20 standard: 

規格上でも`size_type`と`difference_type`は残っています。
* https://timsong-cpp.github.io/cppwp/default.allocator

なので、関連している記述を修正してみました。

`allocator`のリファレンスについては`size_type`と`difference_type`の説明に「C++17から非推奨、C++20で非推奨取り消し」などと書くべきかもしれませんが、わかりにくいかと思ったので「非推奨・削除の詳細」の節に説明を追加するようにしてみました。