### PR TITLE
[Update] gccの動作確認バージョンを追記

### DIFF
--- a/reference/string/stof.md
+++ b/reference/string/stof.md
@@ -164,7 +164,7 @@ float stof(const std::wstring& str, std::size_t* idx = nullptr) {
 
 ### 処理系
 - [Clang](/implementation.md#clang): ?
-- [GCC](/implementation.md#gcc): ?
+- [GCC](/implementation.md#gcc): 4.8.5
 - [ICC](/implementation.md#icc): ?
 - [Visual C++](/implementation.md#visual_cpp): 2010, 2012, 2013
 


### PR DESCRIPTION
## 対象コード

```cpp
#include <iostream>
#include <string>

int main()
{
  // 10進法での変換
  std::cout << "---- decimal point" << std::endl;

  float a = std::stof("1.5"); // std::stof("1.5", nullptr);
  std::cout << a << std::endl;

  float aw = std::stof(L"1."); // std::stof(L"1.", nullptr);
  std::cout << aw << std::endl;

  // 指数表記の変換
  std::cout << "---- base = 8" << std::endl;

  float b = std::stof("0.5e3", nullptr);
  std::cout << b << std::endl;

  float bw = std::stof(L".25e3", nullptr);
  std::cout << bw << std::endl;

  // 16進法での変換
  std::cout << "---- base = 16" << std::endl;

  float c = std::stof("0x1.2P3", nullptr);
  std::cout << c << std::endl;

  float cw = std::stof(L"0x1.2P4", nullptr);
  std::cout << cw << std::endl;

  // 2番目の仮引数の使用例
  std::cout << "---- use of idx parameter" << std::endl;

  std::string es = "30.75%";
  std::size_t ei;
  float e = std::stof(es, &ei);
  std::cout << e << ' ' << es[ei] << std::endl;

  std::wstring ews = L"32%";
  std::size_t ewi;
  float ew = std::stof(ews, &ewi);
  std::cout << ew << ' ' << ewi << std::endl;

  // 文字列先頭に空白がある場合
  std::cout << "---- space character before number" << std::endl;
  std::cout << std::stof("    -1") << std::endl;
  std::cout << std::stof(L"    -.25") << std::endl;
}
```

## 動作確認

```
hironaka@wsl:~$ g++-4.8 --version
g++-4.8 (Ubuntu 4.8.5-4ubuntu8) 4.8.5
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

hironaka@wsl:~$ g++-4.8 -std=c++11 main.cpp 
hironaka@wsl:~$ ./a.out 
---- decimal point
1.5
1
---- base = 8
500
250
---- base = 16
9
18
---- use of idx parameter
30.75 %
32 2
---- space character before number
-1
-0.25
```