### PR TITLE
Fix range_formatter and formattable

### DIFF
--- a/reference/format/formattable.md
+++ b/reference/format/formattable.md
@@ -7,7 +7,7 @@
 ```cpp
 namespace std {
   template <class charT>
-  concept fmt-iter-for = output_iterator<const charT&>;
+  using fmt-iter-for = /* unspecified */;
 
   template <class T, class charT>
   concept formattable =
@@ -23,6 +23,8 @@ namespace std {
   };
 }
 ```
+* fmt-iter-for[italic]
+* unspecified[italic]
 * formatter[link formatter.md]
 * semiregular[link /reference/concepts/semiregular.md]
 * basic_format_context[link basic_format_context.md]
@@ -33,6 +35,7 @@ namespace std {
 
 このコンセプトを使用することで、[`formatter`](formatter.md)クラステンプレートが使用したい型で特殊化されているかをチェックできる。
 
+`formattable`コンセプトの定義において使用されている`fmt-iter-for<charT>`は、[`output_iterator<const charT&>`](/reference/iterator/output_iterator.md)コンセプトのモデルとなる未規定の型である。
 
 ## 例
 ```cpp example

--- a/reference/format/range_formatter.md
+++ b/reference/format/range_formatter.md
@@ -92,7 +92,7 @@ public:
   // format()関数は書式の情報をもたない。
   // parse()関数で解析した書式をメンバ変数で保持しておいて、
   // それをもとに書式化する
-  auto format(MyVector<T>&& v, std::format_context& fctx) const {
+  auto format(const MyVector<T>& v, std::format_context& fctx) const {
     if (is_colon) {
       auto out = fctx.out();
       bool is_first = true;


### PR DESCRIPTION
`<format>`のリファレンスについて、些細ですが気になる点がありましたので、PRを作成しました。

## `range_formatter`のオリジナル書式を定義する例について
```cpp
// 修正前
auto format(MyVector<T>&& v, std::format_context& fctx) const {

// 修正後
auto format(const MyVector<T>& v, std::format_context& fctx) const {
```

`format`の`MyVector`を受け取る引数が右辺値参照になっているため、左辺値を受け取るサンプルコードは動作しないのではないかと思います。`MyVector`は、const-formattable-rangeにできない理由もないため、const左辺値参照にするのが適切ではないかと思い、修正しました。

## `formattable`コンセプトの`fmt-iter-for`について
```cpp
// 修正前
template <class charT>
concept fmt-iter-for = output_iterator<const charT&>;

// 修正後
template <class charT>
using fmt-iter-for = /* unspecified */;
```

`fmt-iter-for`について、P2286R8([該当箇所へのリンク](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2286r8.html#pnum_1))には、

> Let `fmt-iter-for<charT>` be an unspecified type that models `output_iterator<const charT&>` (`fmt-iter-for<charT>`を`output_iterator<const charT&>`コンセプトのモデルとなる未規定の型とする)

とありますので、`fmt-iter-for`はコンセプトではなく、未規定の型であるとの表現が適切ではないかと思い、修正しました。