### PR TITLE
fix: missing `#include <mutex>` in `std::barrier`

### DIFF
--- a/reference/barrier/barrier/arrive.md
+++ b/reference/barrier/barrier/arrive.md
@@ -47,6 +47,7 @@ arrival_token arrive(ptrdiff_t update = 1); // (1) C++26
 #include <barrier>
 #include <chrono>
 #include <iostream>
+#include <mutex>
 #include <thread>
 #include <utility>
 

--- a/reference/barrier/barrier/arrive_and_drop.md
+++ b/reference/barrier/barrier/arrive_and_drop.md
@@ -43,6 +43,7 @@ void arrive_and_drop();
 #include <barrier>
 #include <chrono>
 #include <iostream>
+#include <mutex>
 #include <thread>
 #include <utility>
 

--- a/reference/barrier/barrier/arrive_and_wait.md
+++ b/reference/barrier/barrier/arrive_and_wait.md
@@ -34,6 +34,7 @@ void arrive_and_wait();
 #include <barrier>
 #include <chrono>
 #include <iostream>
+#include <mutex>
 #include <thread>
 #include <utility>
 

--- a/reference/barrier/barrier/wait.md
+++ b/reference/barrier/barrier/wait.md
@@ -38,6 +38,7 @@ void wait(arrival_token&& arrival) const;
 #include <barrier>
 #include <chrono>
 #include <iostream>
+#include <mutex>
 #include <thread>
 #include <utility>
 


### PR DESCRIPTION
Code example in `std::barrier::arrive` was not runnable because `#include <mutex>` was missing to use `lock_guard`.