### PR TITLE
所属ヘッダの指定ミスを検出するCIタスクを追加

### DIFF
--- a/.github/workflows/meta_header_check.yml
+++ b/.github/workflows/meta_header_check.yml
@@ -1,0 +1,19 @@
+name: meta header check
+
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install requests
+    - uses: actions/checkout@v2
+    - name: check
+      run: python3 .github/workflows/script/meta_header_check.py

--- a/.github/workflows/script/meta_header_check.py
+++ b/.github/workflows/script/meta_header_check.py
@@ -1,0 +1,54 @@
+import glob
+import os
+import sys
+import re
+
+def find_header_or_module(line: str) -> (re.Match, str):
+    m = re.fullmatch(r'[\*-] (.*?)\[meta header\]', line, re.MULTILINE)
+    if m:
+        return m, "header"
+
+    m = re.fullmatch(r'[\*-] (.*?)\[meta module\]', line, re.MULTILINE)
+    if m:
+        return m, "module"
+    return None, ""
+
+def check_header(text: str, filename: str) -> bool:
+    found_error: bool = False
+
+    for line in text.split("\n"):
+        m, header = find_header_or_module(line)
+        if m:
+            dirs = filename.split("/")
+            meta_header = m.group(1)
+            if len(dirs) < 2:
+                found_error = True
+                print("[{}] invalid directory: {}".format(filename, meta_header))
+            elif len(dirs) == 2 and dirs[0] in ("reference", "module"):
+                own_filename = os.path.splitext(os.path.basename(filename))[0]
+                if meta_header != own_filename:
+                    found_error = True
+                    print("[{0}] invalid meta {1} \"{2}\". You should specify \"{3}\" as meta {1}".format(
+                            filename, header, meta_header, own_filename))
+            elif len(dirs) > 2 and dirs[0] in ("reference", "module"):
+                own_header = dirs[1]
+                if meta_header != own_header:
+                    found_error = True
+                    print("[{0}] invalid meta {1} \"{2}\". You should specify \"{3}\" as meta {1}".format(
+                            filename, header, meta_header, own_header))
+
+            break
+
+    return not found_error
+
+if __name__ == '__main__':
+    found_error = False
+    for p in sorted(list(glob.glob("**/*.md", recursive=True))):
+        with open(p) as f:
+            text = f.read()
+
+        if not check_header(text, p):
+            found_error = True
+
+    if found_error:
+        sys.exit(1)


### PR DESCRIPTION
- #1203

[meta header]または[meta module]の指定ミスを検出するようにしてみました (指定ミスするとサイドバーが壊れる)。
自動検出できるなら指定する必要すらないのですが、、それは追々site_generatorを直します。

https://github.com/cpprefjp/site/commit/4f5d507d4e9830fee411f6f621b25ba1fc70cdb3

このコミットで[meta header]の指定ミスを修正する前の状態だと、以下のように出力されます。

```bash
[reference/ranges/from_range_t.md] invalid meta header "utility". You should specify "ranges" as meta header
```

module階層も同じように検出されます。