### PR TITLE
fix: ハッシュテーブルのclearメソッドの計算量に関する記述修正

### DIFF
--- a/reference/unordered_map/unordered_map/clear.md
+++ b/reference/unordered_map/unordered_map/clear.md
@@ -34,7 +34,7 @@ void clear() noexcept;
 
 
 ## 計算量
-本関数呼び出し前のコンテナの要素数（[`size`](size.md)`()`）に比例
+本関数呼び出し前のコンテナの要素数（[`bucket_count`](bucket_count.md)`()`）に比例
 
 
 ## 例

--- a/reference/unordered_map/unordered_multimap/clear.md
+++ b/reference/unordered_map/unordered_multimap/clear.md
@@ -34,7 +34,7 @@ void clear() noexcept;
 
 
 ## 計算量
-本関数呼び出し前のコンテナの要素数（[`size`](size.md)`()`）に比例
+本関数呼び出し前のコンテナの要素数（[`bucket_count`](bucket_count.md)`()`）に比例
 
 
 ## 例

--- a/reference/unordered_set/unordered_multiset/clear.md
+++ b/reference/unordered_set/unordered_multiset/clear.md
@@ -34,7 +34,7 @@ void clear() noexcept;
 
 
 ## 計算量
-本関数呼び出し前のコンテナの要素数（[`size`](size.md)`()`）に比例
+本関数呼び出し前のコンテナの要素数（[`bucket_count`](bucket_count.md)`()`）に比例
 
 
 ## 例

--- a/reference/unordered_set/unordered_set/clear.md
+++ b/reference/unordered_set/unordered_set/clear.md
@@ -34,7 +34,7 @@ void clear() noexcept;
 
 
 ## 計算量
-本関数呼び出し前のコンテナの要素数（[`size`](size.md)`()`）に比例
+本関数呼び出し前のコンテナの要素数（[`bucket_count`](bucket_count.md)`()`）に比例
 
 
 ## 例


### PR DESCRIPTION
# 概要
close #1449 

std:: unordered_setやstd:: unordered_mapをはじめとするハッシュテーブルのclearメソッドについて、その計算量は
「本関数呼び出し前のコンテナの要素数（ [size](https://cpprefjp.github.io/reference/unordered_set/unordered_set/size.html)() ）に比例」と記述されている
https://cpprefjp.github.io/reference/unordered_set/unordered_set/clear.html
https://cpprefjp.github.io/reference/unordered_set/unordered_multiset/clear.html
https://cpprefjp.github.io/reference/unordered_map/unordered_map/clear.html
https://cpprefjp.github.io/reference/unordered_map/unordered_multimap/clear.html

しかし、多くの実装では、このメソッドの計算量は本関数呼び出し前の( [bucket_count](https://cpprefjp.github.io/reference/unordered_map/unordered_map/bucket_count.html)() )に比例している
gccの実装: https://github.com/gcc-mirror/gcc/blob/fd50d2a24adaff9a9ba749fd0a1eb5a5c5ee35a8/libstdc%2B%2B-v3/include/bits/hashtable.h#L2707-L2720
clang LLVMの実装: https://github.com/llvm/llvm-project/blob/ad060dfa4c910e8253ba328be947ef70f6597326/libcxx/include/__hash_table#L1338-L1348

これを受けて、該当するメソッドの計算量に関する記述を修正したものである