### PR TITLE
プライマリ宣言のリストを作成し、グローバル修飾リストにプライマリではないオーバーロード・特殊化が登録されたらエラーにするようにした

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,6 +9,7 @@ jobs:
       matrix:
         item:
           - {name: code_qualify}
+          - {name: global_qualify}
           - {name: defined_word}
           - {name: display_error}
           - {name: meta_header}

--- a/.github/workflows/script/global_qualify_check.py
+++ b/.github/workflows/script/global_qualify_check.py
@@ -1,0 +1,49 @@
+# GLOBAL_QYALIFY_LIST.txtファイルについて、以下をチェックする：
+# 1. プライマリ宣言ではないオーバーロード・特殊化がないこと
+
+import glob
+import os
+import sys
+import re
+
+def convrert_qualify_list(qualify_list: str) -> list:
+    ls: list(str, str) = []
+    for line in qualify_list.split("\n"):
+        stripped_line = line.strip()
+        if not stripped_line or stripped_line.startswith("#"):
+            continue
+        m = re.fullmatch(r'[\*-] (.*?)\[link(.*?)\]', stripped_line)
+        if m:
+            ls.append((m.group(1), m.group(2).strip()))
+    return ls
+
+def check(global_qualify_list_str: str, primary_overload_specialization_list_str: str) -> bool:
+    found_error: bool = False
+
+    global_qualify_list = convrert_qualify_list(global_qualify_list_str)
+    primary_overload_specialization_list = convrert_qualify_list(primary_overload_specialization_list_str)
+
+    for name, link in global_qualify_list:
+        for primary_name, primary_link in primary_overload_specialization_list:
+            if name == primary_name:
+                if not primary_link:
+                    print(f"global_qualify_check: {name} is defined at GLOBAL_QUALIFY_LIST.txt, but the link doe's not have primary declaration.")
+                    found_error = True
+                elif link != primary_link:
+                    print(f"global_qualify_check: {name} is defined at GLOBAL_QUALIFY_LIST.txt, but the link is not for primary declaration.")
+                    found_error = True
+
+    return not found_error
+
+if __name__ == '__main__':
+    found_error = False
+    with open("GLOBAL_QUALIFY_LIST.txt") as f:
+        global_qualify_list = f.read()
+    with open("PRIMARY_OVERLOAD_SPECIALIZATION.txt") as f:
+        primary_overload_specialization_list = f.read()
+
+    if not check(global_qualify_list, primary_overload_specialization_list):
+        found_error = True
+
+    if found_error:
+        sys.exit(1)

--- a/GLOBAL_QUALIFY_LIST.txt
+++ b/GLOBAL_QUALIFY_LIST.txt
@@ -37,6 +37,7 @@
 # 7. オーバーロードされている名前は、優先度の高いプライマリ宣言をグローバル修飾リストに登録する
 #     7.1 ライブラリごとにオーバーロード・特殊化されているものはグローバル修飾リストに登録せず、個別ページで指定する
 #         (std::begin/std::end、std::common_typeなど)
+#         プライマリ宣言されている関数・クラスの一覧は、 PRIMARY_OVERLOAD_SPECIALIZATION.txt を参照
 
 * floating-point-type[italic]
 * implementation-defined[italic]

--- a/PRIMARY_OVERLOAD_SPECIALIZATION.txt
+++ b/PRIMARY_OVERLOAD_SPECIALIZATION.txt
@@ -1,0 +1,159 @@
+# オーバーロード・特殊化されている関数・クラスのプライマリ宣言を列挙する。
+# これら識別子のうち、ここで定義されているリンク以外は、GLOBAL_QUALIFY_LIST.txtに登録してはならない。
+# このファイルへの登録ルールとしては、
+# 1. ヘッダごとにアルファベット順
+# 2. ただし、長い名前を優先して登録する
+# 3. プライマリ宣言をどれかひとつに特定できない場合、[link]のように空リンクにする
+
+# <algorithm>
+* std::erase_if[link /reference/algorithm/erase_if.md]
+    # dequeとflat_mapとflat_setとforward_listとlistとmapとsetとstringとunordered_mapとunordered_setとvectorでオーバーロードされている
+* std::erase[link /reference/algorithm/erase.md]
+    # dequeとforward_listとlistとstringとvectorでオーバーロードされている
+* std::iter_swap[link /reference/algorithm/iter_swap.md]
+    # iteratorにもある
+* std::swap[link /reference/algorithm/swap.md]
+
+# <atomic>
+* std::atomic_compare_exchange_strong_explicit[link /reference/atomic/atomic_compare_exchange_strong_explicit.md]
+    # memoryでオーバーロードされている
+* std::atomic_compare_exchange_strong[link /reference/atomic/atomic_compare_exchange_strong.md]
+    # memoryでオーバーロードされている
+* std::atomic_compare_exchange_weak_explicit[link /reference/atomic/atomic_compare_exchange_weak_explicit.md]
+* std::atomic_compare_exchange_weak[link /reference/atomic/atomic_compare_exchange_weak.md]
+* std::atomic_exchange[link /reference/atomic/atomic_exchange.md]
+* std::atomic_exchange_explicit[link /reference/atomic/atomic_exchange_explicit.md]
+* std::atomic_is_lock_free[link /reference/atomic/atomic_is_lock_free.md]
+* std::atomic_load_explicit[link /reference/atomic/atomic_load_explicit.md]
+* std::atomic_load[link /reference/atomic/atomic_load.md]
+* std::atomic_store_explicit[link /reference/atomic/atomic_store_explicit.md]
+* std::atomic_store[link /reference/atomic/atomic_store.md]
+* std::atomic[link /reference/atomic/atomic.md]
+
+# <cctype>
+* std::tolower[link /reference/cctype/tolower.md]
+* std::toupper[link /reference/cctype/toupper.md]
+
+# <cmath>
+* std::acosh[link /reference/cmath/acosh.md]
+    # complexでオーバーロードされている
+* std::acos[link /reference/cmath/acos.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::asinh[link /reference/cmath/asinh.md]
+    # complexでオーバーロードされている
+* std::asin[link /reference/cmath/asin.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::atan2[link /reference/cmath/atan2.md]
+    # valarrayでオーバーロードされている
+* std::atanh[link /reference/cmath/atanh.md]
+    # complexでオーバーロードされている
+* std::atan (valarrayとcomplexでオーバーロードされている。プライマリはcmath)
+* std::ceil[link /reference/cmath/ceil.md]
+    # chronoでオーバーロードされている
+* std::cosh[link /reference/cmath/cosh.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::cos[link /reference/cmath/cos.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::exp[link /reference/cmath/exp.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::floor[link /reference/cmath/floor.md]
+    # chronoでオーバーロードされている
+* std::log10[link /reference/cmath/log10.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::log[link /reference/cmath/log.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::pow[link /reference/cmath/pow.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::round[link /reference/cmath/round.md]
+    # chronoでオーバーロードされている
+* std::sinh[link /reference/cmath/sinh.md]
+    # complexでオーバーロードされている
+* std::sin[link /reference/cmath/sinh.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::sqrt[link /reference/cmath/sqrt.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::tanh[link /reference/cmath/tanh.md]
+    # valarrayとcomplexでオーバーロードされている
+* std::tan[link /reference/cmath/tan.md]
+    # valarrayとcomplexでオーバーロードされている
+
+# <cstdio>
+* std::remove[link /reference/cstdio/remove.md]
+    # algorithmでオーバーロードされている
+
+# <cstdlib>
+* std::abs[link /reference/cstdlib/abs.md]
+    # cmathとvalarrayとcomplexでオーバーロードされている
+
+# <expected>
+* std::unexpected[link /reference/expected/unexpected.md]
+    # exceptionにもある。先に登録されたのはそちらだが、すでに機能削除されている
+
+# <format>
+* std::formatter (いろんなところで特殊化されている。プライマリはformat)
+* std::enable_nonlocking_formatter_optimization (chronoで特殊化されている。プライマリはformat)
+
+# <istream>
+* operator>>[link /reference/istream/basic_istream/op_istream_free.md]
+    * あちこちでオーバーロードされている
+
+# <iterator>
+    * std::begin[link /reference/iterator/begin.md]
+    * std::end[link /reference/iterator/end.md]
+
+# <memory>
+* std::uses_allocator[link /reference/memory/uses_allocator.md]
+    * flat_mapとflat_setとfutureで特殊化されている
+
+# <ostream>
+* operator<<[link /reference/ostream/basic_ostream/op_ostream_free.md]
+    * あちこちでオーバーロードされている
+
+# <print>
+* std::println[link /reference/print/println.md]
+    * ostreamでオーバーロードされている
+* std::print[link /reference/print/print.md]
+    * ostreamでオーバーロードされている
+* std::vprint_unicode[link /reference/print/vprint_unicode.md]
+    * ostreamでオーバーロードされている
+* std::vprint_nonunicode[link /reference/print/vprint_nonunicode.md]
+
+# <system_error>
+* is_error_code_enum[link /reference/system_error/is_error_code_enum.md]
+    # futureで特殊化されている
+* make_error_code[link /reference/system_error/make_error_code.md]
+    # futureでオーバーロードされている
+* make_error_condition[link /reference/system_error/make_error_condition.md]
+    # futureでオーバーロードされている
+
+# <tuple>
+* std::tuple_size[link /reference/tuple/tuple_size.md]
+    # std::arrayとstd::complexが特殊化している
+* std::tuple_element[link /reference/tuple/tuple_element.md]
+    # std::arrayとstd::complexが特殊化している
+* std::get[link /reference/tuple/get.md]
+    # std::arrayとstd::complexとstd::variantがオーバーロードしている
+
+# <type_traits>
+* std::basic_common_reference[link /reference/type_traits/basic_common_reference.md]
+    # tupleとutilityで特殊化されている
+* std::common_type[link /reference/type_traits/common_type.md]
+    # chronoで特殊化されている
+
+# <utility>
+* std::move[link /reference/utility/move.md]
+
+
+* operator==[link]
+* operator!=[link]
+* operator<=>[link]
+* operator<=[link]
+* operator<[link]
+* operator>=[link]
+* operator>[link]
+* std::sorted_equivalent_t[link]
+    # flat_mapとflat_setにある
+* std::sorted_unique_t[link]
+    # flat_mapとflat_setにある
+* std::this_thread[link]
+    # executionとthreadにある

--- a/start_editing.md
+++ b/start_editing.md
@@ -38,11 +38,28 @@ buildアクションで、MarkdownからHTMLへの変換と、GitHub Pagesへの
 
 
 #### 自動テスト
-- 禁止文字の検出 (detect forbidden charactersアクション)
-    - ソフトハイフンやゼロ幅スペースなどの禁止された文字が使用されている場合に、エラーが発生する
-- 内部リンクの誤り検出 (inner link checkアクション)
-    - サイト内のリンクが存在しない、または存在しているのに.nolinkを指定している場合にエラーが発生する
-    - [GitHub Actionsの実行ログ](https://github.com/cpprefjp/site/actions/workflows/check.yml)で、どのページのどのリンクが不正かがわかるので、それを修正すること
+- checkアクション
+    - 禁止文字の検出 (detect forbidden characters)
+        - ソフトハイフンやゼロ幅スペースなどの禁止された文字が使用されている場合に、エラーが発生する
+    - 内部リンクの誤り検出 (inner link check)
+        - サイト内のリンクが存在しない、または存在しているのに.nolinkを指定している場合にエラーが発生する
+        - [GitHub Actionsの実行ログ](https://github.com/cpprefjp/site/actions/workflows/check.yml)で、どのページのどのリンクが不正かがわかるので、それを修正すること
+    - コード修飾の誤り検出 (code qualify check)
+        - コードブロック中のコードを修飾しているのに、その修飾対象がない場合に、エラーが発生する
+        - [GitHub Actionsの実行ログ](https://github.com/cpprefjp/site/actions/workflows/check.yml)で、どのページのどのコード修飾が不正かがわかるので、それを修正すること
+    - グローバル修飾リストの誤り検出 (global qualify check)
+        - `GLOBAL_QUALIFY_LIST.txt`に登録されている識別子のうち、`PRIMARY_OVERLOAD_SPECIALIZATION_LIST.txt`に登録されているプライマリ宣言へのリンク以外が登録されている場合に、エラーが発生する
+    - 所属ヘッダメタ情報の誤り検出 (meta header check)
+        - `[meta header]`または`[meta module]`指定が誤っている（ディレクトリ階層と一致しない）場合に、エラーが発生する
+        - 導入経緯は [PR#1204](https://github.com/cpprefjp/site/issues/1204) を参照
+    - NGワードの検出 (ngword check)
+        - 日本語入力環境における典型的な誤入力・誤変換をエラーとして検知する
+        - 具体的な対象ワードリストは[ngword_check.py](https://github.com/cpprefjp/site/blob/master/.github/workflows/script/ngword_check.py)を参照
+    - 用語の誤った使い方を検出 (defined word check)
+        - 用語の許可した使い方、許可しない使い方を列挙し、許可した使い方以外の使われ方をエラーとして検出する
+        - 具体的な用語、許可した使い方、許可しない使い方は、[defined_word_check.py](https://github.com/cpprefjp/site/blob/master/.github/workflows/script/defined_word_check.py)を参照
+    - 表示崩れする書き方を検出 (display error check)
+        - 箇条書きのインデントが4の倍数でない行をエラーとして検出する
 - 外部リンク切れを検出 (outer link checkアクション)
     - 日本時間で日曜日の23:30に実行される
     - 外部リンクのページにアクセスできない (ページが消滅したか、一時的にアクセスできない、などの理由) 場合にエラーとなる
@@ -50,20 +67,6 @@ buildアクションで、MarkdownからHTMLへの変換と、GitHub Pagesへの
     - ページが消滅した場合は、代替となるものがあれば差し替え、なければInternet Archiveに変更する
     - 一時的にアクセスできない場合は、時間を置いてアクセスできるようになったらissueを閉じる
     - 海外からのアクセス (GitHub Actions) を拒否しているページもあるため、そのようなページは個別にチェックから外す ([link_check.py](https://github.com/cpprefjp/site/blob/master/.github/workflows/script/link_check.py)の`IGNORE_LIST`に追加する)
-- コード修飾の誤り検出 (code qualify checkアクション)
-    - コードブロック中のコードを修飾しているのに、その修飾対象がない場合に、エラーが発生する
-    - [GitHub Actionsの実行ログ](https://github.com/cpprefjp/site/actions/workflows/check.yml)で、どのページのどのコード修飾が不正かがわかるので、それを修正すること
-- 所属ヘッダメタ情報の誤り検出 (meta header checkアクション)
-    - `[meta header]`または`[meta module]`指定が誤っている（ディレクトリ階層と一致しない）場合に、エラーが発生する
-    - 導入経緯は [PR#1204](https://github.com/cpprefjp/site/issues/1204) を参照
-- NGワードの検出 (ngword checkアクション)
-    - 日本語入力環境における典型的な誤入力・誤変換をエラーとして検知する
-    - 具体的な対象ワードリストは[ngword_check.py](https://github.com/cpprefjp/site/blob/master/.github/workflows/script/ngword_check.py)を参照
-- 用語の誤った使い方を検出 (defined word checkアクション)
-    - 用語の許可した使い方、許可しない使い方を列挙し、許可した使い方以外の使われ方をエラーとして検出する
-    - 具体的な用語、許可した使い方、許可しない使い方は、[defined_word_check.py](https://github.com/cpprefjp/site/blob/master/.github/workflows/script/defined_word_check.py)を参照
-- 表示崩れする書き方を検出 (display error checkアクション)
-    - 箇条書きのインデントが4の倍数でない行をエラーとして検出する
 
 
 ### 自動反映ツール


### PR DESCRIPTION
- #1464 

グローバル修飾リスト (GLOBAL_QUALIFY_LIST.txt) への登録ルールとして、「プライマリ宣言ではないオーバーロード・特殊化へのリンクを登録してはならない」というものがありますが、それの自動チェックのために、以下を追加しました：

- PRIMARY_OVERLOAD_SPECIALIZATION.txtファイルを追加し、プライマリ宣言を列挙した
- チェックスクリプトglobal_qualify_check.pyを追加し、プライマリ宣言ではないオーバーロード・特殊化へのリンクがGLOBAL_QUALIFY_LIST.txtに登録されたらエラーになるようにした
- GitHub Actionsのcheckアクションに組み込んだ

このPRがマージされたあとの作業として、以下をやろうと思います：

- `link_check.py --check-inner-link`で、GLOBAL_QUALIFY_LIST.txtとPRIMARY_OVERLOAD_SPECIALIZATION.txtのリンクチェック
- GLOBAL_QUALIFY_LIST.txtとPRIMARY_OVERLOAD_SPECIALIZATION.txtを自動ソートするスクリプトを実装