### PR TITLE
Add missing `noexcept` in `shared_ptr`

### DIFF
--- a/reference/memory/shared_ptr/op_constructor.md
+++ b/reference/memory/shared_ptr/op_constructor.md
@@ -50,7 +50,9 @@ shared_ptr(auto_ptr<Y>&& r);                             // (13)
 template <class Y, class Deleter>
 shared_ptr(unique_ptr<Y, Deleter>&& r);                  // (14)
 
-constexpr shared_ptr(nullptr_t);                         // (15)
+constexpr shared_ptr(nullptr_t);                         // (15)  C++14
+
+constexpr shared_ptr(nullptr_t) noexcept;                // (15)  C++17
 
 template <class Y>
 shared_ptr(shared_ptr<Y>&& r, element_type* p) noexcept; // (16) C++20
@@ -283,3 +285,4 @@ int main()
 - [P0414R1 Merging `shared_ptr` changes from Library Fundamentals to C++17](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0414r1.html)
 - [P0497R0 Fixes to `shared_ptr` support for arrays](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0497r0.html)
 - [LWG Issue 2996. Missing rvalue overloads for `shared_ptr` operations](https://wg21.cmeerw.net/lwg/issue2996)
+- [LWG Issue 2365. Missing `noexcept` in `shared_ptr::shared_ptr(nullptr_t)`](https://wg21.cmeerw.net/lwg/issue2365)


### PR DESCRIPTION
Add missing `noexcept` in `shared_ptr::shared_ptr(nullptr_t)`

close: #1249

長期間そのままになっていそうだったのでやってしまいました。