### PR TITLE
impl(C++11,ICC): アライメント指定がサポートされたバージョンを追加

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -14,8 +14,8 @@
 
 | 言語機能                         | 説明 | [GCC][gcc] | [Clang][clang] | [ICC][icc] | [MSVC][msvc] |
 |----------------------------------|------|-----|-------|-----|------|
-| N2341: [`alignas`](/lang/cpp11/alignas.md) | アライメント指定 | 4.8 | 3.0 | No | 2015<br/>2003あるいはそれ以前からある`__declspec(align(x))`構文で代替可能。 |
-| N2341: [`alignof`](/lang/cpp11/alignof.md) | アライメント取得 | 4.5 | 3.3 | No | 2015<br/>2003あるいはそれ以前よりある`__alignof`で代替可能。 |
+| N2341: [`alignas`](/lang/cpp11/alignas.md) | アライメント指定 | 4.8 | 3.0 | 15.0 | 2015<br/>2003あるいはそれ以前からある`__declspec(align(x))`構文で代替可能。 |
+| N2341: [`alignof`](/lang/cpp11/alignof.md) | アライメント取得 | 4.5 | 3.3 | 15.0 | 2015<br/>2003あるいはそれ以前よりある`__alignof`で代替可能。 |
 | N1984: [`auto`](/lang/cpp11/auto.md) | 型推論 | 4.4 | 2.9 | 12.0 | 2010 |
 | N2343: [`decltype`](/lang/cpp11/decltype.md) | 式の型を取得 | 4.3 | 2.9 | 13.0 | 2010 (partial)<br/> 2012 |
 | N1653: C99互換のプリプロセッサ | [可変引数マクロ](/lang/cpp11/variadic_macros.md)、[Pragma演算子](/lang/cpp11/pragma_operator.md)、[`__func__`](/lang/cpp11/func.md) | 4.3 | 2.9 | 11.1 | 2005 (partial): 可変引数のみ `_Pragma`の代わりに`__pragma`が存在する。<br/> 2019 Update 6 |


### PR DESCRIPTION
https://software.intel.com/en-us/articles/c0x-features-supported-by-intel-c-compiler による