### PR TITLE
Fix typo

### DIFF
--- a/reference/random/piecewise_linear_distribution.md
+++ b/reference/random/piecewise_linear_distribution.md
@@ -48,7 +48,7 @@ namespace std {
 | [`intervals`](piecewise_linear_distribution/intervals.md) | 区間の数列を取得する             | C++11 |
 | [`densities`](piecewise_linear_distribution/densities.md) | 重み付けの数列を取得する         | C++11 |
 | [`param`](piecewise_linear_distribution/param.md)         | 分布のパラメータを取得／設定する | C++11 |
-| [`mix`](piecewise_linear_distribution/min.md)             | 下限を取得する                 | C++11 |
+| [`min`](piecewise_linear_distribution/min.md)             | 下限を取得する                 | C++11 |
 | [`max`](piecewise_linear_distribution/max.md)             | 上限を取得する                 | C++11 |
 
 


### PR DESCRIPTION
`std::piecewise_linear_distribution::min` の `min` が `mix` になっていたのを修正しました