### PR TITLE
fix bug: `std::async` は `std::future_error` ではなく `std::system_error` を投げる

### DIFF
--- a/reference/future/async.md
+++ b/reference/future/async.md
@@ -85,9 +85,9 @@ namespace std {
 非同期実行される関数オブジェクト`f`の結果値取得のための`future`オブジェクトを返す。
 
 ## 例外
-この関数は、以下のerror conditionを持つ[`future_error`](future_error.md)例外オブジェクトを送出する可能性がある：
+この関数は、以下のerror conditionを持つ[`system_error`](/reference/system_error/system_error.md)例外オブジェクトを送出する可能性がある：
 
-- [`resource_unavailable_try_again`](future_errc.md) ： [`launch::async`](launch.md)が指定され、新たなスレッドを起動しようとしたができなかった
+- [`resource_unavailable_try_again`](/reference/system_error/errc.md) ： [`launch::async`](launch.md)が指定され、新たなスレッドを起動しようとしたができなかった
 
 ## launch::asyncポリシーを指定した場合の注意点
 


### PR DESCRIPTION
規格 (  [C++11](https://timsong-cpp.github.io/cppwp/n3337/futures.async#6) [C++20](https://timsong-cpp.github.io/cppwp/n4861/futures.async#7) ) を見る限り、`std::async` は `std::future_error` ではなく `std::system_error` を投げるように思えたので PR を出しました。

手元にぱっと試せる環境が無かったので、実際のコンパイラの動作は確認していません。