### PR TITLE
working_style: 型修飾のスタイルの一覧を等幅フォントで表示するよう修正

### DIFF
--- a/working_style.md
+++ b/working_style.md
@@ -7,12 +7,14 @@
 
 型修飾のスタイル：
 
-- A) const T &v
-- B) const T& v
-- C) const T & v
-- D) T const &v
-- E) T const& v
-- F) T const & v
+```cpp
+/* (A) */ const T &v
+/* (B) */ const T& v
+/* (C) */ const T & v
+/* (D) */ T const &v
+/* (E) */ T const& v
+/* (F) */ T const & v
+```
 
 本サイトでは、Bのスタイルで型修飾を行います。
 


### PR DESCRIPTION
型修飾のスタイルの一覧において、現在の実装ではプロポーショナルフォントで表示されますが、スペースの有無などが見にくいため、等幅フォントで表示できるコードブロックに記述するよう修正しました。
https://cpprefjp.github.io/working_style.html

![Screenshot 2023-10-27 at 18-23-17 スタイル - cpprefjp C 日本語リファレンス](https://github.com/cpprefjp/site/assets/20369462/88f0716b-11f7-4abf-966c-58eb765875cc)
