### PR TITLE
fixed script for the interpreter to detect the word as a raw string

### DIFF
--- a/.github/workflows/script/ngword_check.py
+++ b/.github/workflows/script/ngword_check.py
@@ -49,7 +49,7 @@ NGWORD_LIST = [
     ("", "括弧", "カッコ"),
     ("", "constepx", "constexpr"),
     ("", "wsting", "wstring"),
-    ("", "\[lin ", "[link "), # コード修飾ミス
+    ("", r"\[lin ", "[link "), # コード修飾ミス
     ("reference/chrono", "dulation", "duration"),
     ("reference/random", "施行", "試行"),
     ("reference/random", "疑似", "擬似"),


### PR DESCRIPTION
度々のPRになってしまってすみません。

チェック用のスクリプトを実行すると、

```
/home/rotarymars/projects/personal/cpprefjp-site/.github/workflows/script/ngword_check.py:52: SyntaxWarning: invalid escape sequence '\['
  ("", "\[lin ", "[link "), # コード修飾ミス
```
と出るのですが、これはそういう仕様としてscriptが動いているのですか？