### PR TITLE
execution: C++26 P3557R3対応

### DIFF
--- a/reference/execution/execution.md
+++ b/reference/execution/execution.md
@@ -82,9 +82,8 @@ namespace std::execution {
 | [`execution::default_domain`](execution/default_domain.md) | デフォルト実行ドメイン (class) | C++26 |
 | [`execution::sender`](execution/sender.md) | Sender型 (concept) | C++26 |
 | [`execution::sender_in`](execution/sender_in.md) | 指定環境で有効なSender (concept) | C++26 |
+| [`execution::dependent_sender`](execution/dependent_sender.md) | 依存Sender (concept) | C++26 |
 | [`execution::sender_to`](execution/sender_to.md) | 指定Receiverに接続可能なSender (concept) | C++26 |
-| [`execution::get_completion_signatures`](execution/get_completion_signatures.md) | Senderの完了シグネチャ集合を取得 (customization point object) | C++26 |
-| [`execution::completion_signatures_of_t`](execution/completion_signatures_of_t.md) | Senderの完了シグネチャ集合を取得 (alias template) | C++26 |
 | [`execution::value_types_of_t`](execution/value_types_of_t.md) | Senderの値完了シグネチャ集合から指定操作で型を生成 (alias template) | C++26 |
 | [`execution::error_types_of_t`](execution/error_types_of_t.md) | Senderのエラー完了シグネチャ集合から指定操作で型を生成 (alias template) | C++26 |
 | [`execution::sends_stopped`](execution/sends_stopped.md) | Senderが停止完了を送信しうるか否か (variable template) | C++26 |
@@ -142,6 +141,9 @@ Senderコンシューマは名前空間 `std::this_thread` で定義される。
 | 名前 | 説明 | 対応バージョン |
 |------|------|----------------|
 | [`execution::completion_signatures`](execution/completion_signatures.md) | 完了シグネチャ集合を表現する型 (class template) | C++26 |
+| [`execution::dependent_sender_error`](execution/dependent_sender_error.md) | 依存Sender例外(class) | C++26 |
+| [`execution::get_completion_signatures`](execution/get_completion_signatures.md) | Senderの完了シグネチャ集合を取得 (function template) | C++26 |
+| [`execution::completion_signatures_of_t`](execution/completion_signatures_of_t.md) | Senderの完了シグネチャ集合を取得 (alias template) | C++26 |
 | [`execution::run_loop`](execution/run_loop.md) | 単一スレッド上でのループ実行 (class) | C++26 |
 
 ### コルーチンユーティリティ

--- a/reference/execution/execution.md
+++ b/reference/execution/execution.md
@@ -141,7 +141,7 @@ Senderコンシューマは名前空間 `std::this_thread` で定義される。
 | 名前 | 説明 | 対応バージョン |
 |------|------|----------------|
 | [`execution::completion_signatures`](execution/completion_signatures.md) | 完了シグネチャ集合を表現する型 (class template) | C++26 |
-| [`execution::dependent_sender_error`](execution/dependent_sender_error.md) | 依存Sender例外(class) | C++26 |
+| [`execution::dependent_sender_error`](execution/dependent_sender_error.md) | 依存Senderを表す例外クラス(class) | C++26 |
 | [`execution::get_completion_signatures`](execution/get_completion_signatures.md) | Senderの完了シグネチャ集合を取得 (function template) | C++26 |
 | [`execution::completion_signatures_of_t`](execution/completion_signatures_of_t.md) | Senderの完了シグネチャ集合を取得 (alias template) | C++26 |
 | [`execution::run_loop`](execution/run_loop.md) | 単一スレッド上でのループ実行 (class) | C++26 |

--- a/reference/execution/execution/basic-operation.md
+++ b/reference/execution/execution/basic-operation.md
@@ -39,6 +39,7 @@ namespace std::execution {
 ```
 * operation_state_t[link operation_state.md]
 * tag_of_t[link tag_of_t.md]
+* indices-for[link basic-sender.md]
 * impls-for[link impls-for.md]
 * std::move[link /reference/utility/move.md]
 
@@ -60,6 +61,7 @@ is_nothrow_constructible_v<basic-state<Self, Rcvr>, Self, Rcvr> &&
 noexcept(connect-all(this, std::forward<Sndr>(sndr), indices-for<Sndr>()))
 ```
 * is_nothrow_constructible_v[link /reference/type_traits/is_nothrow_constructible.md]
+* indices-for[link basic-sender.md]
 
 `basic-state`コンストラクタ`noexcept`節の式は下記の通り。
 
@@ -101,13 +103,11 @@ constexpr auto connect-all = see below;  // exposition only
 template<class Sndr, class Rcvr>
 using connect-all-result = call-result-t<  // exposition only
   decltype(connect-all), basic-state<Sndr, Rcvr>*, Sndr, indices-for<Sndr>>;
-
-template<class Sndr>
-using indices-for = remove_reference_t<Sndr>::indices-for;  // exposition only 
 ```
 * call-result-t[link /reference/functional/call-result-t.md]
 * impls-for[link impls-for.md]
 * tag_of_t[link tag_of_t.md]
+* indices-for[link basic-sender.md]
 
 説明専用の定数`connect-all`は、下記ラムダ式と等価な関数呼び出し可能なオブジェクトとして初期化される。
 

--- a/reference/execution/execution/basic-sender.md
+++ b/reference/execution/execution/basic-sender.md
@@ -97,6 +97,7 @@ using indices-for = remove_reference_t<Sndr>::indices-for;  // exposition only
 
 ## 関連項目
 - [`make-sender`](make-sender.md)
+- [`impls-for`](impls-for.md)
 - [`basic-operation`](basic-operation.md)
 - [`execution::sender`](sender.md)
 

--- a/reference/execution/execution/bulk.md
+++ b/reference/execution/execution/bulk.md
@@ -44,6 +44,9 @@ namespace std::execution {
   template<>
   struct impls-for<bulk_t> : default-impls {
     static constexpr auto complete = see below;
+
+    template<class Sndr, class... Env>
+    static consteval void check-types();
   };
 }
 ```
@@ -74,6 +77,26 @@ namespace std::execution {
 * std::move[link /reference/utility/move.md]
 
 型`Tag`が[`set_value_t`](set_value.md)以外の型であるとき、もしくは式`f(auto(shape), args...)`が適格なときに限って、上記ラムダ式のrequires節が満たされる。
+
+メンバ関数`impls-for<bulk_t>::check-types`の効果は下記の通り。
+
+```cpp
+auto cs = get_completion_signatures<child-type<Sndr>, FWD-ENV-T(Env)...>();
+auto fn = []<class... Ts>(set_value_t(*)(Ts...)) {
+  if constexpr (!invocable<remove_cvref_t<data-type<Sndr>>, Ts&...>)
+    throw unspecified-exception();
+};
+cs.for-each(overload-set{fn, [](auto){}});
+```
+* get_completion_signatures[link get_completion_signatures.md]
+* child-type[link child-type.md]
+* FWD-ENV-T[link ../forwarding_query.md]
+* set_value_t[link set_value.md]
+* data-type[link data-type.md]
+* for-each[link completion_signatures.md]
+* overload-set[link overload-set.md]
+
+`unspecified-exception`は[`exception`](/reference/exception/exception.md)から派生した型となる。
 
 
 ## カスタマイゼーションポイント
@@ -133,3 +156,4 @@ int main()
 ## 参照
 - [P2999R3 Sender Algorithm Customization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2999r3.html)
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/completion_signatures.md
+++ b/reference/execution/execution/completion_signatures.md
@@ -90,7 +90,7 @@ int main()
 
 
 ## 関連項目
-- [`execution::receiver`](receiver.md)
+- [`execution::get_completion_signatures`](get_completion_signatures.md)
 - [`execution::set_value_t`](set_value.md)
 - [`execution::set_error_t`](set_error.md)
 - [`execution::set_stopped_t`](set_stopped.md)

--- a/reference/execution/execution/completion_signatures.md
+++ b/reference/execution/execution/completion_signatures.md
@@ -7,21 +7,31 @@
 ```cpp
 namespace std::execution {
   template<completion-signature... Fns>
-  struct completion_signatures {};
+  struct completion_signatures {
+    template<class Tag>
+    static constexpr size_t count-of(Tag) { return see below; }
+
+    template<class Fn>
+    static constexpr void for-each(Fn&& fn) {  // exposition only
+      (std::forward<Fn>(fn)(static_cast<Fns*>(nullptr)), ...);
+    }
+  };
 }
 ```
 
 ## 概要
 `completion_signatures`クラステンプレートは、完了シグネチャの集合をテンプレートパラメータとして表現する。
 
-実行制御ライブラリ仕様定義では、説明専用のコンセプト`valid-completion-signatures`を利用する。
+式`tag`の[decayed](/reference/type_traits/decay.md)型を`Tag`としたとき、説明専用のメンバ関数`count-of`は`Fns`中の`Tag(Ts...)`形式で表される関数型の個数を返す。
 
+
+### 説明専用のコンセプト `valid-completion-signatures`
 ```cpp
 template<class Sigs>
 concept valid-completion-signatures = see below;
 ```
 
-`Sigs`が[`completion_signatures`](completion_signatures.md)クラステンプレートの特殊化であるとき、`Sigs`は説明専用コンセプト`valid-completion-signatures`のモデルである。
+`Sigs`が`completion_signatures`クラステンプレートの特殊化であるとき、`Sigs`は説明専用コンセプト`valid-completion-signatures`のモデルである。
 
 
 ## テンプレートパラメータ制約
@@ -88,3 +98,4 @@ int main()
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/connect.md
+++ b/reference/execution/execution/connect.md
@@ -23,7 +23,6 @@ namespace std::execution {
 
 ## 効果
 説明用の型`Sndr`を`decltype((sndr))`、型`Rcvr`を`decltype((rcvr))`とし、式`new_sndr`を次の通りとする。
-このとき[`sender`](sender.md)`<Sndr> &&` [`receiver`](receiver.md)`<Rcvr> == true`であること。
 
 ```cpp
 transform_sender(decltype(get-domain-late(sndr, get_env(rcvr))){}, sndr, get_env(rcvr))
@@ -36,6 +35,11 @@ transform_sender(decltype(get-domain-late(sndr, get_env(rcvr))){}, sndr, get_env
 
 - 適格であるならば、式`new_sndr.connect(rcvr)`
 - そうでなければ、式`connect-awaitable(new_sndr, rcvr)`
+
+このとき下記が全て`true`であること。
+
+- [`sender_in`](sender_in.md)`<Sndr,` [`env_of_t`](env_of_t.md)`<Rcvr>>`
+- [`receiver_of`](receiver_of.md)`<Rcvr,` [`completion_signatures_of_t`](completion_signatures_of_t.md)`<Sndr,` [`env_of_t`](env_of_t.md)`<Rcvr>>>`
 
 
 ### Awaitable接続用へルパ
@@ -108,7 +112,7 @@ namespace std::execution {
 * destroy()[link /reference/coroutine/coroutine_handle/destroy.md]
 * resume()[link /reference/coroutine/coroutine_handle/resume.md]
 
-`C`型の`c`と[コルーチンPromise型](/lang/cpp20/coroutines.md)の左辺値`p`に対して、`await-result-type<C, Promise>`を`decltype(`[`GET-AWAITER`](../is-awaitable.md)`(c, p).`[`await_resume()`](/lang/cpp20/coroutines.md)`)`型とする。
+`C`型の`c`と[コルーチンPromise型](/lang/cpp20/coroutines.md)の左辺値`p`に対して、`await-result-type<C, Promise>`を`decltype(`[`GET-AWAITER`](../is-awaitable.md)`(c, p).`[`await_resume()`](/lang/cpp20/coroutines.md)`)`型とし、`await-result-type<C>`を`decltype(`[`GET-AWAITER`](../is-awaitable.md)`(c).`[`await_resume()`](/lang/cpp20/coroutines.md)`)`型とする。
 型`V`を`await-result-type<DS, connect-awaitable-promise>`とする。
 
 [完了シグネチャ集合型](completion_signatures.md)`Sigs`を下記の通り定義する。
@@ -238,4 +242,5 @@ int main()
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
 - [P3396R1 std::execution wording fixes](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3396r1.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)
 - [LWG 4208. Wording needs to ensure that in `connect(sndr, rcvr)` that `rcvr` expression is only evaluated once](https://cplusplus.github.io/LWG/issue4208)

--- a/reference/execution/execution/data-type.md
+++ b/reference/execution/execution/data-type.md
@@ -1,4 +1,4 @@
-# child-type
+# data-type
 * execution[meta header]
 * std::execution[meta namespace]
 * type-alias[meta id-type]
@@ -6,14 +6,14 @@
 
 ```cpp
 namespace std::execution {
-  template<class Sndr, size_t I = 0>
-  using child-type = decltype(declval<Sndr>().template get<I+2>());  // exposition only
+  template<class Sndr>
+  using data-type = decltype(declval<Sndr>().template get<1>());  // exposition only
 }
 ```
 * template get[link product-type.md]
 
 ## 概要
-[Senderアルゴリズム型](basic-sender.md)`Sndr`の子Sender型を取得する説明専用のエイリアステンプレート。
+[Senderアルゴリズム型](basic-sender.md)`Sndr`のデータ型を取得する説明専用のエイリアステンプレート。
 
 
 ## バージョン
@@ -21,12 +21,11 @@ namespace std::execution {
 - C++26
 
 ## 関連項目
+- [`execution::read_env`](read_env.md)
 - [`execution::schedule_from`](schedule_from.md)
-- [`execution::let_value`](let_value.md)
-- [`execution::into_variant`](into_variant.md)
-- [`execution::stopped_as_optional`](stopped_as_optional.md)
 - [`write-env`](write-env.md)
 
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/data-type.md
+++ b/reference/execution/execution/data-type.md
@@ -23,6 +23,9 @@ namespace std::execution {
 ## 関連項目
 - [`execution::read_env`](read_env.md)
 - [`execution::schedule_from`](schedule_from.md)
+- [`execution::then`](then.md)
+- [`execution::let_value`](let_value.md)
+- [`execution::bulk`](bulk.md)
 - [`write-env`](write-env.md)
 
 

--- a/reference/execution/execution/decay-copyable-result-datums.md
+++ b/reference/execution/execution/decay-copyable-result-datums.md
@@ -13,6 +13,7 @@ constexpr void decay-copyable-result-datums(auto cs) {
 }
 ```
 * for-each[link completion_signatures.md]
+* is_constructible_v[link /reference/type_traits/is_constructible.md]
 
 ## 概要
 `decay-copyable-result-datums`は、Senderアルゴリズム動作仕様定義で用いられる説明専用の関数テンプレートである。
@@ -33,6 +34,8 @@ constexpr void decay-copyable-result-datums(auto cs) {
 
 ## 関連項目
 - [`execution::schedule_from`](schedule_from.md)
+- [`execution::when_all`](when_all.md)
+- [`execution::into_variant`](into_variant.md)
 
 
 ## 参照

--- a/reference/execution/execution/decay-copyable-result-datums.md
+++ b/reference/execution/execution/decay-copyable-result-datums.md
@@ -1,0 +1,39 @@
+# decay-copyable-result-datums
+* execution[meta header]
+* function template[meta id-type]
+* std::execution[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+constexpr void decay-copyable-result-datums(auto cs) {
+  cs.for-each([]<class Tag, class... Ts>(Tag(*)(Ts...)) {
+    if constexpr (!(is_constructible_v<decay_t<Ts>, Ts> &&...))
+      throw unspecified-exception();
+  });
+}
+```
+* for-each[link completion_signatures.md]
+
+## 概要
+`decay-copyable-result-datums`は、Senderアルゴリズム動作仕様定義で用いられる説明専用の関数テンプレートである。
+
+`unspecified-exception`は[`exception`](/reference/exception/exception.md)から派生した型となる。
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): ??
+- [GCC](/implementation.md#gcc): ??
+- [ICC](/implementation.md#icc): ??
+- [Visual C++](/implementation.md#visual_cpp): ??
+
+
+## 関連項目
+- [`execution::schedule_from`](schedule_from.md)
+
+
+## 参照
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/dependent_sender.md
+++ b/reference/execution/execution/dependent_sender.md
@@ -15,7 +15,7 @@ namespace std::execution {
 * bool_constant[link /reference/type_traits/bool_constant.md]
 
 ## 概要
-`dependent_sender`は、[Sender型](sender.md)`Sndr`が依存Senderであることを表すコンセプトである。
+`dependent_sender`は、[Sender型](sender.md)`Sndr`が[非依存Sender](get_completion_signatures.md)か否かを判定するコンセプトである。
 
 説明用の変数テンプレート`is-dependent-sender-helper`を下記の通り定義する。
 

--- a/reference/execution/execution/dependent_sender.md
+++ b/reference/execution/execution/dependent_sender.md
@@ -1,0 +1,53 @@
+# dependent_sender
+* execution[meta header]
+* concept[meta id-type]
+* std::execution[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::execution {
+  template<class Sndr>
+  concept dependent_sender =
+    sender<Sndr> && bool_constant<is-dependent-sender-helper<Sndr>()>::value;
+}
+```
+* sender[link sender.md]
+* bool_constant[link /reference/type_traits/bool_constant.md]
+
+## 概要
+`dependent_sender`は、[Sender型](sender.md)`Sndr`が依存Senderであることを表すコンセプトである。
+
+説明用の変数テンプレート`is-dependent-sender-helper`を下記の通り定義する。
+
+```cpp
+template<class Sndr>
+consteval bool is-dependent-sender-helper() try {  // exposition only
+  get_completion_signatures<Sndr>();
+  return false;
+} catch (dependent_sender_error&) {
+  return true;
+}
+```
+* get_completion_signatures[link get_completion_signatures.md]
+* dependent_sender_error[link dependent_sender_error.md]
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): ??
+- [GCC](/implementation.md#gcc): ??
+- [ICC](/implementation.md#icc): ??
+- [Visual C++](/implementation.md#visual_cpp): ??
+
+
+## 関連項目
+- [`execution::sender`](sender.md)
+- [`execution::get_completion_signatures`](get_completion_signatures.md)
+
+
+## 参照
+- [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/dependent_sender_error.md
+++ b/reference/execution/execution/dependent_sender_error.md
@@ -12,7 +12,7 @@ namespace std::execution {
 * exception[link /reference/exception/exception.md]
 
 ## 概要
-`dependent_sender_error`は、[依存Sender](dependent_sender.md)に対する[完了シグネチャ集合取得](get_completion_signatures.md)時に送出される例外クラスである。
+`dependent_sender_error`は、[依存Sender](dependent_sender.md)に対して[環境](../queryable.md)を指定せずに[完了シグネチャ集合取得](get_completion_signatures.md)を行った際に送出される例外クラスである。
 
 
 ## バージョン
@@ -29,6 +29,7 @@ namespace std::execution {
 ## 関連項目
 - [`execution::dependent_sender`](dependent_sender.md)
 - [`execution::get_completion_signatures`](get_completion_signatures.md)
+
 
 ## 参照
 - [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/dependent_sender_error.md
+++ b/reference/execution/execution/dependent_sender_error.md
@@ -1,21 +1,18 @@
-# completion_signatures_of_t
+# dependent_sender_error
 * execution[meta header]
+* class[meta id-type]
 * std::execution[meta namespace]
-* type-alias[meta id-type]
 * cpp26[meta cpp]
 
 ```cpp
 namespace std::execution {
-  template<class Sndr, class... Env>
-    requires sender_in<Sndr, Env...>
-  using completion_signatures_of_t = decltype(get_completion_signatures<Sndr, Env...>());
+  struct dependent_sender_error : exception {};
 }
 ```
-* sender_in[link sender_in.md]
-* get_completion_signatures[link get_completion_signatures.md]
+* exception[link /reference/exception/exception.md]
 
 ## 概要
-[Sender型](sender.md)`Sndr`から[環境](../queryable.md)`Env`における[完了シグネチャ集合](completion_signatures.md)を取得する。
+`dependent_sender_error`は、[依存Sender](dependent_sender.md)に対する[完了シグネチャ集合取得](get_completion_signatures.md)時に送出される例外クラスである。
 
 
 ## バージョン
@@ -30,9 +27,8 @@ namespace std::execution {
 
 
 ## 関連項目
+- [`execution::dependent_sender`](dependent_sender.md)
 - [`execution::get_completion_signatures`](get_completion_signatures.md)
 
-
 ## 参照
-- [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
 - [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/get_completion_signatures.md
+++ b/reference/execution/execution/get_completion_signatures.md
@@ -15,6 +15,17 @@ namespace std::execution {
 ## 概要
 `get_completion_signatures`は、[Sender](sender.md)の[完了シグネチャ集合](completion_signatures.md)を取得する関数テンプレートである。
 
+### 非依存Sender
+[環境](../queryable.md)に依存することなく完了シグネチャ集合が決定するSenderは、非依存Sender(non-dependent sender)と呼ばれる。
+
+型`Sndr`に対して[`sender`](sender.md)`<Sndr> == true`かつ[`dependent_sender`](dependent_sender.md)`<Sndr> == false`の場合、`Sndr`は非依存Senderである。
+
+
+## テンプレートパラメータ制約
+`sizeof...(Env) <= 1`
+
+
+## 効果
 説明用の式`except`を、[`move_constructible`](/reference/concepts/move_constructible.md)`<Except> &&` [`derived_from`](/reference/concepts/derived_from.md)`<Except,` [`exception`](/reference/exception/exception.md)`>`が`true`となる未規定なクラス`Except`の右辺値とする。`e`がコア定数式かつその型が[`valid-completion-signatures`](completion_signatures.md)を満たすならば、式`CHECKED-COMPLSIGS(e)`を`e`とする。そうでなければ下記の式となる。
 
 ```cpp
@@ -35,12 +46,6 @@ transform_sender(
 * transform_sender[link transform_sender.md]
 * get-domain-late[link get-domain-late.md]
 
-
-## テンプレートパラメータ制約
-`sizeof...(Env) <= 1`
-
-
-## 効果
 下記の通り定義される式`e`を用いて、`return e;`と等価。
 
 - 式`get-complsigs<NewSndr, Env...>()`が適格であるならば、`CHECKED-COMPLSIGS(get-complsigs<NewSndr, Env...>())`
@@ -92,7 +97,7 @@ int main()
   ex::sender auto sndr = ex::just(42);
 
   // 値完了シグネチャ set_value_t(int)
-  auto sigs = ex::get_completion_signatures(sndr);
+  auto sigs = ex::get_completion_signatures<decltype(sndr)>();
   static_assert(std::same_as<decltype(sigs),
     ex::completion_signatures<ex::set_value_t(int)>>);
 }

--- a/reference/execution/execution/impls-for.md
+++ b/reference/execution/execution/impls-for.md
@@ -15,6 +15,9 @@ namespace std::execution {
     static constexpr auto get-state = see below;  // exposition only
     static constexpr auto start = see below;      // exposition only
     static constexpr auto complete = see below;   // exposition only
+
+    template<class Sndr, class... Env>
+    static consteval void check-types();
   };
 }
 ```
@@ -111,6 +114,24 @@ namespace std::execution {
 * callable[link /reference/functional/callable.md]
 * std::move[link /reference/utility/move.md]
 
+### `check-types`メンバ関数
+
+```cpp
+template<class Sndr, class... Env>
+static consteval void default-impls::check-types();
+```
+
+説明用のパック`Is`を、[`indices-for`](basic-sender.md)`<Sndr>`で導入される[`integer_sequence`](/reference/utility/integer_sequence.md)クラス特殊化の整数テンプレート引数とする。
+
+効果：下記と等価。
+
+```cpp
+(get_completion_signatures<child-type<Sndr, Is>, FWD-ENV-T(Env)...>(), ...);
+```
+* get_completion_signatures[link get_completion_signatures.md]
+* child-type[link child-type.md]
+* FWD-ENV-T[link ../forwarding_query.md]
+
 
 ## バージョン
 ### 言語
@@ -125,3 +146,4 @@ namespace std::execution {
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/into_variant.md
+++ b/reference/execution/execution/into_variant.md
@@ -40,11 +40,21 @@ namespace std::execution {
   struct impls-for<into_variant_t> : default-impls {
     static constexpr auto get-state = see below;
     static constexpr auto complete = see below;
+
+    template<class Sndr, class... Env>
+    static consteval void check-types() {
+      auto cs = get_completion_signatures<child-type<Sndr>, FWD-ENV-T(Env)...>();
+      decay-copyable-result-datums(cs);
+    }
   };
 }
 ```
 * impls-for[link impls-for.md]
 * default-impls[link impls-for.md]
+* get_completion_signatures[link get_completion_signatures.md]
+* child-type[link child-type.md]
+* FWD-ENV-T[link ../forwarding_query.md]
+* decay-copyable-result-datums[link decay-copyable-result-datums.md]
 
 `impls-for<into_variant_t>::get-state`メンバは、下記ラムダ式と等価な関数呼び出し可能なオブジェクトで初期化される。
 
@@ -206,4 +216,5 @@ int main()
 ## 参照
 - [P2999R3 Sender Algorithm Customization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2999r3.html)
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)
 - [LWG 4203. Constraints on `get-state` functions are incorrect](https://cplusplus.github.io/LWG/issue4203)

--- a/reference/execution/execution/into_variant.md
+++ b/reference/execution/execution/into_variant.md
@@ -117,6 +117,11 @@ struct FizzBuzzSender {
     ex::set_value_t(int),
     ex::set_value_t(std::string)
   >;
+  template <typename Self>
+  static consteval auto get_completion_signatures()
+  {
+    return completion_signatures{};
+  }
 
   // Operation State型
   template <typename Rcvr>

--- a/reference/execution/execution/let_value.md
+++ b/reference/execution/execution/let_value.md
@@ -17,7 +17,7 @@ namespace std::execution {
 
 `let_value`は[パイプ可能Senderアダプタオブジェクト](sender_adaptor_closure.md)であり、パイプライン記法をサポートする。
 
-本ページにてSenderアルゴリズム`let_value`／[`let_error`](let_error.md)／[`let_stopped`](let_stopped.md)の動作仕様を包括的に説明するため、以降のセクションにおいては、`let-cpo`, `set-cpo`をそれぞれ下記の通りとする。
+本ページにてSenderアルゴリズム`let_value`／[`let_error`](let_error.md)／[`let_stopped`](let_stopped.md)の動作仕様を包括的に説明するため、以降のセクションにおいては`let-cpo`, `set-cpo`をそれぞれ下記の通りとする。
 
 | `let-cpo` | `set-cpo` |
 |----|----|

--- a/reference/execution/execution/let_value.md
+++ b/reference/execution/execution/let_value.md
@@ -147,12 +147,12 @@ cs.for-each(overload-set(fn, [](auto){}));
 * set-cpo[italic]
 
 `unspecified-exception`は[`exception`](/reference/exception/exception.md)から派生した型となる。
-変数`is-valid-let-sender`は下記を全て満たす時に限って`true`となる。
+説明用の変数`is-valid-let-sender`は下記を全て満たす時に限って`true`となる。
 
 - `(`[`constructible_from`](/reference/concepts/constructible_from.md)`<decay_t<Ts>, Ts> &&...)`
-- `invocable<LetFn, decay_t<Ts>&...>`
-- [`sender`](sender.md)`<invoke_result_t<LetFn, decay_t<Ts>&...>>`
-- パック`env-t`を`decltype(let-cpo.transform_env(declval<Sndr>(), declval<Env>()))`としたとき、`sizeof...(Env) == 0 ||` [`sender_in`](sender_in.md)`<invoke_result_t<LetFn, decay_t<Ts>&...>, env-t...>`
+- [`invocable`](/reference/concepts/invocable.md)`<LetFn, decay_t<Ts>&...>`
+- [`sender`](sender.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<LetFn, decay_t<Ts>&...>>`
+- パック`env-t`を`decltype(let-cpo.transform_env(declval<Sndr>(), declval<Env>()))`としたとき、`sizeof...(Env) == 0 ||` [`sender_in`](sender_in.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<LetFn, decay_t<Ts>&...>, env-t...>`
 
 説明用の式`sndr`と`env`に対して、型`Sndr`を`decltype((sndr))`とする。[`sender-for`](sender-for.md)`<Sndr,` [`decayed-typeof`](/reference/functional/decayed-typeof.md)`<let-cpo>> == false`のとき、式`let-cpo.transform_env(sndr, env)`は不適格となる。
 

--- a/reference/execution/execution/let_value.md
+++ b/reference/execution/execution/let_value.md
@@ -48,6 +48,9 @@ namespace std::execution {
   struct impls-for<decayed-typeof<let-cpo>> : default-impls {
     static constexpr auto get-state = see below;
     static constexpr auto complete = see below;
+
+    template<class Sndr, class... Env>
+    static consteval void check-types();
   };
 }
 ```
@@ -122,6 +125,34 @@ namespace std::execution {
 * TRY-EVAL[link set_value.md]
 * std::move[link /reference/utility/move.md]
 * set-cpo[italic]
+
+メンバ関数`impls-for<decayed-typeof<let-cpo>>::check-types`の効果は下記の通り。
+
+```cpp
+using LetFn = remove_cvref_t<data-type<Sndr>>;
+auto cs = get_completion_signatures<child-type<Sndr>, FWD-ENV-T(Env)...>();
+auto fn = []<class... Ts>(decayed-typeof<set-cpo>(*)(Ts...)) {
+  if constexpr (!is-valid-let-sender) 　// see below
+    throw unspecified-exception();
+};
+cs.for-each(overload-set(fn, [](auto){}));
+```
+* data-type[link data-type.md]
+* get_completion_signatures[link get_completion_signatures.md]
+* child-type[link child-type.md]
+* FWD-ENV-T[link ../forwarding_query.md]
+* decayed-typeof[link /reference/functional/decayed-typeof.md]
+* for-each[link completion_signatures.md]
+* overload-set[link overload-set.md]
+* set-cpo[italic]
+
+`unspecified-exception`は[`exception`](/reference/exception/exception.md)から派生した型となる。
+変数`is-valid-let-sender`は下記を全て満たす時に限って`true`となる。
+
+- `(`[`constructible_from`](/reference/concepts/constructible_from.md)`<decay_t<Ts>, Ts> &&...)`
+- `invocable<LetFn, decay_t<Ts>&...>`
+- [`sender`](sender.md)`<invoke_result_t<LetFn, decay_t<Ts>&...>>`
+- パック`env-t`を`decltype(let-cpo.transform_env(declval<Sndr>(), declval<Env>()))`としたとき、`sizeof...(Env) == 0 ||` [`sender_in`](sender_in.md)`<invoke_result_t<LetFn, decay_t<Ts>&...>, env-t...>`
 
 説明用の式`sndr`と`env`に対して、型`Sndr`を`decltype((sndr))`とする。[`sender-for`](sender-for.md)`<Sndr,` [`decayed-typeof`](/reference/functional/decayed-typeof.md)`<let-cpo>> == false`のとき、式`let-cpo.transform_env(sndr, env)`は不適格となる。
 
@@ -407,6 +438,7 @@ catch 0
 - [P2999R3 Sender Algorithm Customization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2999r3.html)
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
 - [P3396R1 std::execution wording fixes](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3396r1.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)
 - [LWG 4203. Constraints on `get-state` functions are incorrect](https://cplusplus.github.io/LWG/issue4203)
 - [LWG 4204. specification of `as-sndr2(Sig)` in [exec.let] is incomplete](https://cplusplus.github.io/LWG/issue4204)
 - [LWG 4205. `let_[*].transform_env` is specified in terms of the `let_*` sender itself instead of its child](https://cplusplus.github.io/LWG/issue4205)

--- a/reference/execution/execution/make-sender.md
+++ b/reference/execution/execution/make-sender.md
@@ -20,9 +20,12 @@ constexpr auto make-sender(Tag tag, Data&& data, Child&&... child);
 
 
 ## 適格要件
-- [`semiregular`](/reference/concepts/semiregular.md)`<Tag> == true`
-- [`movable-value`](../movable-value.md)`<Data> == true`
-- `(`[`sender`](sender.md)`<Child> && ...) == true`
+下記の式が全て`true`であること。
+
+- [`semiregular`](/reference/concepts/semiregular.md)`<Tag>`
+- [`movable-value`](../movable-value.md)`<Data>`
+- `(`[`sender`](sender.md)`<Child> && ...)`
+- 型`Sndr`を[`basic-sender`](basic-sender.md)`<Tag, Data, Child...>`としたとき、[`dependent_sender`](dependent_sender.md)`<Sndr> ||` [`sender_in`](sender_in.md)`<Sndr>`
 
 
 ## 戻り値
@@ -31,6 +34,8 @@ constexpr auto make-sender(Tag tag, Data&& data, Child&&... child);
 
 ## 備考
 テンプレートパラメータ`Data`のデフォルト引数は、[`semiregular`](/reference/concepts/semiregular.md)のモデルである空のトリビアルにコピー可能な未規定なクラス型。
+
+[`sender_in`](sender_in.md)`<Sndr>`の評価結果が[`get_completion_signatures`](get_completion_signatures.md)`<Sndr>()`から送出された例外の場合、処理系（標準ライブラリ実装者）はエラーメッセージにその例外に関する情報を含めることが推奨される。
 
 
 ## バージョン
@@ -45,3 +50,4 @@ constexpr auto make-sender(Tag tag, Data&& data, Child&&... child);
 ## 参照
 - [P2999R3 Sender Algorithm Customization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2999r3.html)
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/not-a-sender.md
+++ b/reference/execution/execution/not-a-sender.md
@@ -1,0 +1,39 @@
+# not-a-sender
+* execution[meta header]
+* class[meta id-type]
+* std::execution[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+struct not-a-sender {
+  using sender_concept = sender_t;
+
+  template<class Sndr>
+    static consteval auto get_completion_signatures() -> completion_signatures<> {
+      throw unspecified-exception();
+  }
+};
+```
+* sender_t[link sender.md]
+* get_completion_signatures[link get_completion_signatures.md]
+* completion_signatures[link completion_signatures.md]
+
+## 概要
+`not-a-sender`は、Senderアルゴリズム動作仕様定義で用いられる説明専用のクラスである。
+
+`unspecified-exception`は[`exception`](/reference/exception/exception.md)から派生した型となる。
+
+
+## バージョン
+### 言語
+- C++26
+
+
+## 関連項目
+- [`execution::on`](on.md)
+- [`execution::stopped_as_optional`](stopped_as_optional.md)
+
+
+## 参照
+- [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/on.md
+++ b/reference/execution/execution/on.md
@@ -127,25 +127,12 @@ transform_sender(
     * set_value_t[link set_value.md]
     * get_env[link get_env.md]
     * query-with-default[link query-with-default.md]
+    * not-a-sender[link not-a-sender.md]
     * write-env[link write-env.md]
     * SCHED-ENV[link scheduler.md]
     * std::move[link /reference/utility/move.md]
 
-説明専用のクラス`not-a-scheduler`を未規定な空のクラス型、`not-a-sender`を下記の通り定義する。
-
-```cpp
-struct not-a-sender {
-  using sender_concept = sender_t;
-
-  auto get_completion_signatures(auto&&) const {
-    return see below;
-  }
-};
-```
-* sender_t[link sender.md]
-
-メンバ関数`get_completion_signatures`は[`completion_signatures`](completion_signatures.md)クラステンプレートの特殊化とは異なる型のオブジェクトを返す。
-処理系（標準ライブラリ実装者）は、この型を用いてユーザにエラー理由を通知することが推奨される。
+説明専用のクラス`not-a-scheduler`を未規定な空のクラス型とする。
 
 
 ## カスタマイゼーションポイント
@@ -328,3 +315,4 @@ val=42
 ## 参照
 - [P2999R3 Sender Algorithm Customization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2999r3.html)
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/overload-set.md
+++ b/reference/execution/execution/overload-set.md
@@ -1,0 +1,30 @@
+# overload-set
+* execution[meta header]
+* class template[meta id-type]
+* std::execution[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+template<class... Fns>
+struct overload-set : Fns... {
+  using Fns::operator()...;
+};
+```
+
+## 概要
+`overload-set`は、Senderアルゴリズム動作仕様定義で用いられる説明専用のクラステンプレートである。
+
+
+## バージョン
+### 言語
+- C++26
+
+
+## 関連項目
+- [`execution::then`](then.md)
+- [`execution::let_value`](let_value.md)
+- [`execution::bulk`](bulk.md)
+
+
+## 参照
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/read_env.md
+++ b/reference/execution/execution/read_env.md
@@ -33,6 +33,9 @@ namespace std::execution {
       [](auto query, auto& rcvr) noexcept -> void {
         TRY-SET-VALUE(rcvr, query(get_env(rcvr)));
       };
+
+    template<class Sndr, class Env>
+    static consteval void check-types();
   };
 }
 ```
@@ -41,6 +44,9 @@ namespace std::execution {
 * default-impls[link impls-for.md]
 * TRY-SET-VALUE[link set_value.md]
 * get_env[link get_env.md]
+
+型`Q`を[`decay_t`](/reference/type_traits/decay.md)`<`[`data-type`](data-type.md)`<Sndr>>`とする。
+`Env`型の左辺値`env`に対して式`Q()(env)`が不適格もしくは`void`型をもつとき、メンバ関数`check-types`は[`exception`](/reference/exception/exception.md)から派生した未規定の型を例外として送出する。
 
 
 ## 備考
@@ -96,3 +102,4 @@ int main()
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/run_loop/get_scheduler.md
+++ b/reference/execution/execution/run_loop/get_scheduler.md
@@ -34,8 +34,8 @@ int main()
   ex::sender auto sndr = ex::schedule(sch);
 
   // スケジュールSenderの完了シグネチャ集合を確認
-  auto sigs = ex::get_completion_signatures(sndr);
-  static_assert(std::same_as<decltype(sigs),
+  using Sigs = ex::completion_signatures_of_t<decltype(sndr)>;
+  static_assert(std::same_as<Sigs,
     ex::completion_signatures<ex::set_value_t(),
                               ex::set_error_t(std::exception_ptr),
                               ex::set_stopped_t()>>);
@@ -50,7 +50,7 @@ int main()
 * ex::scheduler[link ../scheduler.md]
 * ex::sender[link ../sender.md]
 * ex::schedule[link ../schedule.md]
-* ex::get_completion_signatures[link ../get_completion_signatures.md]
+* ex::completion_signatures_of_t[link ../completion_signatures_of_t.md]
 * ex::completion_signatures[link ../completion_signatures.md]
 * ex::set_value_t[link ../set_value.md]
 * ex::set_error_t[link ../set_error.md]

--- a/reference/execution/execution/run_loop/run-loop-sender.md
+++ b/reference/execution/execution/run_loop/run-loop-sender.md
@@ -14,7 +14,7 @@ class run-loop-sender;  // exposition only
 
 ## クラス仕様
 - `run-loop-sender`型は[`sender`](../sender.md)のモデルである。
-- 任意の型`Env`に対して、[`completion_signatures_of_t`](../completion_signatures_of_t.md)`<run-loop-sender, Env>`は[`completion_signatures`](../completion_signatures.md)`<`[`set_value_t`](../set_value.md)`(),` [`set_error_t`](../set_error.md)`(`[`exception_ptr`](/reference/exception/exception_ptr.md)`),` [`set_stopped_t`](../set_stopped.md)`()>`
+- [`completion_signatures_of_t`](../completion_signatures_of_t.md)`<run-loop-sender>`は[`completion_signatures`](../completion_signatures.md)`<`[`set_value_t`](../set_value.md)`(),` [`set_error_t`](../set_error.md)`(`[`exception_ptr`](/reference/exception/exception_ptr.md)`),` [`set_stopped_t`](../set_stopped.md)`()>`
 - `run-loop-sender`インスタンスは、関連付けられた[`run_loop`](../run_loop.md)インスタンスの生存期間(lifetime)終了まで有効。
 - 説明用の式`sndr`の型を`run-loop-sender`、`CS`が上記[`completion_signatures`](../completion_signatures.md)の特殊化であるとき[`receiver_of`](../receiver_of.md)`<decltype((rcvr)), CS>`が`true`となる式`rcvr`としたとき、
     - 式[`connect`](../connect.md)`(sndr, rcvr)`の型は[`run-loop-opstate`](run-loop-opstate.md)`<`[`decay_t`](/reference/type_traits/decay.md)`<decltype((rcvr))>>`であり、潜在的な例外送出(potentially-throwing)は式`(void(sndr), auto(rcvr))`に従う。
@@ -34,3 +34,4 @@ class run-loop-sender;  // exposition only
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/schedule_from.md
+++ b/reference/execution/execution/schedule_from.md
@@ -45,6 +45,9 @@ namespace std::execution {
     static constexpr auto get-attrs = see below;
     static constexpr auto get-state = see below;
     static constexpr auto complete = see below;
+
+    template<class Sndr, class... Env>
+    static consteval void check-types();
   };
 }
 ```
@@ -135,6 +138,19 @@ namespace std::execution {
 * exception_ptr[link /reference/exception/exception_ptr.md]
 * current_exception()[link /reference/exception/current_exception.md]
 
+メンバ関数`impls-for<schedule_from_t>::check-types`の効果は下記の通り。
+
+```cpp
+get_completion_signatures<schedule_result_t<data-type<Sndr>>, FWD-ENV-T(Env)...>();
+auto cs = get_completion_signatures<child-type<Sndr>, FWD-ENV-T(Env)...>();
+decay-copyable-result-datums(cs);
+```
+* get_completion_signatures[link get_completion_signatures.md]
+* schedule_result_t[link schedule_result_t.md]
+* data-type[link data-type.md]
+* FWD-ENV-T[link ../forwarding_query.md]
+* decay-copyable-result-datums[link decay-copyable-result-datums.md]
+
 
 ## 説明専用エンティティ
 説明専用のクラス`receiver-type`を下記の通り定義する。
@@ -211,5 +227,6 @@ Senderアルゴリズム構築時および[Receiver](receiver.md)接続時に、
 - [P2999R3 Sender Algorithm Customization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2999r3.html)
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
 - [P3396R1 std::execution wording fixes](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3396r1.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)
 - [LWG 4198. `schedule_from` isn't starting the schedule sender if decay-copying results throws](https://cplusplus.github.io/LWG/issue4198)
 - [LWG 4203. Constraints on `get-state` functions are incorrect](https://cplusplus.github.io/LWG/issue4203)

--- a/reference/execution/execution/scheduler.md
+++ b/reference/execution/execution/scheduler.md
@@ -45,28 +45,7 @@ namespace std::execution {
 
 
 ## モデル
-説明専用のエイリアステンプレート`value-signature`, コンセプト`sender-in-of`を下記の通り定義する。
-
-```cpp
-namespace std::execution {
-  template<class... As>
-  using value-signature = set_value_t(As...);
-
-  template<class Sndr, class Env, class... Values>
-  concept sender-in-of =
-    sender_in<Sndr, Env> &&
-    MATCHING-SIG(
-      set_value_t(Values...),
-      value_types_of_t<Sndr, Env, value-signature, type_identity_t>);
-}
-```
-* set_value_t[link set_value.md]
-* sender_in[link sender_in.md]
-* MATCHING-SIG[link get_completion_signatures.md]
-* value_types_of_t[link value_types_of_t.md]
-* type_identity_t[link /reference/type_traits/true_type.md]
-
-型`Sch`を`scheduler`の型、型`Env`を[`sender_in`](sender_in.md)`<`[`schedule_result_t`](schedule_result_t.md)`<Sch>, Env>`を満たす実行環境の型としたとき、`sender-in-of<`[`schedule_result_t`](schedule_result_t.md)`<Sch>, Env>`のモデルとなること。
+型`Sch`を`scheduler`の型、型`Env`を[`sender_in`](sender_in.md)`<`[`schedule_result_t`](schedule_result_t.md)`<Sch>, Env>`を満たす実行環境の型としたとき、[`sender-in-of`](sender-in-of.md)`<`[`schedule_result_t`](schedule_result_t.md)`<Sch>, Env>`のモデルとなること。
 
 [`copyable`](/reference/concepts/copyable.md)`<remove_cvref_t<Sch>>`および[`equality_comparable`](/reference/concepts/equality_comparable.md)`<remove_cvref_t<Sch>>`により要求される操作は、例外で終了してはならない。
 これらの操作やScheduler型の[`schedule`](schedule.md)関数は、異なるスレッドから同時に操作を呼び出す可能性がある場合でも、データ競合を引き起こしてはならない。

--- a/reference/execution/execution/sender-in-of.md
+++ b/reference/execution/execution/sender-in-of.md
@@ -26,7 +26,7 @@ namespace std::execution {
 
   template<class Sndr, class SetValue, class... Env>
   concept sender-in-of-impl =  // exposition only
-    sender_in<Sndr, Env> &&
+    sender_in<Sndr, Env...> &&
     MATCHING-SIG(SetValue,
                  gather-signatures<set_value_t,
                                   completion_signatures_of_t<Sndr, Env...>,

--- a/reference/execution/execution/sender-in-of.md
+++ b/reference/execution/execution/sender-in-of.md
@@ -1,0 +1,63 @@
+# sender-in-of
+* execution[meta header]
+* concept[meta id-type]
+* std::execution[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::execution {
+  template<class Sndr, class Env, class... Values>
+  concept sender-in-of = see below;
+
+  template<class Sndr, class... Values>
+  concept sender-of = see below;
+}
+```
+
+## 概要
+`sender-in-of`および`sender-of`は、実行制御ライブラリの仕様定義で用いられる説明専用のコンセプトである。
+
+説明用のエイリアステンプレート`value-signature`, コンセプト`sender-in-of-impl`, `sender-in-of`, `sender-of`を下記の通り定義する。
+
+```cpp
+namespace std::execution {
+  template<class... As>
+  using value-signature = set_value_t(As...);  // exposition only
+
+  template<class Sndr, class SetValue, class... Env>
+  concept sender-in-of-impl =  // exposition only
+    sender_in<Sndr, Env> &&
+    MATCHING-SIG(SetValue,
+                 gather-signatures<set_value_t,
+                                  completion_signatures_of_t<Sndr, Env...>,
+                                  value-signature,
+                                  type_identity_t>);
+
+  template<class Sndr, class Env, class... Values>
+  concept sender-in-of =  // exposition only
+    sender-in-of-impl<Sndr, set_value_t(Values...), Env>;
+
+  template<class Sndr, class... Values>
+  concept sender-of =  // exposition only
+    sender-in-of-impl<Sndr, set_value_t(Values...)>;
+}
+```
+* set_value_t[link set_value.md]
+* sender_in[link sender_in.md]
+* MATCHING-SIG[link get_completion_signatures.md]
+* gather-signatures[link gather-signatures.md]
+* completion_signatures_of_t[link completion_signatures_of_t.md]
+* type_identity_t[link /reference/type_traits/true_type.md]
+
+
+## バージョン
+### 言語
+- C++26
+
+
+## 関連項目
+- [`execution::scheduler`](scheduler.md)
+
+
+## 参照
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/sender_in.md
+++ b/reference/execution/execution/sender_in.md
@@ -6,24 +6,27 @@
 
 ```cpp
 namespace std::execution {
-  template<class Sndr, class Env = env<>>
+  template<class Sndr, class... Env>
   concept sender_in =
     sender<Sndr> &&
-    queryable<Env> &&
-    requires (Sndr&& sndr, Env&& env) {
-      { get_completion_signatures(std::forward<Sndr>(sndr), std::forward<Env>(env)) }
-        -> valid-completion-signatures;
-    };
+    (sizeof...(Env) <= 1) &&
+    (queryable<Env> && ...) &&
+    is-constant<get_completion_signatures<Sndr, Env...>()>;
 }
 ```
-* env<>[link env.md]
 * sender[link sender.md]
 * queryable[link ../queryable.md]
 * get_completion_signatures[link get_completion_signatures.md]
-* valid-completion-signatures[link completion_signatures.md]
 
 ## 概要
 `sender_in`は、[Sender型](sender.md)`Sndr`が[環境](../queryable.md)`Env`において非同期操作を作成できることを表すコンセプトである。
+
+説明用のコンセプト`is-constant`を下記の通り定義する。
+
+```cpp
+template <auto>
+concept is-constant = true;  // exposition only
+```
 
 
 ## モデル
@@ -42,13 +45,12 @@ namespace ex = std::execution;
 int main()
 {
   ex::sender auto sndr = ex::just(42);
-  static_assert(ex::sender_in<decltype(sndr), ex::env<>>);
+  static_assert(ex::sender_in<decltype(sndr)>);
 }
 ```
 * ex::sender_in[color ff0000]
 * ex::sender[link sender.md]
 * ex::just[link just.md]
-* ex::env<>[link env.md]
 
 ### 出力
 ```
@@ -73,3 +75,4 @@ int main()
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/single-sender-value-type.md
+++ b/reference/execution/execution/single-sender-value-type.md
@@ -5,19 +5,21 @@
 * cpp26[meta cpp]
 
 ```cpp
-template<class Sndr, class Env>
+template<class Sndr, class... Env>
 using single-sender-value-type = see below;  // exposition only
 ```
 
 ## 概要
 `single-sender-value-type`は、実行制御ライブラリの仕様定義で用いられる説明専用のエイリアステンプレートである。
 
-型`Sndr`と`Env`に対して、`single-sender-value-type<Sndr, Env>`は下記のエイリアスとなる。
+型`Sndr`と型パック`Env`に対して、`CS`を[`completion_signatures_of_t`](completion_signatures_of_t.md)`<Sndr, Env...>`とする。`CS`が不適格または`sizeof...(Env) > 1`のとき、`single-sender-value-type<Sndr, Env...>`は不適格となる。
 
-- [`value_types_of_t`](value_types_of_t.md)`<Sndr, Env,` [`decay_t`](/reference/type_traits/decay.md)`,` [`type_identity_t`](/reference/type_traits/type_identity.md)`>`が適格であるならば、その型。
-- そうではなく、[`value_types_of_t`](value_types_of_t.md)`<Sndr, Env,` [`tuple`](/reference/tuple/tuple.md)`,` [`variant`](/reference/variant/variant.md)`>`が`variant<tuple<>>`もしくは`variant<>`ならば、`void`型。
-- [`value_types_of_t`](value_types_of_t.md)`<Sndr, Env,` [`decayed-tuple`](decayed-tuple.md)`,` [`type_identity_t`](/reference/type_traits/type_identity.md)`>`が適格であるならば、その型。
-- そうでなければ、`single-sender-value-type<Sndr, Env>`は不適格。
+そうでなければ、`single-sender-value-type<Sndr, Env...>`は下記のエイリアスとなる。
+
+- [`gather-signatures`](gather-signatures.md)`<`[`set_value_t`](set_value.md)`, CS,` [`decay_t`](/reference/type_traits/decay.md)`,` [`type_identity_t`](/reference/type_traits/type_identity.md)`>`が適格であるならば、その型。
+- そうではなく、[`gather-signatures`](gather-signatures.md)`<`[`set_value_t`](set_value.md)`, CS,` [`tuple`](/reference/tuple/tuple.md)`,` [`variant`](/reference/variant/variant.md)`>`が`variant<tuple<>>`もしくは`variant<>`ならば、`void`型。
+- そうではなく、[`gather-signatures`](gather-signatures.md)`<`[`set_value_t`](set_value.md)`, CS,` [`decayed-tuple`](decayed-tuple.md)`,` [`type_identity_t`](/reference/type_traits/type_identity.md)`>`が適格であるならば、その型。
+- そうでなければ、`single-sender-value-type<Sndr, Env...>`は不適格。
 
 
 ## バージョン
@@ -32,3 +34,4 @@ using single-sender-value-type = see below;  // exposition only
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/single-sender.md
+++ b/reference/execution/execution/single-sender.md
@@ -5,10 +5,10 @@
 * cpp26[meta cpp]
 
 ```cpp
-template<class Sndr, class Env>
-concept single-sender = sender_in<Sndr, Env> &&
+template<class Sndr, class... Env>
+concept single-sender = sender_in<Sndr, Env...> &&
   requires {
-    typename single-sender-value-type<Sndr, Env>;
+    typename single-sender-value-type<Sndr, Env...>;
   };
 ```
 * sender_in[link sender_in.md]
@@ -29,3 +29,4 @@ concept single-sender = sender_in<Sndr, Env> &&
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/stopped_as_error.md
+++ b/reference/execution/execution/stopped_as_error.md
@@ -70,10 +70,16 @@ namespace ex = std::execution;
 //   停止完了 set_stopped()
 struct MySender {
   using sender_concept = ex::sender_t;
+
   using completion_signatures = ex::completion_signatures<
     ex::set_value_t(int),
     ex::set_stopped_t()
   >;
+  template <typename Self>
+  static consteval auto get_completion_signatures()
+  {
+    return completion_signatures{};
+  }
 
   template <typename Rcvr>
   struct state {

--- a/reference/execution/execution/stopped_as_optional.md
+++ b/reference/execution/execution/stopped_as_optional.md
@@ -99,10 +99,16 @@ namespace ex = std::execution;
 //   停止完了 set_stopped()
 struct MySender {
   using sender_concept = ex::sender_t;
+
   using completion_signatures = ex::completion_signatures<
     ex::set_value_t(int),
     ex::set_stopped_t()
   >;
+  template <typename Self>
+  static consteval auto get_completion_signatures()
+  {
+    return completion_signatures{};
+  }
 
   template <typename Rcvr>
   struct state {

--- a/reference/execution/execution/stopped_as_optional.md
+++ b/reference/execution/execution/stopped_as_optional.md
@@ -30,7 +30,33 @@ transform_sender(get-domain-early(sndr), make-sender(stopped_as_optional, {}, sn
 
 
 ### Senderアルゴリズムタグ `stopped_as_optional`
-説明用の式`sndr`と`env`に対して、型`Sndr`を`decltype((sndr))`、型`Env`を`decltype((env))`とする。[`sender-for`](sender-for.md)`<Sndr, stopped_as_optional_t> == false`、もしくは[`single-sender-value-type`](single-sender-value-type.md)`<`[`child-type`](child-type.md)`<Sndr>,` [`FWD-ENV-T`](../forwarding_query.md)`(Env)>`が不適格または`void`のとき、式`stopped_as_optional.transform_sender(sndr, env)`は不適格となる。
+Senderアルゴリズム動作説明用のクラステンプレート[`impls-for`](impls-for.md)に対して、下記の特殊化が定義される。
+
+```cpp
+namespace std::execution {
+  template<>
+  struct impls-for<stopped_as_optional_t> : default-impls {
+    template<class Sndr, class... Env>
+    static consteval void check-types() {
+      default-impls::check-types<Sndr, Env...>();
+      if constexpr (!requires {
+        requires (!same_as<void, single-sender-value-type<child-type<Sndr>, FWD-ENV-T(Env)...>>); })
+        throw unspecified-exception();
+      }
+  };
+}
+```
+* impls-for[link impls-for.md]
+* default-impls[link impls-for.md]
+* single-sender-value-type[link single-sender-value-type.md]
+* child-type[link child-type.md]
+* FWD-ENV-T[link ../forwarding_query.md]
+
+`unspecified-exception`は[`exception`](/reference/exception/exception.md)から派生した型となる。
+
+説明用の式`sndr`と`env`に対して、型`Sndr`を`decltype((sndr))`、型`Env`を`decltype((env))`とする。[`sender-for`](sender-for.md)`<Sndr, stopped_as_optional_t> == false`のとき、式`stopped_as_optional.transform_sender(sndr, env)`は不適格となる。
+
+そうではなく、[`sender_in`](sender_in.md)`<`[`child-type`](child-type.md)`<Sndr>,` [`FWD-ENV-T`](../forwarding_query.md)`(Env)> == false`のとき、式`stopped_as_optional.transform_sender(sndr, env)`は[`not-a-sender()`](not-a-sender.md)と等価。
 
 そうでなければ、式`stopped_as_optional.transform_sender(sndr, env)`は下記と等価。
 
@@ -166,4 +192,5 @@ stopped
 ## 参照
 - [P2999R3 Sender Algorithm Customization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2999r3.html)
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)
 - [LWG 4203. Constraints on `get-state` functions are incorrect](https://cplusplus.github.io/LWG/issue4203)

--- a/reference/execution/execution/then.md
+++ b/reference/execution/execution/then.md
@@ -48,6 +48,9 @@ namespace std::execution {
             Tag()(std::move(rcvr), std::forward<Args>(args)...);
           }
         };
+
+    template<class Sndr, class... Env>
+    static consteval void check-types();
   };
 }
 ```
@@ -58,6 +61,24 @@ namespace std::execution {
 * TRY-SET-VALUE[link set_value.md]
 * invoke[link /reference/functional/invoke.md]
 * std::move[link /reference/utility/move.md]
+
+メンバ関数`impls-for<decayed-typeof<then>>::check-types`の効果は下記の通り。
+
+```cpp
+auto cs = get_completion_signatures<child-type<Sndr>, FWD-ENV-T(Env)...>();
+auto fn = []<class... Ts>(set_value_t(*)(Ts...)) {
+  if constexpr (!invocable<remove_cvref_t<data-type<Sndr>>, Ts...>)
+    throw unspecified-exception();
+};
+cs.for-each(overload-set{fn, [](auto){}});
+```
+* get_completion_signatures[link get_completion_signatures.md]
+* child-type[link child-type.md]
+* FWD-ENV-T[link ../forwarding_query.md]
+* set_value_t[link set_value.md]
+* data-type[link data-type.md]
+
+`unspecified-exception`は[`exception`](/reference/exception/exception.md)から派生した型となる。
 
 
 ## カスタマイゼーションポイント
@@ -130,3 +151,4 @@ C++
 ## 参照
 - [P2999R3 Sender Algorithm Customization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2999r3.html)
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/then.md
+++ b/reference/execution/execution/then.md
@@ -68,6 +68,8 @@ namespace std::execution {
 * TRY-SET-VALUE[link set_value.md]
 * invoke[link /reference/functional/invoke.md]
 * std::move[link /reference/utility/move.md]
+* then-cpo[italic]
+* set-cpo[italic]
 
 メンバ関数`impls-for<decayed-typeof<then-cpo>>::check-types`の効果は下記の通り。
 
@@ -84,6 +86,8 @@ cs.for-each(overload-set{fn, [](auto){}});
 * FWD-ENV-T[link ../forwarding_query.md]
 * set_value_t[link set_value.md]
 * data-type[link data-type.md]
+* for-each[link completion_signatures.md]
+* overload-set[link overload-set.md]
 
 `unspecified-exception`は[`exception`](/reference/exception/exception.md)から派生した型となる。
 

--- a/reference/execution/execution/upon_error.md
+++ b/reference/execution/execution/upon_error.md
@@ -18,56 +18,7 @@ namespace std::execution {
 `upon_error`は[パイプ可能Senderアダプタオブジェクト](sender_adaptor_closure.md)であり、パイプライン記法をサポートする。
 
 
-## 効果
-説明用の式`sndr`と`f`に対して、`decltype((sndr))`が[`sender`](sender.md)を満たさない、もしくは`decltype((f))`が[`movable-value`](../movable-value.md)を満たさないとき、呼び出し式`upon_error(sndr, f)`は不適格となる。
-
-そうでなければ、呼び出し式`upon_error(sndr, f)`は`sndr`が1回だけ評価されることを除いて、下記と等価。
-
-```cpp
-transform_sender(get-domain-early(sndr), make-sender(upon_error, f, sndr))
-```
-* transform_sender[link transform_sender.md]
-* get-domain-early[link get-domain-early.md]
-* make-sender[link make-sender.md]
-
-
-### Senderアルゴリズムタグ `upon_error`
-Senderアルゴリズム動作説明用のクラステンプレート[`impls-for`](impls-for.md)に対して、下記の特殊化が定義される。
-
-```cpp
-namespace std::execution {
-  template<>
-  struct impls-for<decayed-typeof<upon_error>> : default-impls {
-    static constexpr auto complete =
-      []<class Tag, class... Args>
-        (auto, auto& fn, auto& rcvr, Tag, Args&&... args) noexcept -> void {
-          if constexpr (same_as<Tag, decayed-typeof<set_error>>) {
-            TRY-SET-VALUE(rcvr,
-                          invoke(std::move(fn), std::forward<Args>(args)...));
-          } else {
-            Tag()(std::move(rcvr), std::forward<Args>(args)...);
-          }
-        };
-  };
-}
-```
-* decayed-typeof[link /reference/functional/decayed-typeof.md]
-* impls-for[link impls-for.md]
-* default-impls[link impls-for.md]
-* set_error[link set_error.md]
-* TRY-SET-VALUE[link set_value.md]
-* invoke[link /reference/functional/invoke.md]
-* std::move[link /reference/utility/move.md]
-
-
-## カスタマイゼーションポイント
-Senderアルゴリズム構築時および[Receiver](receiver.md)接続時に、関連付けられた実行ドメインに対して[`execution::transform_sender`](transform_sender.md)経由でSender変換が行われる。
-[デフォルト実行ドメイン](default_domain.md)では無変換。
-
-戻り値の[Sender](sender.md)`out_sndr`が下記を満たさない場合、呼び出し式`upon_error(sndr, f)`の動作は未定義となる。
-
-- `upon_error`に対する`sndr`のエラー結果データで`f`またはそのコピーを呼び出し、`out_sndr`の値完了として`f`の結果値を用いること。
-- 他の完了操作では変更なしに転送すること。
+Senderアルゴリズム`upon_error`の仕様は、[`then`](then.md)ページを参照のこと。
 
 
 ## 例

--- a/reference/execution/execution/upon_stopped.md
+++ b/reference/execution/execution/upon_stopped.md
@@ -17,57 +17,7 @@ namespace std::execution {
 
 `upon_stopped`は[パイプ可能Senderアダプタオブジェクト](sender_adaptor_closure.md)であり、パイプライン記法をサポートする。
 
-
-## 効果
-説明用の式`sndr`と`f`に対して、`decltype((sndr))`が[`sender`](sender.md)を満たさない、もしくは`decltype((f))`が[`movable-value`](../movable-value.md)を満たさないとき、呼び出し式`upon_stopped(sndr, f)`は不適格となる。
-
-そうでなければ、呼び出し式`upon_stopped(sndr, f)`は`sndr`が1回だけ評価されることを除いて、下記と等価。
-
-```cpp
-transform_sender(get-domain-early(sndr), make-sender(upon_stopped, f, sndr))
-```
-* transform_sender[link transform_sender.md]
-* get-domain-early[link get-domain-early.md]
-* make-sender[link make-sender.md]
-
-
-### Senderアルゴリズムタグ `upon_stopped`
-Senderアルゴリズム動作説明用のクラステンプレート[`impls-for`](impls-for.md)に対して、下記の特殊化が定義される。
-
-```cpp
-namespace std::execution {
-  template<>
-  struct impls-for<decayed-typeof<upon_stopped>> : default-impls {
-    static constexpr auto complete =
-      []<class Tag, class... Args>
-        (auto, auto& fn, auto& rcvr, Tag, Args&&... args) noexcept -> void {
-          if constexpr (same_as<Tag, decayed-typeof<set_stopped>>) {
-            TRY-SET-VALUE(rcvr,
-                          invoke(std::move(fn), std::forward<Args>(args)...));
-          } else {
-            Tag()(std::move(rcvr), std::forward<Args>(args)...);
-          }
-        };
-  };
-}
-```
-* decayed-typeof[link /reference/functional/decayed-typeof.md]
-* impls-for[link impls-for.md]
-* default-impls[link impls-for.md]
-* set_stopped[link set_stopped.md]
-* TRY-SET-VALUE[link set_value.md]
-* invoke[link /reference/functional/invoke.md]
-* std::move[link /reference/utility/move.md]
-
-
-## カスタマイゼーションポイント
-Senderアルゴリズム構築時および[Receiver](receiver.md)接続時に、関連付けられた実行ドメインに対して[`execution::transform_sender`](transform_sender.md)経由でSender変換が行われる。
-[デフォルト実行ドメイン](default_domain.md)では無変換。
-
-戻り値の[Sender](sender.md)`out_sndr`が下記を満たさない場合、呼び出し式`upon_stopped(sndr, f)`の動作は未定義となる。
-
-- `upon_stopped`に対する`sndr`の停止結果データで`f`またはそのコピーを呼び出し、`out_sndr`の値完了として`f`の結果値を用いること。
-- 他の完了操作では変更なしに転送すること。
+Senderアルゴリズム`upon_stopped`の仕様は、[`then`](then.md)ページを参照のこと。
 
 
 ## 例

--- a/reference/execution/execution/when_all.md
+++ b/reference/execution/execution/when_all.md
@@ -29,8 +29,7 @@ namespace std::execution {
 下記いずれかが`true`となるとき、呼び出し式`when_all(sndrs...)`は不適格となる。
 
 - `sizeof...(sndrs) == 0`、または
-- `(`[`sender`](sender.md)`<Sndrs> && ...) == false`、または
-- 型`CD`が不適格
+- `(`[`sender`](sender.md)`<Sndrs> && ...) == false`
 
 そうでなければ、呼び出し式`when_all(sndrs...)`は下記と等価。
 

--- a/reference/execution/execution/when_all.md
+++ b/reference/execution/execution/when_all.md
@@ -398,11 +398,17 @@ namespace ex = std::execution;
 //   停止完了   set_stopped()
 struct MySender {
   using sender_concept = ex::sender_t;
+
   using completion_signatures = ex::completion_signatures<
     ex::set_value_t(std::string),
     ex::set_error_t(int),
     ex::set_stopped_t()
   >;
+  template <typename Self>
+  static consteval auto get_completion_signatures()
+  {
+    return completion_signatures{};
+  }
 
   template <typename Rcvr>
   struct state {

--- a/reference/execution/execution/when_all_with_variant.md
+++ b/reference/execution/execution/when_all_with_variant.md
@@ -73,11 +73,17 @@ namespace ex = std::execution;
 //   エラー完了 set_error(int)
 struct MySender {
   using sender_concept = ex::sender_t;
+
   using completion_signatures = ex::completion_signatures<
     ex::set_value_t(int),
     ex::set_value_t(std::string),
     ex::set_error_t(int)
   >;
+  template <typename Self>
+  static consteval auto get_completion_signatures()
+  {
+    return completion_signatures{};
+  }
 
   template <typename Rcvr>
   struct state {

--- a/reference/execution/execution/when_all_with_variant.md
+++ b/reference/execution/execution/when_all_with_variant.md
@@ -29,8 +29,7 @@ namespace std::execution {
 下記いずれかが`true`となるとき、呼び出し式`when_all_with_variant(sndrs...)`は不適格となる。
 
 - `sizeof...(sndrs) == 0`、または
-- `(`[`sender`](sender.md)`<Sndrs> && ...) == false`、または
-- 型`CD`が不適格
+- `(`[`sender`](sender.md)`<Sndrs> && ...) == false`
 
 そうでなければ、呼び出し式`when_all_with_variant(sndrs...)`は下記と等価。
 

--- a/reference/execution/execution/when_all_with_variant.md
+++ b/reference/execution/execution/when_all_with_variant.md
@@ -24,7 +24,7 @@ namespace std::execution {
 
 
 ## 効果
-説明用のパック`sndrs`に対してパック`Sndrs`を`decltype((sndrs))...`としたとき、型`CD`を[`common_type_t`](/reference/type_traits/common_type.md)`<decltype(`[`get-domain-early`](get-domain-early.md)`(sndrs))...>`とする。
+説明用のパック`sndrs`に対してパック`Sndrs`を`decltype((sndrs))...`としたとき、型`CD`を[`common_type_t`](/reference/type_traits/common_type.md)`<decltype(`[`get-domain-early`](get-domain-early.md)`(sndrs))...>`とする。型`CD`が適格ならば型`CD2`を`CD`とし、そうでなければ[`default_domain`](default_domain.md)とする。
 
 下記いずれかが`true`となるとき、呼び出し式`when_all_with_variant(sndrs...)`は不適格となる。
 
@@ -35,7 +35,7 @@ namespace std::execution {
 そうでなければ、呼び出し式`when_all_with_variant(sndrs...)`は下記と等価。
 
 ```cpp
-transform_sender(CD(), make-sender(when_all_with_variant, {}, sndrs...))
+transform_sender(CD2(), make-sender(when_all_with_variant, {}, sndrs...))
 ```
 * transform_sender[link transform_sender.md]
 * make-sender[link make-sender.md]
@@ -184,3 +184,4 @@ int main()
 ## 参照
 - [P2999R3 Sender Algorithm Customization](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2999r3.html)
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/execution/write-env.md
+++ b/reference/execution/execution/write-env.md
@@ -30,19 +30,29 @@ Senderアルゴリズム動作説明用のクラステンプレート[`impls-for
 ```cpp
 template<>
 struct impls-for<write-env-t> : default-impls {
+  static constexpr auto join-env(const auto& state, const auto& env) noexcept {
+    return see below;
+  }
+
   static constexpr auto get-env =
     [](auto, const auto& state, const auto& rcvr) noexcept {
-      return see below;
+      return join-env(state, FWD-ENV(get_env(rcvr)));
     };
+
+  template<class Sndr, class... Env>
+  static consteval void check-types();
 };
 ```
 * impls-for[link impls-for.md]
 * default-impls[link impls-for.md]
+* FWD-ENV[link ../forwarding_query.md]
+* get_env[link get_env.md]
 
-`impls-for<write-env-t>::get-env`メンバの呼び出しは下記を満たすオブジェクト`e`を返す。
+`impls-for<write-env-t>::join-env`メンバの呼び出しは下記を満たすオブジェクト`e`を返す。
 
 - 型`decltype(e)`が[`queryable`](../queryable.md)のモデルであり、かつ
-- 与えられた[クエリオブジェクト](../queryable.md)`q`に対して、式`e.query(q)`は式`state.query(q)`が有効ならばその式と等価。そうでなければ、式`e.query(q)`は[`get_env`](get_env.md)`(rcvr).query(q)`と等価。
+- 与えられた[クエリオブジェクト](../queryable.md)`q`に対して、式`e.query(q)`は式`state.query(q)`が有効ならばその式と等価。そうでなければ、式`e.query(q)`は`env.query(q)`と等価。
+- 型`Sndr`と型パック`Env`に対して、型`State`を[`data-type`](data-type.md)`<Sndr>`とし、パック`JoinEnv`を`decltype(join-env(declval<State>(),` [`FWD-ENV`](../forwarding_query.md)`(declval<Env>())))`とする。式`impls-for<write-env-t>::check-types<Sndr, Env...>()`は[`get_completion_signatures`](get_completion_signatures.md)`<`[`child-type`](child-type.md)`<Sndr>, JoinEnv...>()`と等価。
 
 
 ## バージョン
@@ -57,3 +67,4 @@ struct impls-for<write-env-t> : default-impls {
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
 - [P3396R1 std::execution wording fixes](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3396r1.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/is-awaitable.md
+++ b/reference/execution/is-awaitable.md
@@ -5,7 +5,7 @@
 * cpp26[meta cpp]
 
 ```cpp
-template<class C, class Promise>
+template<class C, class... Promise>
 concept is-awaitable;
 ```
 
@@ -19,15 +19,17 @@ concept is-awaitable;
 - （有効ならば）Promise型の`await_transform`メンバ関数を適用
 - （有効ならば）`co_await`演算子オーバーロードを適用
 
+`await_transform`メンバ関数を持たず[`coroutine_handle`](/reference/coroutine/coroutine_handle.md)`<none-such>`が`coroutine_handle<void>`と同様に振る舞う未規定の空のクラス`none-such`の左辺値`p`を用いて、説明用の式`GET-AWAITER(c)`は`GET-AWAITER(c, p)`と等価とする。
+
 また、説明用のコンセプト`await-suspend-result`, `is-awaiter`を以下のように定義する。
 
 ```cpp
 template<class T>
 concept await-suspend-result = see below;
 
-template<class A, class Promise>
+template<class A, class... Promise>
 concept is-awaiter =
-  requires (A& a, coroutine_handle<Promise> h) {
+  requires (A& a, coroutine_handle<Promise...> h) {
     a.await_ready() ? 1 : 0;
     { a.await_suspend(h) } -> await-suspend-result;
     a.await_resume();
@@ -44,10 +46,10 @@ concept is-awaiter =
 `is-awaitable`コンセプトは、以下のように定義される。
 
 ```cpp
-template<class C, class Promise>
+template<class C, class... Promise>
 concept is-awaitable =
-  requires (C (*fc)() noexcept, Promise& p) {
-    { GET-AWAITER(fc(), p) } -> is-awaiter<Promise>;
+  requires (C (*fc)() noexcept, Promise&... p) {
+    { GET-AWAITER(fc(), p...) } -> is-awaiter<Promise...>;
   };
 ```
 * GET-AWAITER[italic]
@@ -64,3 +66,4 @@ concept is-awaitable =
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/this_thread/sync_wait.md
+++ b/reference/execution/this_thread/sync_wait.md
@@ -24,9 +24,7 @@ namespace std::this_thread {
 ## 効果
 説明用の`sndr`を`decltype((sndr))`が`Sndr`型となる式とする。
 
-[`sender_in`](../execution/sender_in.md)`<Sndr,` [`sync-wait-env`](sync-wait-env.md)`> == false`のとき、呼び出し式`this_thread::sync_wait(sndr)`は不適格となる。
-
-そうでなければ、呼び出し式`this_thread::sync_wait(sndr)`は`sndr`が1回だけ評価されることを除いて、下記と等価。
+呼び出し式`this_thread::sync_wait(sndr)`は`sndr`が1回だけ評価されることを除いて、下記と等価。
 
 ```cpp
 apply_sender(get-domain-early(sndr), sync_wait, sndr)
@@ -34,6 +32,7 @@ apply_sender(get-domain-early(sndr), sync_wait, sndr)
 * apply_sender[link ../execution/apply_sender.md]
 * get-domain-early[link ../execution/get-domain-early.md]
 
+- [`sender_in`](../execution/sender_in.md)`<Sndr,` [`sync-wait-env`](sync-wait-env.md)`> == true`であること。
 - 型`sync-wait-result-type<Sndr>`が適格であること。
 - 上記の`apply_sender`式を`e`としたとき、[`same_as`](/reference/concepts/same_as.md)`<decltype(e), sync-wait-result-type<Sndr>> == true`であること。
 
@@ -145,3 +144,4 @@ result=(100, X)
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)

--- a/reference/execution/this_thread/sync_wait_with_variant.md
+++ b/reference/execution/this_thread/sync_wait_with_variant.md
@@ -25,9 +25,7 @@ namespace std::this_thread {
 ## 効果
 説明用の`sndr`を`decltype(`[`into_variant`](../execution/into_variant.md)`(sndr))`が`Sndr`型となる式とする。
 
-[`sender_in`](../execution/sender_in.md)`<Sndr,` [`sync-wait-env`](sync-wait-env.md)`> == false`のとき、呼び出し式`this_thread::sync_wait_with_variant(sndr)`は不適格となる。
-
-そうでなければ、呼び出し式`this_thread::sync_wait_with_variant(sndr)`は`sndr`が1回だけ評価されることを除いて、下記と等価。
+呼び出し式`this_thread::sync_wait_with_variant(sndr)`は`sndr`が1回だけ評価されることを除いて、下記と等価。
 
 ```cpp
 apply_sender(get-domain-early(sndr), sync_wait_with_variant, sndr)
@@ -35,6 +33,7 @@ apply_sender(get-domain-early(sndr), sync_wait_with_variant, sndr)
 * apply_sender[link ../execution/apply_sender.md]
 * get-domain-early[link ../execution/get-domain-early.md]
 
+- [`sender_in`](../execution/sender_in.md)`<Sndr,` [`sync-wait-env`](sync-wait-env.md)`> == true`であること。
 - 型`sync-wait-with-variant-result-type<Sndr>`が適格であること。
 - 上記の`apply_sender`式を`e`としたとき、[`same_as`](/reference/concepts/same_as.md)`<decltype(e), sync-wait-with-variant-result-type<Sndr>> == true`であること。
 
@@ -58,9 +57,7 @@ namespace std::this_thread {
 ### Senderアルゴリズムタグ `sync_wait_with_variant`
 説明用の`sndr`を`decltype(`[`into_variant`](../execution/into_variant.md)`(sndr))`が`Sndr`型となる式とする。
 
-[`callable`](/reference/functional/callable.md)`<`[`sync_wait_t`](sync_wait.md)`, Sndr> == false`のとき、式`sync_wait_with_variant.apply_sender(sndr)`は不適格となる。
-
-そうでなければ、式`sync_wait_with_variant.apply_sender(sndr)`は下記と等価。
+式`sync_wait_with_variant.apply_sender(sndr)`は下記と等価。
 
 ```cpp
 using result_type = sync-wait-with-variant-result-type<Sndr>;
@@ -138,3 +135,4 @@ result=(100, 'X')
 
 ## 参照
 - [P2300R10 `std::execution`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2300r10.html)
+- [P3557R3 High-Quality Sender Diagnostics with Constexpr Exceptions](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3557r3.html)


### PR DESCRIPTION
- dependent_senderコンセプト追加
- dependent_sender_error例外クラス追加
- get_completion_signatures仕様変更(CPO→関数テンプレート)
- Senderアルゴリズム仕様定義check-typesメンバ関数追加
- 各種Senderアルゴリズム仕様定義を修正
- 他修正, ページ構成再整理