### PR TITLE
[Fix] 誤字の修正, 出力例の修正

### DIFF
--- a/reference/string/stof.md
+++ b/reference/string/stof.md
@@ -101,8 +101,10 @@ int main()
 
 ### 出力例
 ```
+---- decimal point
 1.5
 1
+---- base = 8
 500
 250
 ---- base = 16
@@ -172,8 +174,8 @@ float stof(const std::wstring& str, std::size_t* idx = nullptr) {
 
 ## 関連リンク
 ### C標準ライブラリに由来する関数
-- `atof`: `stold`は`atof`を`std::string`および`std::wsting`に対応させ、戻り値の型を`float`に変更したものと見なせる。
-- `strtof`, `wcstof`: `stof`は`strtof`および`wcstof`をそれぞれ`std::string`と`std::wsting`に対応させたものと見なせる。
+- `atof`: `stold`は`atof`を`std::string`および`std::wstring`に対応させ、戻り値の型を`float`に変更したものと見なせる。
+- `strtof`, `wcstof`: `stof`は`strtof`および`wcstof`をそれぞれ`std::string`と`std::wstring`に対応させたものと見なせる。
 
 ### ファミリー
 - [`stoi`](stoi.md): 戻り値の型が`int`となったもの。


### PR DESCRIPTION
## typo

`std::wsting`となっている箇所があったため`std::wstring`に修正しました。

## 出力例

出力例に以下の行が抜けていたようなので修正しました。

```cpp
  // 10進法での変換
  std::cout << "---- decimal point" << std::endl;

  // 指数表記の変換
  std::cout << "---- base = 8" << std::endl;
```