### PR TITLE
どこからも参照されていないページ (リンクミスと思われる) のチェックを追加

### DIFF
--- a/.github/workflows/script/link_check.py
+++ b/.github/workflows/script/link_check.py
@@ -156,7 +156,33 @@ def find_all_links(text: str, is_global: bool) -> tuple[list, set[str]]:
         for m in re.finditer(r'[\*-] (.*?)\[link (.*?)\]', line):
             add_link(m.group(2))
 
+    # Markdownの参照スタイルリンク定義 (`[label]: url`) も参照として扱う。
+    # 例: `[max_size]: ./scoped_allocator_adaptor/max_size.md`
+    # (脚注 `[^label]:` は除外)
+    for line in text.split("\n"):
+        m = re.match(r'\s{0,3}\[([^\^\]][^\]]*)\]:\s+(\S+)', line)
+        if m:
+            add_link(m.group(2))
+
     return inner_links, outer_links
+
+# --- 孤立ページ (lonely page) チェック用 ---
+# 「孤立ページ」とは、どのページからもリンクされていない .md のこと。
+# reference/ 配下の .md は、リンク先パスをtypoすると「ページは存在するのに
+# どこからもリンクされない」孤立ページになる。そうしたリンクミスを検出するため、
+# 内部リンクチェックの一部として、reference/ 配下の全 .md が最低1箇所から
+# 参照されているかを確認する。
+
+# どこからもリンクされていなくてよいページ (意図的に他ページから参照されないもの)。
+# ここに載せるのは「意図的にスタンドアロンなページ」だけにすること。
+# リンクミスで孤立したページは、ここに登録せず親ページ側のリンクを修正すること。
+LONELY_PAGE_ALLOWLIST = {
+    "reference.md",  # リファレンスのトップ索引 (index.md からのリンクはグローバルナビ扱い)
+    "reference/node_handle.md",  # node_handleを説明する説明用カテゴリ概要ページ
+    # C++26の説明専用ヘルパー。Senderアルゴリズムの仕様定義で用いられるが、
+    # 現状どのアルゴリズムページの仕様記述からも参照されていない。
+    "reference/execution/execution/query-with-default.md",
+}
 
 def check(check_inner_link: bool, check_outer_link: bool, url: str) -> bool:
     if not check_inner_link and not check_outer_link:
@@ -166,6 +192,7 @@ def check(check_inner_link: bool, check_outer_link: bool, url: str) -> bool:
     found_error = False
     current_dir = os.getcwd()
     outer_link_dict = dict()
+    referenced = set()  # 内部リンクの参照先 (repo相対パスに正規化)。孤立ページ検出用
     if len(url) <= 0:
         path_list = [(p, False) for p in glob.glob("**/*.md", recursive=True)]
         path_list.append(("GLOBAL_QUALIFY_LIST.txt", True))
@@ -198,6 +225,25 @@ def check(check_inner_link: bool, check_outer_link: bool, url: str) -> bool:
                         if not os.path.exists(rel_link):
                             print("{} href {} not found.".format(p, link), file=sys.stderr)
                             found_error = True
+                        # 孤立ページ検出用に、.md への参照先をrepo相対で記録する
+                        if link.endswith(".md"):
+                            if link.startswith("/"):
+                                referenced.add(os.path.normpath(link.lstrip("/")))
+                            else:
+                                referenced.add(os.path.normpath(os.path.join(dirname, link)))
+
+        # 孤立ページ (lonely page) チェック: reference/ 配下に、どのページからも
+        # リンクされていない .md ファイルが無いか確認する (リンク先パスのtypo等で発生する)。
+        if check_inner_link:
+            for p in sorted(glob.glob("reference/**/*.md", recursive=True)):
+                norm = os.path.normpath(p)
+                if norm in LONELY_PAGE_ALLOWLIST:
+                    continue
+                if norm not in referenced:
+                    print("{} is a lonely page (どこからもリンクされていない孤立ページです。"
+                          "リンク先のtypo等が原因の可能性があります)".format(p),
+                          file=sys.stderr)
+                    found_error = True
 
     if check_outer_link:
         # GitHub-hosted runnerはIPv6アウトバウンド経路を持たない

--- a/reference/chrono/year_month.md
+++ b/reference/chrono/year_month.md
@@ -57,7 +57,7 @@ namespace std::chrono {
 
 | 名前 | 説明 | 対応バージョン |
 |------|------|----------------|
-| [`operator/`](month_day/op_append.md) | カレンダー要素同士をつなぎ合わせる | C++20 |
+| [`operator/`](year_month/op_append.md) | カレンダー要素同士をつなぎ合わせる | C++20 |
 
 
 ### 算術演算

--- a/reference/execution.md
+++ b/reference/execution.md
@@ -19,7 +19,7 @@
 | 名前 | 説明 | 対応バージョン |
 |------|------|----------------|
 | [`execution`](execution/execution.md) | 実行制御ライブラリの名前空間 (namespace) | C++26 |
-| [`this_thread`](execution/execution.md) | 実行制御ライブラリ／Senderコンシューマの名前空間 (namespace) | C++26 |
+| [`this_thread`](execution/this_thread.md) | 実行制御ライブラリ／Senderコンシューマの名前空間 (namespace) | C++26 |
 
 
 ## バージョン

--- a/reference/execution/execution/counting_scope.md
+++ b/reference/execution/execution/counting_scope.md
@@ -32,6 +32,14 @@ namespace std::execution {
 | [`join`](counting_scope/join.md) | 非同期スコープを合流する[Sender](sender.md)取得 | C++26 |
 | [`request_stop`](counting_scope/request_stop.md) | 停止要求を作成する | C++26 |
 
+### 説明専用メンバ関数
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`try-associate`](counting_scope/try-associate.md) | 関連付けを試行 | C++26 |
+| [`disassociate`](counting_scope/disassociate.md) | 関連付けを解除 | C++26 |
+| [`start-join-sender`](counting_scope/start-join-sender.md) | 合流[Sender](sender.md)を開始 | C++26 |
+
 ## メンバ型
 
 | 名前 | 説明 | 対応バージョン |

--- a/reference/execution/execution/let_value.md
+++ b/reference/execution/execution/let_value.md
@@ -238,6 +238,7 @@ struct let-state {
 ```
 * connect_result_t[link connect_result_t.md]
 * connect[link connect.md]
+* emplace-from[link emplace-from.md]
 * start[link start.md]
 * receiver_tag[link receiver.md]
 * execution::set_value[link set_value.md]

--- a/reference/random/piecewise_constant_distribution.md
+++ b/reference/random/piecewise_constant_distribution.md
@@ -60,6 +60,16 @@ namespace std {
 | `param_type`  | 分布パラメータの型。未規定。  | C++11 |
 
 
+## 非メンバ関数
+
+| 名前 | 説明 | 対応バージョン |
+|------------------------------------------------------------------|----------------------|-------|
+| [`operator==`](piecewise_constant_distribution/op_equal.md)     | 等値比較             | C++11 |
+| [`operator!=`](piecewise_constant_distribution/op_not_equal.md) | 非等値比較           | C++11 |
+| [`operator<<`](piecewise_constant_distribution/op_ostream.md)   | ストリームへの出力   | C++11 |
+| [`operator>>`](piecewise_constant_distribution/op_istream.md)   | ストリームからの入力 | C++11 |
+
+
 ## 例
 ```cpp example
 #include <fstream>

--- a/reference/random/piecewise_linear_distribution.md
+++ b/reference/random/piecewise_linear_distribution.md
@@ -60,6 +60,16 @@ namespace std {
 | `param_type`  | 分布パラメータの型。未規定。  | C++11 |
 
 
+## 非メンバ関数
+
+| 名前 | 説明 | 対応バージョン |
+|--------------------------------------------------------------|----------------------|-------|
+| [`operator==`](piecewise_linear_distribution/op_equal.md)     | 等値比較             | C++11 |
+| [`operator!=`](piecewise_linear_distribution/op_not_equal.md) | 非等値比較           | C++11 |
+| [`operator<<`](piecewise_linear_distribution/op_ostream.md)   | ストリームへの出力   | C++11 |
+| [`operator>>`](piecewise_linear_distribution/op_istream.md)   | ストリームからの入力 | C++11 |
+
+
 ## 例
 ```cpp example
 #include <fstream>


### PR DESCRIPTION
@yohhoy 
reference/execution/execution/query-with-default.md
このページがいまどこからも参照されていないようなのですが、確認おねがいできますでしょうか。
修正が必要なら、ご自身で修正される場合はmasterブランチに変更を入れてもらえれば取り込みます。指示いただければ私の方でも修正できます。