### PR TITLE
chrono/{tai,gps}_clock: クラス説明を増補

### DIFF
--- a/reference/chrono/gps_clock.md
+++ b/reference/chrono/gps_clock.md
@@ -13,19 +13,23 @@ namespace std::chrono {
 ## 概要
 `gps_clock`は、GPS時間 (GPST) を表現するためのクロックである。この時刻系は、カーナビや携帯端末などで使用される。
 
+GPS時間ではうるう秒 (leap second) 補正が行われないため、2017年1月1日以降～2024年現在ではUTC (世界協定時) よりも18秒進んだ時間をとる。
+つまり 2024-01-01 00:00:18 GPS と 2024-01-01 00:00:00 UTC は等価である。
+
 このクラスの[`now()`](gps_clock/now.md)静的メンバ関数は、標準では`noexcept(false)`である。実装が`noexcept(true)`である保証をしない限り、このクラスはTrivialClock要件を満たさない。
 
 
 ### エポック
 クロックごとの初期時間 (内部的にカウンタがあれば値ゼロ) をエポックと呼ぶ。
 
-`gps_clock`のエポックは、1980年1月6日 (この年の最初の日曜日) 0時0分0秒である。
+`gps_clock`のエポックは、1980年1月6日 (同年の最初の日曜日) 0時0分0秒である。
 
 
 ### うるう秒の扱い
-このクロックではうるう秒は挿入されず、うるう秒の数だけ時間が進む。そのため、UTCにうるう秒が挿入されるたびに、UTCはGPSよりも1秒ずつずれていく。
+`gps_clock`ではうるう秒は考慮されず、UTCに対してうるう秒分だけ時間がシフトする。そのため、UTCに正のうるう秒が挿入されるたびに、UTC時間はGPS時間よりも1秒ずつ遅れていく。
 
-GPS時間とTAI時間は19秒ずれていて、このずれは時間が経過しても変わらない。GPS時間のエポックが[`1958y`](year/op_y.md)`/`[`January`](month_constants.md)`/1`、TAI時間のエポックが[`1980y`](year/op_y.md)`/`[`January`](month_constants.md)`/`[`Sunday`](weekday_constants.md)`[1]`であるが、1958年から1970年までのオフセットが10秒と、1970年から1980年までに挿入されたうるう秒が9秒あるためだ。
+同じくうるう秒を考慮しない[TAI時間](tai_clock.md)に対してGPS時間は19秒遅れており、このずれは時間が経過しても変わらない。これはTAI時間のエポックが[`1958y`](year/op_y.md)`/`[`January`](month_constants.md)`/1`、GPS時間のエポックが[`1980y`](year/op_y.md)`/`[`January`](month_constants.md)`/`[`Sunday`](weekday_constants.md)`[1]`であるが、1958年から1970年までのオフセットが10秒と、1970年から1980年までに挿入されたうるう秒が9秒あるためだ。
+(1970年はTAI時間が定められた年である。)
 
 
 ## メンバ関数
@@ -56,6 +60,7 @@ GPS時間とTAI時間は19秒ずれていて、このずれは時間が経過し
 
 
 ## 例
+### 例1: 現在GPS時間
 ```cpp example
 #include <iostream>
 #include <chrono>
@@ -68,12 +73,39 @@ int main()
   std::cout << tp << std::endl;
 }
 ```
+* chrono::gps_clock[color ff0000]
 * now()[link gps_clock/now.md]
 
-### 出力例
+#### 出力例
 ```
 2019-10-24 11:15:37.493236171
 ```
+
+### 例2: うるう秒の影響
+```cpp example
+#include <iostream>
+#include <chrono>
+
+namespace chrono = std::chrono;
+using namespace std::literals::chrono_literals;
+
+int main() {
+  auto utc_tp = chrono::utc_clock::from_sys(chrono::sys_days{2024y/1/1});
+  auto gps_tp = chrono::gps_clock::from_utc(utc_tp);
+  std::cout << utc_tp << " UTC" << std::endl;
+  std::cout << gps_tp << " GPS" << std::endl;
+}
+```
+* chrono::gps_clock[color ff0000]
+* from_sys[link utc_clock/from_sys.md]
+* from_utc[link gps_clock/from_utc.md]
+
+#### 出力
+```
+2024-01-01 00:00:00 UTC
+2024-01-01 00:00:18 GPS
+```
+
 
 ## バージョン
 ### 言語
@@ -81,7 +113,7 @@ int main()
 
 ### 処理系
 - [Clang](/implementation.md#clang): 9.0 [mark noimpl]
-- [GCC](/implementation.md#gcc): 9.2 [mark noimpl], 13.1 [mark verified]
+- [GCC](/implementation.md#gcc): 9.2 [mark noimpl], 13.2 [mark verified]
 - [Visual C++](/implementation.md#visual_cpp): 2019 Update 3 [mark noimpl]
 
 

--- a/reference/chrono/tai_clock.md
+++ b/reference/chrono/tai_clock.md
@@ -13,7 +13,8 @@ namespace std::chrono {
 ## 概要
 `tai_clock`は、TAI時間 (国際原子時、International Atomic Time) を表現するためのクロックである。
 
-このクロックは、UTCよりも10秒進んでいる。そのため、1958-01-01 00:00:00 TAIと1957-12-31 23:59:50 UTCは等価である。
+TAIではうるう秒 (leap second) 補正が行われないため、2017年1月1日以降～2024年現在ではUTC (世界協定時) よりも37秒進んだ時間をとる。
+つまり 2024-01-01 00:00:37 TAI と 2024-01-01 00:00:00 UTC は等価である。
 
 
 このクラスの[`now()`](tai_clock/now.md)静的メンバ関数は、標準では`noexcept(false)`である。実装が`noexcept(true)`である保証をしない限り、このクラスはTrivialClock要件を満たさない。
@@ -23,12 +24,13 @@ namespace std::chrono {
 クロックごとの初期時間 (内部的にカウンタがあれば値ゼロ) をエポックと呼ぶ。
 
 `tai_clock`のエポックは、1958年1月1日0時0分0秒である。
+これはUTC時間1957年12月31日23時59分50秒に対応する。
 
 
 ### うるう秒の扱い
-このクロックではうるう秒は挿入されず、うるう秒の数だけ時間が進む。そのため、UTCにうるう秒が挿入されるたびに、UTCはTAIよりも1秒ずつずれていく。
+`tai_clock`ではうるう秒は考慮されず、UTCに対してうるう秒数分だけ時間がシフトする。そのため、UTCに正のうるう秒が挿入されるたびに、UTC時間はTAI時間よりも1秒ずつ遅れていく。
 
-例として、2000年01月01日までに正のうるう秒が22回、負のうるう秒が0回挿入されたため、TAIがUTCより10秒進んでいることも含めて、2000-01-01 00:00:00 UTCと2000-01-01 00:00:32 TAIは等価となる。
+例として、`tai_clock`エポック日 (1958年1月1日) 時点ではUTCには正のうるう秒が10回挿入されており、さらに2000年01月01日までに正のうるう秒が22回、負のうるう秒が0回挿入されたため、2000-01-01 00:00:00 UTCと2000-01-01 00:00:32 TAIは等価となる。
 
 
 ## メンバ関数
@@ -59,6 +61,7 @@ namespace std::chrono {
 
 
 ## 例
+### 例1: 現在TAI時間
 ```cpp example
 #include <iostream>
 #include <chrono>
@@ -71,12 +74,39 @@ int main()
   std::cout << tp << std::endl;
 }
 ```
+* chrono::tai_clock[color ff0000]
 * now()[link tai_clock/now.md]
 
-### 出力例
+#### 出力例
 ```
-2019-10-24 11:15:47 TAI
+2019-10-24 11:15:47.519957239
 ```
+
+### 例2: うるう秒の影響
+```cpp example
+#include <iostream>
+#include <chrono>
+
+namespace chrono = std::chrono;
+using namespace std::literals::chrono_literals;
+
+int main() {
+  auto utc_tp = chrono::utc_clock::from_sys(chrono::sys_days{2024y/1/1});
+  auto tai_tp = chrono::tai_clock::from_utc(utc_tp);
+  std::cout << utc_tp << " UTC" << std::endl;
+  std::cout << tai_tp << " TAI" << std::endl;
+}
+```
+* chrono::tai_clock[color ff0000]
+* from_sys[link utc_clock/from_sys.md]
+* from_utc[link tai_clock/from_utc.md]
+
+#### 出力
+```
+2024-01-01 00:00:00 UTC
+2024-01-01 00:00:37 TAI
+```
+
 
 ## バージョン
 ### 言語
@@ -84,10 +114,11 @@ int main()
 
 ### 処理系
 - [Clang](/implementation.md#clang): 9.0 [mark noimpl]
-- [GCC](/implementation.md#gcc): 9.2 [mark noimpl]
+- [GCC](/implementation.md#gcc): 9.2 [mark noimpl], 13.2 [mark verified]
 - [Visual C++](/implementation.md#visual_cpp): 2019 Update 3 [mark noimpl]
 
 
 ## 参照
 - [国際原子時 - Wikipedia](https://ja.wikipedia.org/wiki/国際原子時)
+- [国立天文台 水沢, うるう秒について](https://www.miz.nao.ac.jp/vlbi/leapsec.html)
 - [LWG Issue 3359. `<chrono>` leap second support should allow for negative leap seconds](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2117r0.html#3359)


### PR DESCRIPTION
- 概要: TAI時計,GPS時計ではうるう秒補正が行われないことを明記
- うるう秒の扱い: "負のうるう秒"を考慮した表記に調整
- 例示: うるう秒の影響を追加
- gps_clockのうるう秒説明において"1970年"の意味を補足