### PR TITLE
古い表記を修正

### DIFF
--- a/lang/cpp11/initializer_lists.md
+++ b/lang/cpp11/initializer_lists.md
@@ -258,11 +258,11 @@ int main()
     //auto x2 = {};      // コンパイルエラー！x2の型を推論できない
     ```
 
-- 単一要素の初期化子リストを`auto`で受けた場合、C++11では`std::initializer_list<T>`型に推論されるが、C++17では`T`型に推論されるよう仕様が変更されるので注意
+- 単一要素の初期化子リストを`auto`で受けた場合、C++11では`std::initializer_list<T>`型に推論されるが、C++17では直接初期化の場合`T`型に推論されるよう仕様が変更されるので注意
 
     ```cpp
-    auto x = {1}; // C++11ではxの型はstd::initializer_list<int>。
-                  // C++17ではxの型はintになる
+    auto x{1}; // C++17ではxの型はintになる
+    auto x = {1}; // C++11,17共に、xの型はstd::initializer_list<int>。
     ```
 
 - 関数テンプレートのパラメータとして初期化子リストを受けとった場合は、`std::initializer_list`型には推論されない


### PR DESCRIPTION
単一要素の初期化リストをautoで受けた場合の表記が、最新の仕様と異なり、
https://cpprefjp.github.io/lang/cpp17/new_rules_for_auto_deduction_from_braced-init-list.html 
と矛盾しているので修正してもらいたい