### PR TITLE
Visual Studio 2022 version 17.0.2の表記からUpdate 1を削除する

### DIFF
--- a/implementation.md
+++ b/implementation.md
@@ -152,7 +152,7 @@
 | 2022 Update 4 | Visual Studio 2022 version 17.4.9      | ??              | 1934       | 193431944       |
 | 2022 Update 3 | Visual Studio 2022 version 17.3.6      | 14.33           | 1933       | 193331630       |
 | 2022 Update 2 | Visual Studio 2022 version 17.2.2      | 14.32           | 1932       | 193231329       |
-| 2022 Update 1 | Visual Studio 2022 version 17.0.2      | 14.30           | 1930       | 193030706       |
+| 2022          | Visual Studio 2022 version 17.0.2      | 14.30           | 1930       | 193030706       |
 | 2022          | Visual Studio 2022 version 17.0.1      | 14.30           | 1930       | 193030705       |
 | 2019 Update 11 | Visual Studio 2019 バージョン 16.11.2  | 14.28           | 1929       | 192930133       |
 | 2019 Update 9 | Visual Studio 2019 バージョン 16.9.2   | 14.28           | 1928       | 192829913       |


### PR DESCRIPTION
https://github.com/cpprefjp/site/commit/2f771c9f5e2d693949cf280f03e7001203f86488#r150600641

上のコメントに基づき、表記と製品名との間に一貫性が無いので修正を提案します。

表記と製品名のどちらに合わせるかですが、`_MSC_VER` と `_MSC_FULL_VER` から推測するに製品名に合わせるのが妥当だと判断しました。

製品名は 17.0 系列ですので " Update 1" が無い表記にしています。

元のコミッターの @faithandbrave さんが良ければリアクションください。
そのリアクションに基づいて、私か@faithandbrave さんがマージすることを考えています。