### PR TITLE
fix: use `replace with` instead of ` replace by`

### DIFF
--- a/reference/atomic/atomic/exchange.md
+++ b/reference/atomic/atomic/exchange.md
@@ -54,7 +54,7 @@ int main()
   std::atomic<int> x(1);
 
   if (x.exchange(2) == 1) {
-    std::cout << "replaced 1 by 2" << std::endl;
+    std::cout << "replaced 1 with 2" << std::endl;
   }
   else {
     std::cout << "replace failed" << std::endl;
@@ -66,7 +66,7 @@ int main()
 
 ### 出力
 ```
-replaced 1 by 2
+replaced 1 with 2
 ```
 
 

--- a/reference/atomic/atomic_exchange.md
+++ b/reference/atomic/atomic_exchange.md
@@ -72,7 +72,7 @@ int main()
   std::atomic<int> x(1);
 
   if (std::atomic_exchange(&x, 2) == 1) {
-    std::cout << "replaced 1 by 2" << std::endl;
+    std::cout << "replaced 1 with 2" << std::endl;
   }
   else {
     std::cout << "replace failed" << std::endl;
@@ -84,7 +84,7 @@ int main()
 
 ### 出力
 ```
-replaced 1 by 2
+replaced 1 with 2
 ```
 
 ## バージョン

--- a/reference/atomic/atomic_exchange_explicit.md
+++ b/reference/atomic/atomic_exchange_explicit.md
@@ -78,7 +78,7 @@ int main()
   std::atomic<int> x(1);
 
   if (std::atomic_exchange_explicit(&x, 2, std::memory_order_acquire) == 1) {
-    std::cout << "replaced 1 by 2" << std::endl;
+    std::cout << "replaced 1 with 2" << std::endl;
   }
   else {
     std::cout << "replace failed" << std::endl;
@@ -90,7 +90,7 @@ int main()
 
 ### 出力
 ```
-replaced 1 by 2
+replaced 1 with 2
 ```
 
 

--- a/reference/atomic/atomic_ref/exchange.md
+++ b/reference/atomic/atomic_ref/exchange.md
@@ -47,7 +47,7 @@ int main()
   std::atomic_ref<int> x{value};
 
   if (x.exchange(2) == 1) {
-    std::cout << "replaced 1 by 2" << std::endl;
+    std::cout << "replaced 1 with 2" << std::endl;
   }
 }
 ```
@@ -56,7 +56,7 @@ int main()
 
 ### 出力
 ```
-replaced 1 by 2
+replaced 1 with 2
 ```
 
 


### PR DESCRIPTION
- Grammar fixes