### PR TITLE
ライセンスのバージョンを更新

### DIFF
--- a/index.md
+++ b/index.md
@@ -163,9 +163,9 @@ Googleによるデータ使用の詳細は、以下のURLで確認すること�
 
 
 ## ライセンスについて
-本サイトの情報は、[クリエイティブ・コモンズ 表示 3.0 非移植 ライセンス(CC BY)](https://creativecommons.org/licenses/by/3.0/)の下に提供しています。
+本サイトの情報は、[クリエイティブ・コモンズ 表示 4.0 非移植 ライセンス(CC BY)](https://creativecommons.org/licenses/by/4.0/)の下に提供しています。
 
-![](https://i.creativecommons.org/l/by/3.0/88x31.png)
+![](https://i.creativecommons.org/l/by/4.0/88x31.png)
 
 cpprefjpサイトのアイコン・ロゴ画像は、[クリエイティブ・コモンズ 表示 - 非営利 - 改変禁止 4.0 国際 (CC BY-NC-ND 4.0)](https://creativecommons.org/licenses/by-nc-nd/4.0/deed.ja)の下に提供しています。
 


### PR DESCRIPTION
画像の方はCreative Commonsの4.0を使っていましたが、画像以外の方は3.0になっていました。
3.0のページにも古いバージョンであることの注意文章がでているように、4.0へのアップデートで大きな問題はでないという認識です。

- https://creativecommons.org/licenses/by/3.0/

> Notice
This is an older version of this license. Compared to previous versions, the 4.0 versions of all CC licenses are [more user-friendly and more internationally robust ](https://creativecommons.org/version4/). If you are [licensing your own work ](https://creativecommons.org/choose/), we strongly recommend the use of the 4.0 license instead: [Deed - Attribution 4.0 International](https://creativecommons.org/licenses/by/4.0/deed.en)
> これはこのライセンスの古いバージョンです。以前のバージョンと比較して、すべてのCCライセンスの4.0バージョンはよりユーザーフレンドリーで、より国際的に堅牢です。ご自身の作品をライセンスする場合は、4.0ライセンスのご利用を強くお勧めします：Deed - Attribution 4.0 International

それと私のミスで申し訳ないのですが、Open Collectiveから「LICENSEファイルがないから追加してください」という指摘を受け、4.0でLICENSEファイルを作って連絡してしまいました。
その整合性のためにもライセンスのアップデートをしたいです。

一旦このPRは整合性のためにマージしようかと思います。
問題ありましたら、Issueを立てて継続議論をさせてください。