### PR TITLE
typo: 動作未定義 -> 未定義動作

### DIFF
--- a/reference/memory/shared_ptr/const_pointer_cast.md
+++ b/reference/memory/shared_ptr/const_pointer_cast.md
@@ -35,7 +35,7 @@ namespace std {
 
 
 ## 備考
-- `shared_ptr<T>(const_cast<T*>(r.get()))` という方法は動作未定義となるので使用しないこと。
+- `shared_ptr<T>(const_cast<T*>(r.get()))` という方法は未定義動作となるので使用しないこと。
 
 
 ## 例外

--- a/reference/memory/shared_ptr/dynamic_pointer_cast.md
+++ b/reference/memory/shared_ptr/dynamic_pointer_cast.md
@@ -35,7 +35,7 @@ namespace std {
 
 
 ## 備考
-- `shared_ptr<T>(dynamic_cast<T*>(r.get()))` という方法は動作未定義となるので使用しないこと。
+- `shared_ptr<T>(dynamic_cast<T*>(r.get()))` という方法は未定義動作となるので使用しないこと。
 
 
 ## 例外

--- a/reference/memory/shared_ptr/reinterpret_pointer_cast.md
+++ b/reference/memory/shared_ptr/reinterpret_pointer_cast.md
@@ -35,7 +35,7 @@ namespace std {
 
 
 ## 備考
-- `shared_ptr<T>(reinterpret_cast<T*>(r.get()))` という方法は動作未定義となるので使用しないこと。
+- `shared_ptr<T>(reinterpret_cast<T*>(r.get()))` という方法は未定義動作となるので使用しないこと。
 
 
 ## 例外

--- a/reference/memory/shared_ptr/static_pointer_cast.md
+++ b/reference/memory/shared_ptr/static_pointer_cast.md
@@ -35,7 +35,7 @@ namespace std {
 
 
 ## 備考
-- `shared_ptr<T>(static_cast<T*>(r.get()))` という方法は動作未定義となるので使用しないこと。
+- `shared_ptr<T>(static_cast<T*>(r.get()))` という方法は未定義動作となるので使用しないこと。
 
 
 ## 例


### PR DESCRIPTION
`shared_ptr`の`(const|static|dynamic|reinterpret)_pointer_cast`の解説では「動作未定義となる」という表現が使われています。
これは比較的耳にしない表現で、かつ他のページでは「未定義動作となる」の用例の方が多いため、そちらに統一しました。
他の候補として、「～という方法では、その動作は未定義となる」を考えましたが、冗長に感じたため「未定義動作となる」を選んでいます。

単にtypoとしてpushしようかと思いましたが、複数個所あったため一応ワンクッション置いた方が無難かと考えてpull reqにしています。問題なさそうでしたら、あるいは理由があってこの表現になっていた場合は、その旨お伝えください。