### PR TITLE
fix: CIのactionsをnode16以降対応に切り替える

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         chmod 600 $HOME/.ssh/id_ed25519
 
     # site_generator
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: cpprefjp/site_generator
         path: site_generator
@@ -31,7 +31,7 @@ jobs:
       working-directory: site_generator
 
     # kunai
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: cpprefjp/kunai
         path: site_generator/kunai
@@ -39,13 +39,13 @@ jobs:
       working-directory: site_generator/kunai
 
     # cpprefjp.github.io
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: cpprefjp/cpprefjp.github.io
         path: site_generator/cpprefjp/cpprefjp.github.io
 
     # site
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: cpprefjp/site
         path: site_generator/cpprefjp/site
@@ -55,7 +55,7 @@ jobs:
       working-directory: site_generator/cpprefjp/site
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11
         # 3.12でUndefined symbolエラーがでた

--- a/.github/workflows/code_qualify_check.yml
+++ b/.github/workflows/code_qualify_check.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install requests
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: check
       run: python3 .github/workflows/script/code_qualify_check.py

--- a/.github/workflows/detect_forbidden_characters.yml
+++ b/.github/workflows/detect_forbidden_characters.yml
@@ -20,7 +20,7 @@ jobs:
       cache-version: v1
     steps:
     - id: cache-ripgrep
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ${{ env.BIN_DIR }}
         key: ${{ env.cache-version }}-ripgrep-${{ env.RIPGREP_VERSION }}
@@ -31,7 +31,7 @@ jobs:
         mkdir -p $BIN_DIR
         tar xvf ripgrep-$RIPGREP_VERSION-x86_64-unknown-linux-musl.tar.gz --strip=1 --no-anchor -C $BIN_DIR rg
       working-directory: ${{ runner.temp }}
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         path: ${{ env.REPO_DIR }}
     - name: check

--- a/.github/workflows/inner_link_check.yml
+++ b/.github/workflows/inner_link_check.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install requests
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: check
       run: python3 .github/workflows/script/link_check.py --check-inner-link

--- a/.github/workflows/meta_header_check.yml
+++ b/.github/workflows/meta_header_check.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install requests
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: check
       run: python3 .github/workflows/script/meta_header_check.py

--- a/.github/workflows/ngword_check.yml
+++ b/.github/workflows/ngword_check.yml
@@ -7,13 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install requests
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: check
       run: python3 .github/workflows/script/ngword_check.py

--- a/.github/workflows/outer_link_check.yml
+++ b/.github/workflows/outer_link_check.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install requests
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         ref: master
     - name: check


### PR DESCRIPTION
# 動機

CIの実行時に次のような警告が出ています。

>The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-python@v1. For more info: 
>https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

actionsたちはnodejsで動くわけですがこのnodejsのバージョンアップ対応となります。

# 対象としたactions

- checkout
  - https://github.com/actions/checkout/blob/main/CHANGELOG.md
- setup-python
  - https://github.com/actions/setup-python/releases
- cache
  - https://github.com/actions/cache
  - https://github.com/actions/cache/blob/v2/README.md

それぞれchange logを確認し、破壊的変更がないことを確認しました。

# その他

kunaiのビルドに、setup-nodeとかを使わずにいきなりnpmコマンドを呼び出していますが、

https://github.com/cpprefjp/site/blob/041ff2d5575a2b81f67f3265a126ee57cd54d4aa/.github/workflows/script/build.sh#L7-L11

下記CIよりnode18に対応しているということらしいのでnode version upの影響を受けないと判断しました。

https://github.com/cpprefjp/kunai/blob/master/.github/workflows/build.yml

