### PR TITLE
リンクチェックCI : グローバル修飾リストのリンクもチェックするようにした

### DIFF
--- a/.github/workflows/script/link_check.py
+++ b/.github/workflows/script/link_check.py
@@ -75,7 +75,7 @@ def is_ignore_link(link: str) -> bool:
     return False
 
 
-def find_all_links(text: str) -> (list, set):
+def find_all_links(text: str, is_global: bool) -> (list, set):
     inner_links = []
     outer_links = set()
 
@@ -115,6 +115,10 @@ def find_all_links(text: str) -> (list, set):
                 add_link(link)
 
     for line in text.split("\n"):
+        # コメント
+        if is_global and line.startswith("#"):
+            continue
+
         for m in re.finditer(r'[\*-] (.*?)\[link (.*?)\]', line):
             add_link(m.group(2))
 
@@ -144,12 +148,15 @@ if __name__ == '__main__':
     current_dir = os.getcwd()
     outer_link_dict = dict()
     if len(args.url) <= 0:
-        for p in glob.glob("**/*.md", recursive=True):
+        path_list = [(p, False) for p in glob.glob("**/*.md", recursive=True)]
+        path_list.append(("GLOBAL_QUALIFY_LIST.txt", True))
+        path_list.append(("PRIMARY_OVERLOAD_SPECIALIZATION.txt", True))
+        for p, is_global in path_list:
             dirname = os.path.dirname(p)
             with open(p) as f:
                 text = f.read()
 
-            inner_links, outer_links = find_all_links(text)
+            inner_links, outer_links = find_all_links(text, is_global)
             for link in outer_links:
                 if link in outer_link_dict:
                     outer_link_dict[link].append(p)

--- a/PRIMARY_OVERLOAD_SPECIALIZATION.txt
+++ b/PRIMARY_OVERLOAD_SPECIALIZATION.txt
@@ -6,13 +6,8 @@
 # 3. プライマリ宣言をどれかひとつに特定できない場合、[link]のように空リンクにする
 
 # <algorithm>
-* std::erase_if[link /reference/algorithm/erase_if.md]
-    # dequeとflat_mapとflat_setとforward_listとlistとmapとsetとstringとunordered_mapとunordered_setとvectorでオーバーロードされている
-* std::erase[link /reference/algorithm/erase.md]
-    # dequeとforward_listとlistとstringとvectorでオーバーロードされている
 * std::iter_swap[link /reference/algorithm/iter_swap.md]
     # iteratorにもある
-* std::swap[link /reference/algorithm/swap.md]
 
 # <atomic>
 * std::atomic_compare_exchange_strong_explicit[link /reference/atomic/atomic_compare_exchange_strong_explicit.md]
@@ -131,7 +126,7 @@
     # std::arrayとstd::complexが特殊化している
 * std::tuple_element[link /reference/tuple/tuple_element.md]
     # std::arrayとstd::complexが特殊化している
-* std::get[link /reference/tuple/get.md]
+* std::get[link /reference/tuple/tuple/get.md]
     # std::arrayとstd::complexとstd::variantがオーバーロードしている
 
 # <type_traits>
@@ -142,6 +137,7 @@
 
 # <utility>
 * std::move[link /reference/utility/move.md]
+* std::swap[link /reference/utility/swap.md]
 
 
 * operator==[link]
@@ -151,6 +147,10 @@
 * operator<[link]
 * operator>=[link]
 * operator>[link]
+* std::erase_if[link]
+    # dequeとflat_mapとflat_setとforward_listとlistとmapとsetとstringとunordered_mapとunordered_setとvectorでオーバーロードされている
+* std::erase[link]
+    # dequeとforward_listとlistとstringとvectorでオーバーロードされている
 * std::sorted_equivalent_t[link]
     # flat_mapとflat_setにある
 * std::sorted_unique_t[link]


### PR DESCRIPTION
リンクチェックのCIで、GLOBAL_QUALIFY_LIST.txtとPRIMARY_OVERLOAD_SPECIALIZATION.txtのリンクもチェックするようにしました。
内部リンクに限定はしていないので、外部リンクを入力したらそれもチェックされます。

PRIMARY_OVERLOAD_SPECIALIZATION.txtのまちがっていた指定も、リンクチェックで検出されたので合わせて直してあります。