### PR TITLE
C++26対応としてsimdライブラリを追加

### DIFF
--- a/.github/workflows/script/ngword_check.py
+++ b/.github/workflows/script/ngword_check.py
@@ -78,6 +78,25 @@ def check_ngword(text: str, filename: str) -> bool:
             found_error = True
     return not found_error
 
+# 名前付きHTMLエンティティ（&radic; &nbsp; &times; 等）は、CIのビルドが
+# 生成HTMLをXMLとしてパースする際に "undefined entity" エラーになる。
+# XMLで有効なのは &amp; &lt; &gt; &quot; &apos; と数値文字参照 &#...; のみ。
+# 数値文字参照（&#x221A; 等）か、実際のUnicode文字（√ 等）を使うこと。
+NAMED_HTML_ENTITY_RE = re.compile(r'&(?!(?:amp|lt|gt|quot|apos);|#)[A-Za-z][A-Za-z0-9]*;')
+
+def remove_code(text: str) -> str:
+    # コード中の `return &x;` 等を誤検出しないよう、コードブロック／インラインコードを除去する
+    text = re.sub(r'```.*?```', '', text, flags=re.DOTALL)
+    text = re.sub(r'`[^`]*`', '', text)
+    return text
+
+def check_named_html_entity(text: str, filename: str) -> bool:
+    found_error: bool = False
+    for m in NAMED_HTML_ENTITY_RE.finditer(remove_code(text)):
+        print("{}: the file includes a named HTML entity \"{}\" which is undefined in the XML build. use a numeric character reference instead (e.g. \"&#x221A;\" for √, \"&#xA0;\" for nbsp).".format(filename, m.group(0)))
+        found_error = True
+    return not found_error
+
 def check() -> bool:
     found_error = False
     for p in sorted(list(glob.glob("**/*.md", recursive=True))):
@@ -88,6 +107,9 @@ def check() -> bool:
             text = f.read()
 
         if not check_ngword(text, p):
+            found_error = True
+
+        if not check_named_html_entity(text, p):
             found_error = True
 
     return not found_error

--- a/GLOBAL_QUALIFY_LIST.txt
+++ b/GLOBAL_QUALIFY_LIST.txt
@@ -310,6 +310,7 @@
 * <set>[link /reference/set.md]
     * std::set[link /reference/set/set.md]
 * <shared_mutex>[link /reference/shared_mutex.md]
+* <simd>[link /reference/simd.md]
 * <source_location>[link /reference/source_location.md]
     * std::source_location[link /reference/source_location/source_location.md]
 * <span>[link /reference/span.md]

--- a/GLOBAL_QUALIFY_LIST.txt
+++ b/GLOBAL_QUALIFY_LIST.txt
@@ -258,6 +258,7 @@
     * std::endl[link /reference/ostream/endl.md]
 * <print>[link /reference/print.md]
     * std::println[link /reference/print/println.md]
+    * std::print[link /reference/print/print.md]
 * <queue>[link /reference/queue.md]
 * <random>[link /reference/random.md]
     * std::default_random_engine[link /reference/random/default_random_engine.md]

--- a/lang/cpp26.md
+++ b/lang/cpp26.md
@@ -136,7 +136,7 @@ C++26とは、2026年中に改訂される予定の、C++バージョンの通�
 - 要素のメモリ位置が安定するシーケンスコンテナのライブラリとして[`<hive>`](/reference/hive.md)を追加
 - 並行処理におけるデータの参照・更新を行うRCU (Read Copy Update) のライブラリとして、[`<rcu>`](/reference/rcu.md)を追加
 - 並行処理において参照中のデータが更新されないよう保護するハザードポインタのライブラリとして、[`<hazard_pointer>`](/reference/hazard_pointer.md.nolink)を追加
-- データ並列ライブラリとして、[`<simd>`](/reference/simd.md.nolink)を追加
+- データ並列ライブラリとして、[`<simd>`](/reference/simd.md)を追加
 - デバッグサポートのライブラリとして[`<debugging>`](/reference/debugging.md)を追加
 - 線形代数ライブラリとして[`<linalg>`](/reference/linalg.md)を追加
 - コンパイル時に容量を固定する可変長配列クラスのライブラリとして[`<inplace_vector>`](/reference/inplace_vector.md)を追加

--- a/lang/cpp26/feature_test_macros.md
+++ b/lang/cpp26/feature_test_macros.md
@@ -144,9 +144,9 @@
 |`__cpp_lib_reflection`|`202506L`|[静的リフレクション](/lang/cpp26/reflection.md)のライブラリ機能|[`<meta>`](/reference/meta.md)|
 |`__cpp_lib_saturation_arithmetic`|`202603L`|[`<numeric>`](/reference/numeric.md)に飽和演算 (Saturation Arithmetic) として[`std::saturating_add()`](/reference/numeric/saturating_add.md)などの関数を追加|[`<numeric>`](/reference/numeric.md)|
 |`__cpp_lib_senders`|`202506L`||[`<execution>`](/reference/execution.md)|
-|`__cpp_lib_simd`|`202506L`|データ並列ライブラリとして、[`<simd>`](/reference/simd.md.nolink)を追加|[`<simd>`](/reference/simd.md.nolink)|
-|`__cpp_lib_simd_complex`|`202502L`|[`<simd>`](/reference/simd.md.nolink)が[`std::complex`](/reference/complex/complex.md)をサポートする|[`<simd>`](/reference/simd.md.nolink)|
-|`__cpp_lib_simd_permutations`|`202506L`|[`<simd>`](/reference/simd.md.nolink)に`permute()`などを追加する|[`<simd>`](/reference/simd.md.nolink)|
+|`__cpp_lib_simd`|`202506L`|データ並列ライブラリとして、[`<simd>`](/reference/simd.md)を追加|[`<simd>`](/reference/simd.md)|
+|`__cpp_lib_simd_complex`|`202502L`|[`<simd>`](/reference/simd.md)が[`std::complex`](/reference/complex/complex.md)をサポートする|[`<simd>`](/reference/simd.md)|
+|`__cpp_lib_simd_permutations`|`202506L`|[`<simd>`](/reference/simd.md)に`permute()`などを追加する|[`<simd>`](/reference/simd.md)|
 |`__cpp_lib_smart_ptr_owner_equality`|`202306L`|[`<memory>`](/reference/memory.md)に[`std::owner_hash`](/reference/memory/owner_hash.md)と[`std::owner_equal`](/reference/memory/owner_equal.md)を追加|[`<memory>`](/reference/memory.md)|
 |`__cpp_lib_span`|`202311L`|[`std::mdspan`](/reference/mdspan/mdspan.md)に[`at()`](/reference/mdspan/mdspan/at.md)メンバ関数を追加|[`<span>`](/reference/span.md)|
 |`__cpp_lib_span_initializer_list`|`202311L`|[`std::span`](/reference/span/span.md)に[`std::initializer_list`](/reference/initializer_list/initializer_list.md)をとるコンストラクタを追加|[`<span>`](/reference/span.md)|

--- a/reference.md
+++ b/reference.md
@@ -150,6 +150,7 @@
 | [`<bit>`](/reference/bit.md)           | ビット操作       | C++20          |
 | [`<random>`](/reference/random.md)     | 乱数生成         | C++11          |
 | [`<valarray>`](/reference/valarray.md) | 数値の配列       |                |
+| [`<simd>`](/reference/simd.md)         | データ並列型     | C++26          |
 | [`<numeric>`](/reference/numeric.md)   | 一般的な数値操作 |                |
 | [`<numbers>`](/reference/numbers.md)   | 数値             | C++20          |
 | [`<linalg>`](/reference/linalg.md)     | 線形代数 | C++26 |
@@ -213,7 +214,7 @@
 | [`<future>`](/reference/future.md)                         | Future                | C++11          |
 | [`<rcu>`](/reference/rcu.md)                               | データの参照・更新    | C++26          |
 | [`<hazard_pointer>`](/reference/hazard_pointer.md.nolink)         | ハザードポインタ      | C++26          |
-| [`<simd>`](/reference/simd.md.nolink) | データ並列 | C++26 |
+| [`<simd>`](/reference/simd.md) | データ並列 | C++26 |
 
 
 ## <a id="clib-facilities" href="#clib-facilities">C言語互換ライブラリ</a>

--- a/reference/bit.md
+++ b/reference/bit.md
@@ -38,6 +38,24 @@
 | [`rotr`](bit/rotr.md) | 右循環ビットシフト (function template) | C++20 |
 
 
+## ビットシフト
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`shl`](bit/shl.md) | 左ビットシフト（未定義動作にならない） (function template) | C++29 |
+| [`shr`](bit/shr.md) | 右ビットシフト（未定義動作にならない） (function template) | C++29 |
+
+
+## ビット並べ替え
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`bit_reverse`](bit/bit_reverse.md) | ビット列の並びを反転する (function template) | C++29 |
+| [`bit_repeat`](bit/bit_repeat.md) | 最下位`l`ビットのパターンを繰り返す (function template) | C++29 |
+| [`bit_compress`](bit/bit_compress.md) | マスクで立っている位置のビットを下位へ詰める (function template) | C++29 |
+| [`bit_expand`](bit/bit_expand.md) | 下位ビットをマスクで立っている位置へ展開する (function template) | C++29 |
+
+
 ## ビットカウント
 
 | 名前 | 説明 | 対応バージョン |

--- a/reference/bit/bit_compress.md
+++ b/reference/bit/bit_compress.md
@@ -1,0 +1,78 @@
+# bit_compress
+* bit[meta header]
+* std[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std {
+  template <class T>
+  constexpr T bit_compress(T x, T m) noexcept; // C++29
+}
+```
+
+## 概要
+マスク`m`でビットが立っている位置の`x`のビットを集め、結果の下位ビットへ詰めて配置する（parallel bits extract）。
+
+x86の`PEXT`命令に相当する操作である。
+
+
+## テンプレートパラメータ制約
+- 型`T`が符号なし整数型であること
+
+
+## 戻り値
+`T`のビット数を`N`とする。`m`の第`n`ビットが`1`である位置を下位から順に走査し、対応する`x`の第`n`ビットを結果の下位側から順に詰めた値を返す。すなわち、結果の第`k`ビットは、`m`のなかで`k`番目に立っているビット位置の`x`のビットに等しい。
+
+
+## 例外
+投げない
+
+
+## 備考
+- [`bit_expand`](bit_expand.md)は逆操作である。`m`のビットがすべて`1`のとき、`bit_expand(bit_compress(x, m), m)`は`x`に等しい。
+
+
+## 例
+```cpp example
+#include <bit>
+#include <cstdint>
+#include <print>
+
+int main()
+{
+  std::uint8_t x = 0b1011'0100;
+  std::uint8_t m = 0b1111'0000; // 上位4ビットを抽出
+
+  std::uint8_t r = std::bit_compress(x, m);
+
+  std::println("{:08b}", r);
+}
+```
+* std::bit_compress[color ff0000]
+
+### 出力
+```
+00001011
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::bit_expand`](bit_expand.md)
+- [`std::bit_reverse`](bit_reverse.md)
+- [`std::bit_repeat`](bit_repeat.md)
+
+
+## 参照
+- [P3104R3 Bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3104r3.html)
+    - C++29で追加された

--- a/reference/bit/bit_expand.md
+++ b/reference/bit/bit_expand.md
@@ -1,0 +1,78 @@
+# bit_expand
+* bit[meta header]
+* std[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std {
+  template <class T>
+  constexpr T bit_expand(T x, T m) noexcept; // C++29
+}
+```
+
+## 概要
+`x`の下位ビットを、マスク`m`でビットが立っている位置へ順に配置する（parallel bits deposit）。
+
+x86の`PDEP`命令に相当する操作であり、[`bit_compress`](bit_compress.md)の逆操作である。
+
+
+## テンプレートパラメータ制約
+- 型`T`が符号なし整数型であること
+
+
+## 戻り値
+`T`のビット数を`N`とする。`m`の第`n`ビットが`1`である位置を下位から順に走査し、`x`の下位ビットから順に取り出した値をその位置へ配置した値を返す。すなわち、`m`のなかで`k`番目に立っているビット位置には、`x`の第`k`ビットが配置される。
+
+
+## 例外
+投げない
+
+
+## 備考
+- [`bit_compress`](bit_compress.md)は逆操作である。`m`のビットがすべて`1`のとき、`bit_expand(bit_compress(x, m), m)`は`x`に等しい。
+
+
+## 例
+```cpp example
+#include <bit>
+#include <cstdint>
+#include <print>
+
+int main()
+{
+  std::uint8_t x = 0b0000'1011;
+  std::uint8_t m = 0b1111'0000; // 下位4ビットを上位4ビットの位置へ展開
+
+  std::uint8_t r = std::bit_expand(x, m);
+
+  std::println("{:08b}", r);
+}
+```
+* std::bit_expand[color ff0000]
+
+### 出力
+```
+10110000
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::bit_compress`](bit_compress.md)
+- [`std::bit_reverse`](bit_reverse.md)
+- [`std::bit_repeat`](bit_repeat.md)
+
+
+## 参照
+- [P3104R3 Bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3104r3.html)
+    - C++29で追加された

--- a/reference/bit/bit_repeat.md
+++ b/reference/bit/bit_repeat.md
@@ -1,0 +1,78 @@
+# bit_repeat
+* bit[meta header]
+* std[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std {
+  template <class T>
+  constexpr T bit_repeat(T x, int l); // C++29
+}
+```
+
+## 概要
+値`x`の最下位`l`ビットのパターンを、`T`の幅いっぱいに繰り返した値を求める。
+
+
+## テンプレートパラメータ制約
+- 型`T`が符号なし整数型であること
+
+
+## 事前条件
+- `l`が`0`より大きいこと
+
+
+## 戻り値
+`T`のビット数を`N`（[`std::numeric_limits`](/reference/limits/numeric_limits.md)`<T>::digits`）とする。第`n`ビット（`0`以上`N`未満）が`x`の第`n % l`ビットに等しい値を返す。
+
+
+## 例外
+投げない
+
+
+## 備考
+- 事前条件に違反する関数呼び出し式は、定数式として評価されない。
+
+
+## 例
+```cpp example
+#include <bit>
+#include <cstdint>
+#include <print>
+
+int main()
+{
+  // 最下位4ビットのパターン 0b1100 を繰り返す
+  std::uint32_t r = std::bit_repeat(std::uint32_t{0xc}, 4);
+
+  std::println("{:08x}", r);
+}
+```
+* std::bit_repeat[color ff0000]
+
+### 出力
+```
+cccccccc
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::bit_reverse`](bit_reverse.md)
+- [`std::bit_compress`](bit_compress.md)
+- [`std::bit_expand`](bit_expand.md)
+
+
+## 参照
+- [P3104R3 Bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3104r3.html)
+    - C++29で追加された

--- a/reference/bit/bit_reverse.md
+++ b/reference/bit/bit_reverse.md
@@ -1,0 +1,78 @@
+# bit_reverse
+* bit[meta header]
+* std[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std {
+  template <class T>
+  constexpr T bit_reverse(T x) noexcept; // C++29
+}
+```
+
+## 概要
+値`x`のビット列の並びを反転する。
+
+最下位ビットと最上位ビットを入れ替えるように、すべてのビットを逆順に並べ替える。
+
+
+## テンプレートパラメータ制約
+- 型`T`が符号なし整数型であること
+
+
+## 戻り値
+`T`のビット数を`N`（[`std::numeric_limits`](/reference/limits/numeric_limits.md)`<T>::digits`）とする。`x`の第`n`ビット（`0`以上`N`未満）を第`N - 1 - n`ビットへ移した値を返す。
+
+
+## 例外
+投げない
+
+
+## 備考
+- `bit_reverse(bit_reverse(x))`は`x`に等しい。
+- この関数は、ハードウェア機能として提供されている場合がある。
+
+
+## 例
+```cpp example
+#include <bit>
+#include <cstdint>
+#include <print>
+
+int main()
+{
+  std::uint16_t x = 0b0000'0000'0000'0001;
+
+  std::uint16_t r = std::bit_reverse(x);
+
+  std::println("{:016b}", r);
+}
+```
+* std::bit_reverse[color ff0000]
+
+### 出力
+```
+1000000000000000
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::bit_repeat`](bit_repeat.md)
+- [`std::byteswap`](byteswap.md)
+- [`std::rotl`](rotl.md)
+
+
+## 参照
+- [P3104R3 Bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3104r3.html)
+    - C++29で追加された

--- a/reference/bit/shl.md
+++ b/reference/bit/shl.md
@@ -1,0 +1,76 @@
+# shl
+* bit[meta header]
+* std[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std {
+  template <class T, class S>
+  constexpr T shl(T x, S s) noexcept; // C++29
+}
+```
+
+## 概要
+値`x`を左方向に`s`ビットシフトした値（`x`を`2`の`s`乗倍した値）を求める。
+
+組み込みの`operator<<`と異なり、シフト量`s`が`T`のビット幅以上であっても、また負であっても未定義動作とならない。`s`が負の場合は、右方向へ`-s`ビットシフトした結果（[`shr`](shr.md)`(x, -s)`）となる。
+
+
+## テンプレートパラメータ制約
+- `T`と`S`がそれぞれ符号付きまたは符号なし整数型であること
+
+
+## 戻り値
+十分な値域をもつ仮想的な整数型で`x × 2`<sup>`s`</sup>を計算して負の無限大方向に丸め、その結果を`static_cast`で`T`に変換した値を返す。
+
+
+## 例外
+投げない
+
+
+## 備考
+- `shl(x, s)`は[`shr`](shr.md)`(x, -s)`に等しい。
+
+
+## 例
+```cpp example
+#include <bit>
+#include <cstdint>
+#include <print>
+
+int main()
+{
+  std::uint8_t x = 0b0000'0011;
+
+  std::uint8_t r = std::shl(x, 2);
+
+  std::println("{:08b}", r);
+}
+```
+* std::shl[color ff0000]
+
+### 出力
+```
+00001100
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::shr`](shr.md)
+- [`std::rotl`](rotl.md)
+
+
+## 参照
+- [P3793R1 Better shifting](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3793r1.html)
+    - C++29で追加された

--- a/reference/bit/shr.md
+++ b/reference/bit/shr.md
@@ -1,0 +1,78 @@
+# shr
+* bit[meta header]
+* std[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std {
+  template <class T, class S>
+  constexpr T shr(T x, S s) noexcept; // C++29
+}
+```
+
+## 概要
+値`x`を右方向に`s`ビットシフトした値（`x`を`2`の`s`乗で割った値）を求める。
+
+組み込みの`operator>>`と異なり、シフト量`s`が`T`のビット幅以上であっても、また負であっても未定義動作とならない。`s`が負の場合は、左方向へ`-s`ビットシフトした結果（[`shl`](shl.md)`(x, -s)`）となる。
+
+`x`が符号付き整数型で負の値の場合は、負の無限大方向に丸められる（算術右シフトに相当する）。
+
+
+## テンプレートパラメータ制約
+- `T`と`S`がそれぞれ符号付きまたは符号なし整数型であること
+
+
+## 戻り値
+十分な値域をもつ仮想的な整数型で`x × 2`<sup>`-s`</sup>を計算して負の無限大方向に丸め、その結果を`static_cast`で`T`に変換した値を返す。
+
+
+## 例外
+投げない
+
+
+## 備考
+- `shr(x, s)`は[`shl`](shl.md)`(x, -s)`に等しい。
+
+
+## 例
+```cpp example
+#include <bit>
+#include <cstdint>
+#include <print>
+
+int main()
+{
+  std::uint8_t x = 0b0011'0000;
+
+  std::uint8_t r = std::shr(x, 2);
+
+  std::println("{:08b}", r);
+}
+```
+* std::shr[color ff0000]
+
+### 出力
+```
+00001100
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::shl`](shl.md)
+- [`std::rotr`](rotr.md)
+
+
+## 参照
+- [P3793R1 Better shifting](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3793r1.html)
+    - C++29で追加された

--- a/reference/simd.md
+++ b/reference/simd.md
@@ -1,0 +1,261 @@
+# simd
+* simd[meta header]
+* cpp26[meta cpp]
+
+`<simd>`ヘッダでは、データ並列型（data-parallel types）のライブラリを提供する。SIMD命令やSIMDレジスタといったデータ並列実行資源を活用して、複数の値に対する演算を一度に適用するための型と操作を定義する。
+
+このライブラリの機能は`std::simd`名前空間で定義される。中心となる型は、ベクトル型[`basic_vec`](simd/basic_vec.md)（および別名`vec`）と、マスク型[`basic_mask`](simd/basic_mask.md)（および別名`mask`）である。
+
+## <a id="vectorizable-type" href="#vectorizable-type">vectorizable type（ベクトル化可能型）</a>
+「vectorizable type」は、データ並列型（[`basic_vec`](simd/basic_vec.md)・[`basic_mask`](simd/basic_mask.md)）の要素型として使用できる型である。次の型が該当する。
+
+- すべての標準の整数型・文字型、および`float`・`double`（`long double`は含まない）
+- [`std::float16_t`](/reference/stdfloat/float16_t.md)・[`std::float32_t`](/reference/stdfloat/float32_t.md)・[`std::float64_t`](/reference/stdfloat/float64_t.md)（定義されている場合）
+- 要素型が浮動小数点数の「vectorizable type」である[`std::complex`](/reference/complex/complex.md)
+
+## クラス
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`basic_vec`](simd/basic_vec.md) | データ並列のベクトル型 (class template) | C++26 |
+| [`vec`](simd/basic_vec.md) | 要素数を指定する`basic_vec`の別名 (alias template) | C++26 |
+| [`basic_mask`](simd/basic_mask.md) | データ並列のマスク型 (class template) | C++26 |
+| [`mask`](simd/basic_mask.md) | 要素数を指定する`basic_mask`の別名 (alias template) | C++26 |
+| [`flags`](simd/flags.md) | 読み込み／書き込みの動作フラグ (class template) | C++26 |
+
+## 型特性
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`alignment`](simd/alignment.md) | 読み込み／書き込みに必要なアライメントを取得する (class template) | C++26 |
+| [`rebind`](simd/rebind.md) | 要素数を維持して要素型を変更する (class template) | C++26 |
+| [`resize`](simd/resize.md) | 要素型を維持して要素数を変更する (class template) | C++26 |
+
+## 説明専用コンセプト
+以下は規格の説明専用（exposition-only）のコンセプトであり、各関数のテンプレートパラメータ制約として使用される。規格の宣言では、[`math-floating-point`](/reference/simd/math-floating-point.md)のように斜体のハイフン区切り名で示される。
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`simd-vec-type`](simd/simd-vec-type.md) | データ並列のベクトル型（`basic_vec`の特殊化）を表す (説明専用concept) | C++26 |
+| [`simd-mask-type`](simd/simd-mask-type.md) | データ並列のマスク型（`basic_mask`の特殊化）を表す (説明専用concept) | C++26 |
+| [`simd-floating-point`](simd/simd-floating-point.md) | 要素型が浮動小数点数の`basic_vec`を表す (説明専用concept) | C++26 |
+| [`simd-integral`](simd/simd-integral.md) | 要素型が整数の`basic_vec`を表す (説明専用concept) | C++26 |
+| [`simd-complex`](simd/simd-complex.md) | 要素型が複素数の`basic_vec`を表す (説明専用concept) | C++26 |
+| [`math-floating-point`](simd/math-floating-point.md) | 数学関数向けに、浮動小数点数の`basic_vec`またはスカラーを表す (説明専用concept) | C++26 |
+| [`explicitly-convertible-to`](simd/explicitly-convertible-to.md) | 型`From`が型`To`へ明示的に変換可能であることを表す (説明専用concept) | C++26 |
+| [`reduction-binary-operation`](simd/reduction-binary-operation.md) | `reduce`の二項演算として使用できることを表す (説明専用concept) | C++26 |
+
+## 説明専用の型・変数
+以下は規格の説明専用（exposition-only）の型エイリアス・変数であり、宣言の記述に使用される。
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`simd-size-type`](simd/simd-size-type.md) | 要素数・インデックスを表す符号付き整数型 (説明専用type-alias) | C++26 |
+| [`deduced-vec-t`](simd/deduced-vec-t.md) | 型`T`から導出されるデータ並列型（スカラーは対応する`basic_vec`） (説明専用type-alias) | C++26 |
+| [`simd-complex-value-type`](simd/simd-complex-value-type.md) | 複素数要素の実数部・虚数部の型 (説明専用type-alias) | C++26 |
+| [`simd-size-v`](simd/simd-size-v.md) | `basic_vec`の幅（要素数） (説明専用variable) | C++26 |
+| [`mask-size-v`](simd/mask-size-v.md) | `basic_mask`の幅（要素数） (説明専用variable) | C++26 |
+| [`mask-element-size`](simd/mask-element-size.md) | `basic_mask`の要素1つが対応するバイトサイズ (説明専用variable) | C++26 |
+| [`native-abi`](simd/native-abi.md) | 要素型`T`に対する既定のABIタグ (説明専用type-alias) | C++26 |
+| [`deduce-abi-t`](simd/deduce-abi-t.md) | 要素型`T`と要素数`N`から導出されるABIタグ (説明専用type-alias) | C++26 |
+
+## 集計
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`reduce`](simd/reduce.md) | 全要素を二項演算で集計し、単一の値を求める (function template) | C++26 |
+| [`reduce_min`](simd/reduce_min.md) | 全要素の最小値を求める (function template) | C++26 |
+| [`reduce_max`](simd/reduce_max.md) | 全要素の最大値を求める (function template) | C++26 |
+| [`all_of`](simd/all_of.md) | マスクの全要素が`true`かを判定する (function template) | C++26 |
+| [`any_of`](simd/any_of.md) | マスクのいずれかの要素が`true`かを判定する (function template) | C++26 |
+| [`none_of`](simd/none_of.md) | マスクの全要素が`false`かを判定する (function template) | C++26 |
+| [`reduce_count`](simd/reduce_count.md) | マスクの`true`である要素数を数える (function template) | C++26 |
+| [`reduce_min_index`](simd/reduce_min_index.md) | マスクで最初に`true`となる要素のインデックスを求める (function template) | C++26 |
+| [`reduce_max_index`](simd/reduce_max_index.md) | マスクで最後に`true`となる要素のインデックスを求める (function template) | C++26 |
+
+## 読み込み／書き込み
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`unchecked_load`](simd/unchecked_load.md) | メモリから要素をまとめて読み込む（境界チェックなし） (function template) | C++26 |
+| [`partial_load`](simd/partial_load.md) | メモリから要素を安全にまとめて読み込む（範囲外は値初期化） (function template) | C++26 |
+| [`unchecked_store`](simd/unchecked_store.md) | 全要素をメモリへまとめて書き込む（境界チェックなし） (function template) | C++26 |
+| [`partial_store`](simd/partial_store.md) | 要素をメモリへ安全にまとめて書き込む（範囲外は書き込まない） (function template) | C++26 |
+| [`unchecked_gather_from`](simd/unchecked_gather_from.md) | インデックスで指定した飛び飛びの位置から要素を集めて読み込む（境界チェックなし） (function template) | C++26 |
+| [`partial_gather_from`](simd/partial_gather_from.md) | インデックスで指定した飛び飛びの位置から要素を安全に集めて読み込む (function template) | C++26 |
+| [`unchecked_scatter_to`](simd/unchecked_scatter_to.md) | 各要素をインデックスで指定した飛び飛びの位置へ書き出す（境界チェックなし） (function template) | C++26 |
+| [`partial_scatter_to`](simd/partial_scatter_to.md) | 各要素をインデックスで指定した飛び飛びの位置へ安全に書き出す (function template) | C++26 |
+
+## 要素の置換・生成
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`permute`](simd/permute.md) | 要素を指定したインデックスのマッピングに従って並べ替える (function template) | C++26 |
+| [`compress`](simd/compress.md) | マスクが`true`である要素だけを先頭に詰める (function template) | C++26 |
+| [`expand`](simd/expand.md) | 先頭に詰められた要素をマスクが`true`である位置へ展開する (function template) | C++26 |
+| [`chunk`](simd/chunk.md) | 大きなデータ並列オブジェクトを小さなオブジェクトへ分割する (function template) | C++26 |
+| [`cat`](simd/cat.md) | 複数のデータ並列オブジェクトを連結する (function template) | C++26 |
+| [`select`](simd/select.md) | 条件に応じて2つの値のうちいずれかを要素ごとに選択する (function template) | C++26 |
+| [`iota`](simd/iota.md) | 各要素がインデックスに等しい連番（`0, 1, 2, …`）を表す定数 (variable template) | C++29 |
+
+## アルゴリズム
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`min`](simd/min.md) | 2つのオブジェクトを要素ごとに比較して小さいほうを返す (function template) | C++26 |
+| [`max`](simd/max.md) | 2つのオブジェクトを要素ごとに比較して大きいほうを返す (function template) | C++26 |
+| [`minmax`](simd/minmax.md) | 要素ごとの最小値と最大値をまとめて取得する (function template) | C++26 |
+| [`clamp`](simd/clamp.md) | 各要素を指定した範囲に収める (function template) | C++26 |
+
+## 数学関数
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`exp`](simd/exp.md) | 各要素に指数関数を適用する (function template) | C++26 |
+| [`exp2`](simd/exp2.md) | 各要素に2を底とする指数関数を適用する (function template) | C++26 |
+| [`expm1`](simd/expm1.md) | 各要素に`e^x - 1`を適用する (function template) | C++26 |
+| [`log`](simd/log.md) | 各要素に自然対数を適用する (function template) | C++26 |
+| [`log10`](simd/log10.md) | 各要素に常用対数を適用する (function template) | C++26 |
+| [`log2`](simd/log2.md) | 各要素に2を底とする対数を適用する (function template) | C++26 |
+| [`log1p`](simd/log1p.md) | 各要素に`log(1 + x)`を適用する (function template) | C++26 |
+| [`pow`](simd/pow.md) | 各要素の累乗を求める (function template) | C++26 |
+| [`sqrt`](simd/sqrt.md) | 各要素の平方根を求める (function template) | C++26 |
+| [`cbrt`](simd/cbrt.md) | 各要素の立方根を求める (function template) | C++26 |
+| [`hypot`](simd/hypot.md) | 各要素の平方和の平方根（斜辺の長さ）を求める (function template) | C++26 |
+| [`sin`](simd/sin.md) | 各要素の正弦を求める (function template) | C++26 |
+| [`cos`](simd/cos.md) | 各要素の余弦を求める (function template) | C++26 |
+| [`tan`](simd/tan.md) | 各要素の正接を求める (function template) | C++26 |
+| [`asin`](simd/asin.md) | 各要素の逆正弦を求める (function template) | C++26 |
+| [`acos`](simd/acos.md) | 各要素の逆余弦を求める (function template) | C++26 |
+| [`atan`](simd/atan.md) | 各要素の逆正接を求める (function template) | C++26 |
+| [`atan2`](simd/atan2.md) | 各要素について`y/x`の逆正接を象限を考慮して求める (function template) | C++26 |
+| [`sinh`](simd/sinh.md) | 各要素の双曲線正弦を求める (function template) | C++26 |
+| [`cosh`](simd/cosh.md) | 各要素の双曲線余弦を求める (function template) | C++26 |
+| [`tanh`](simd/tanh.md) | 各要素の双曲線正接を求める (function template) | C++26 |
+| [`asinh`](simd/asinh.md) | 各要素の逆双曲線正弦を求める (function template) | C++26 |
+| [`acosh`](simd/acosh.md) | 各要素の逆双曲線余弦を求める (function template) | C++26 |
+| [`atanh`](simd/atanh.md) | 各要素の逆双曲線正接を求める (function template) | C++26 |
+| [`abs`](simd/abs.md) | 各要素の絶対値を求める (function template) | C++26 |
+| [`fabs`](simd/fabs.md) | 各要素の絶対値を求める（浮動小数点数） (function template) | C++26 |
+| [`fmod`](simd/fmod.md) | 各要素の浮動小数点剰余を求める (function template) | C++26 |
+| [`remainder`](simd/remainder.md) | 各要素のIEEE浮動小数点剰余を求める (function template) | C++26 |
+| [`remquo`](simd/remquo.md) | 各要素のIEEE剰余と商の下位ビットを求める (function template) | C++26 |
+| [`fma`](simd/fma.md) | 各要素の積和演算`x*y+z`を1回の丸めで求める (function template) | C++26 |
+| [`fmax`](simd/fmax.md) | 各要素の大きいほうの値を求める (function template) | C++26 |
+| [`fmin`](simd/fmin.md) | 各要素の小さいほうの値を求める (function template) | C++26 |
+| [`fdim`](simd/fdim.md) | 各要素の正の差（`x-y`が正ならその値、それ以外は`0`）を求める (function template) | C++26 |
+| [`ceil`](simd/ceil.md) | 各要素を切り上げる (function template) | C++26 |
+| [`floor`](simd/floor.md) | 各要素を切り捨てる (function template) | C++26 |
+| [`trunc`](simd/trunc.md) | 各要素を0方向へ切り捨てる (function template) | C++26 |
+| [`round`](simd/round.md) | 各要素を四捨五入する (function template) | C++26 |
+| [`nearbyint`](simd/nearbyint.md) | 各要素を現在の丸めモードで整数に丸める (function template) | C++26 |
+| [`rint`](simd/rint.md) | 各要素を現在の丸めモードで整数に丸める (function template) | C++26 |
+| [`lrint`](simd/lrint.md) | 各要素を現在の丸めモードで`long`の整数に丸める (function template) | C++26 |
+| [`llrint`](simd/llrint.md) | 各要素を現在の丸めモードで`long long`の整数に丸める (function template) | C++26 |
+| [`lround`](simd/lround.md) | 各要素を四捨五入して`long`にする (function template) | C++26 |
+| [`llround`](simd/llround.md) | 各要素を四捨五入して`long long`にする (function template) | C++26 |
+| [`lerp`](simd/lerp.md) | 各要素を線形補間する (function template) | C++26 |
+| [`frexp`](simd/frexp.md) | 各要素を仮数部と指数部に分解する (function template) | C++26 |
+| [`ldexp`](simd/ldexp.md) | 各要素に2の累乗を掛ける (function template) | C++26 |
+| [`modf`](simd/modf.md) | 各要素を整数部と小数部に分解する (function template) | C++26 |
+| [`scalbn`](simd/scalbn.md) | 各要素に基数`FLT_RADIX`の累乗を掛ける (function template) | C++26 |
+| [`scalbln`](simd/scalbln.md) | 各要素に基数`FLT_RADIX`の累乗を掛ける (function template) | C++26 |
+| [`ilogb`](simd/ilogb.md) | 各要素の指数部を整数で求める (function template) | C++26 |
+| [`logb`](simd/logb.md) | 各要素の指数部を求める (function template) | C++26 |
+| [`nextafter`](simd/nextafter.md) | 各要素の次に表現可能な値を求める (function template) | C++26 |
+| [`copysign`](simd/copysign.md) | 各要素の大きさに別の値の符号を合成する (function template) | C++26 |
+| [`erf`](simd/erf.md) | 各要素の誤差関数を求める (function template) | C++26 |
+| [`erfc`](simd/erfc.md) | 各要素の相補誤差関数を求める (function template) | C++26 |
+| [`lgamma`](simd/lgamma.md) | 各要素のガンマ関数の絶対値の自然対数を求める (function template) | C++26 |
+| [`tgamma`](simd/tgamma.md) | 各要素のガンマ関数を求める (function template) | C++26 |
+
+## 数学関数（分類・比較）
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`fpclassify`](simd/fpclassify.md) | 各要素の浮動小数点数分類を求める (function template) | C++26 |
+| [`isfinite`](simd/isfinite.md) | 各要素が有限値かを判定する (function template) | C++26 |
+| [`isinf`](simd/isinf.md) | 各要素が無限大かを判定する (function template) | C++26 |
+| [`isnan`](simd/isnan.md) | 各要素がNaNかを判定する (function template) | C++26 |
+| [`isnormal`](simd/isnormal.md) | 各要素が正規化数かを判定する (function template) | C++26 |
+| [`signbit`](simd/signbit.md) | 各要素の符号ビットが立っているかを判定する (function template) | C++26 |
+| [`isgreater`](simd/isgreater.md) | 各要素について`x > y`かを判定する (function template) | C++26 |
+| [`isgreaterequal`](simd/isgreaterequal.md) | 各要素について`x >= y`かを判定する (function template) | C++26 |
+| [`isless`](simd/isless.md) | 各要素について`x < y`かを判定する (function template) | C++26 |
+| [`islessequal`](simd/islessequal.md) | 各要素について`x <= y`かを判定する (function template) | C++26 |
+| [`islessgreater`](simd/islessgreater.md) | 各要素について`x < y || x > y`かを判定する (function template) | C++26 |
+| [`isunordered`](simd/isunordered.md) | 各要素が順序付けできない（いずれかがNaN）かを判定する (function template) | C++26 |
+
+## 数学関数（特殊関数）
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`assoc_laguerre`](simd/assoc_laguerre.md) | 各要素にラゲール陪多項式を適用する (function template) | C++26 |
+| [`assoc_legendre`](simd/assoc_legendre.md) | 各要素にルジャンドル陪関数を適用する (function template) | C++26 |
+| [`beta`](simd/beta.md) | 各要素にベータ関数を適用する (function template) | C++26 |
+| [`comp_ellint_1`](simd/comp_ellint_1.md) | 各要素に第一種完全楕円積分を適用する (function template) | C++26 |
+| [`comp_ellint_2`](simd/comp_ellint_2.md) | 各要素に第二種完全楕円積分を適用する (function template) | C++26 |
+| [`comp_ellint_3`](simd/comp_ellint_3.md) | 各要素に第三種完全楕円積分を適用する (function template) | C++26 |
+| [`cyl_bessel_i`](simd/cyl_bessel_i.md) | 各要素に第一種変形ベッセル関数を適用する (function template) | C++26 |
+| [`cyl_bessel_j`](simd/cyl_bessel_j.md) | 各要素に第一種ベッセル関数を適用する (function template) | C++26 |
+| [`cyl_bessel_k`](simd/cyl_bessel_k.md) | 各要素に第二種変形ベッセル関数を適用する (function template) | C++26 |
+| [`cyl_neumann`](simd/cyl_neumann.md) | 各要素に第二種ベッセル関数（ノイマン関数）を適用する (function template) | C++26 |
+| [`ellint_1`](simd/ellint_1.md) | 各要素に第一種不完全楕円積分を適用する (function template) | C++26 |
+| [`ellint_2`](simd/ellint_2.md) | 各要素に第二種不完全楕円積分を適用する (function template) | C++26 |
+| [`ellint_3`](simd/ellint_3.md) | 各要素に第三種不完全楕円積分を適用する (function template) | C++26 |
+| [`expint`](simd/expint.md) | 各要素に指数積分を適用する (function template) | C++26 |
+| [`hermite`](simd/hermite.md) | 各要素にエルミート多項式を適用する (function template) | C++26 |
+| [`laguerre`](simd/laguerre.md) | 各要素にラゲール多項式を適用する (function template) | C++26 |
+| [`legendre`](simd/legendre.md) | 各要素にルジャンドル多項式を適用する (function template) | C++26 |
+| [`riemann_zeta`](simd/riemann_zeta.md) | 各要素にリーマンゼータ関数を適用する (function template) | C++26 |
+| [`sph_bessel`](simd/sph_bessel.md) | 各要素に第一種球ベッセル関数を適用する (function template) | C++26 |
+| [`sph_legendre`](simd/sph_legendre.md) | 各要素に球面調和関数のルジャンドル陪関数部分を適用する (function template) | C++26 |
+| [`sph_neumann`](simd/sph_neumann.md) | 各要素に第二種球ベッセル関数（球ノイマン関数）を適用する (function template) | C++26 |
+
+## ビット操作
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`byteswap`](simd/byteswap.md) | 各要素のバイト順を反転する (function template) | C++26 |
+| [`has_single_bit`](simd/has_single_bit.md) | 各要素が2の累乗（1ビットのみ）かを判定する (function template) | C++26 |
+| [`bit_ceil`](simd/bit_ceil.md) | 各要素以上で最小の2の累乗を求める (function template) | C++26 |
+| [`bit_floor`](simd/bit_floor.md) | 各要素以下で最大の2の累乗を求める (function template) | C++26 |
+| [`bit_width`](simd/bit_width.md) | 各要素を表現するのに必要なビット数を求める (function template) | C++26 |
+| [`rotl`](simd/rotl.md) | 各要素を左に循環ビットシフトする (function template) | C++26 |
+| [`rotr`](simd/rotr.md) | 各要素を右に循環ビットシフトする (function template) | C++26 |
+| [`countl_zero`](simd/countl_zero.md) | 各要素の最上位から連続する0ビットの数を数える (function template) | C++26 |
+| [`countl_one`](simd/countl_one.md) | 各要素の最上位から連続する1ビットの数を数える (function template) | C++26 |
+| [`countr_zero`](simd/countr_zero.md) | 各要素の最下位から連続する0ビットの数を数える (function template) | C++26 |
+| [`countr_one`](simd/countr_one.md) | 各要素の最下位から連続する1ビットの数を数える (function template) | C++26 |
+| [`popcount`](simd/popcount.md) | 各要素の1になっているビットの数を数える (function template) | C++26 |
+| [`bit_compress`](simd/bit_compress.md) | 各要素について、マスクのビットが立つ位置の値を下位へ詰める (function template) | C++29 |
+| [`bit_expand`](simd/bit_expand.md) | 各要素について、下位ビットをマスクのビットが立つ位置へ展開する (function template) | C++29 |
+| [`bit_reverse`](simd/bit_reverse.md) | 各要素のビット列の並びを反転する (function template) | C++29 |
+| [`bit_repeat`](simd/bit_repeat.md) | 各要素の最下位`l`ビットのパターンを幅いっぱいに繰り返す (function template) | C++29 |
+| [`shl`](simd/shl.md) | 各要素を論理左シフトする (function template) | C++29 |
+| [`shr`](simd/shr.md) | 各要素を論理右シフトする (function template) | C++29 |
+
+## 複素数
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`real`](simd/real.md) | 各要素の実部を取得する (function template) | C++26 |
+| [`imag`](simd/imag.md) | 各要素の虚部を取得する (function template) | C++26 |
+| [`arg`](simd/arg.md) | 各要素の偏角を求める (function template) | C++26 |
+| [`norm`](simd/norm.md) | 各要素のノルム（絶対値の2乗）を求める (function template) | C++26 |
+| [`conj`](simd/conj.md) | 各要素の共役複素数を求める (function template) | C++26 |
+| [`proj`](simd/proj.md) | 各要素をリーマン球面へ射影する (function template) | C++26 |
+| [`polar`](simd/polar.md) | 絶対値と偏角から複素数を生成する (function template) | C++26 |
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`<simd>`ヘッダが追加された

--- a/reference/simd/abs.md
+++ b/reference/simd/abs.md
@@ -1,0 +1,143 @@
+# abs
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  // 浮動小数点版
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    abs(const V& j);                 // (1) C++26
+
+  // 符号付き整数版
+  template<std::signed_integral T, class Abi>
+  constexpr basic_vec<T, Abi>
+    abs(const basic_vec<T, Abi>& j); // (2) C++26
+
+  // 複素数版
+  template<simd-complex V>
+  constexpr rebind_t<simd-complex-value-type<V>, V>
+    abs(const V& v);                 // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* simd-complex-value-type[link /reference/simd/simd-complex-value-type.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+* std::signed_integral[link /reference/concepts/signed_integral.md]
+* basic_vec[link basic_vec.md]
+* rebind_t[link rebind.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、絶対値を求める。
+
+- (1) : 浮動小数点要素の各要素の絶対値を求める。
+- (2) : 符号付き整数要素の各要素の絶対値を求める。
+- (3) : 複素数要素の各要素の絶対値（大きさ・マグニチュード）を求め、実数型を要素とする[`basic_vec`](basic_vec.md)として返す。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型を表す。
+
+制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`simd-complex-value-type<V>`](/reference/simd/simd-complex-value-type.md)は`V`の要素型`std::complex<T>`における`T`（実数型）を表す。(3)の戻り値の型は、`V`の要素数はそのままに要素型を`T`とした[`basic_vec`](basic_vec.md)となる。
+
+
+## 事前条件
+- (2) : [`all_of`](all_of.md)`(j >= -`[`std::numeric_limits`](/reference/limits/numeric_limits.md)`<T>::max())`が`true`であること。すなわち、`T`の最小値（`std::numeric_limits<T>::min()`）は許容されない。
+
+
+## 戻り値
+- (1) : 各要素`i`について、`j`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`abs`](/reference/cmath/abs.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+- (2) : 各要素`i`（`0`以上`j.size()`未満）について、[`abs`](/reference/cstdlib/abs.md)`(j[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+- (3) : 各要素`i`（`0`以上`V::size()`未満）について、`v[i]`に[`<complex>`](/reference/complex/complex.md)の[`abs`](/reference/complex/complex/abs.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+(1), (3)について、ある要素`i`で定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+- (1), (3) : [`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+### 基本的な使い方
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v{[](int i) { return i % 2 == 0 ? -(i + 1) : (i + 1); }};
+  // {-1, 2, -3, 4}
+
+  // 各要素の絶対値を求める
+  simd::vec<int, 4> a = simd::abs(v);
+
+  for (int i = 0; i < a.size(); ++i)
+    std::print("{} ", a[i]);
+  std::println("");
+}
+```
+* simd::abs[color ff0000]
+* simd::vec[link basic_vec.md]
+
+#### 出力
+```
+1 2 3 4 
+```
+
+### 複素数版の例 (C++26)
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i + 3.0f, i + 4.0f); }
+  };  // {(3, 4), (4, 5)}
+
+  // 各要素の絶対値（大きさ）を求める
+  simd::vec<float, 2> a = simd::abs(v);
+
+  for (std::size_t i = 0; i < a.size(); ++i)
+    std::print("{} ", a[i]);
+  std::println("");
+}
+```
+* simd::abs[color ff0000]
+* simd::vec[link basic_vec.md]
+
+#### 出力例
+```
+5 6.40312 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::fabs`](fabs.md)
+- [`std::simd::arg`](arg.md)
+- [`std::simd::norm`](norm.md)
+- [`std::simd::polar`](polar.md)
+- [`std::complex::abs`](/reference/complex/complex/abs.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/acos.md
+++ b/reference/simd/acos.md
@@ -1,0 +1,80 @@
+# acos
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> acos(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の逆余弦（アークコサイン）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`acos`](/reference/cmath/acos.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return -0.75f + i * 0.5f; }); // {-0.75, -0.25, 0.25, 0.75}
+
+  // 各要素の逆余弦を求める
+  simd::vec<float, 4> r = simd::acos(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::acos[color ff0000]
+
+### 出力例
+```
+2.41886 1.82348 1.31812 0.722734 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::cos`](cos.md)
+- [`std::simd::asin`](asin.md)
+- [`std::simd::atan`](atan.md)
+- [`std::simd::acosh`](acosh.md)
+- [`acos`](/reference/cmath/acos.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/acosh.md
+++ b/reference/simd/acosh.md
@@ -1,0 +1,80 @@
+# acosh
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> acosh(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の逆双曲線余弦（エリアハイパボリックコサイン）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`acosh`](/reference/cmath/acosh.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return 1.0f + i * 0.5f; }); // {1, 1.5, 2, 2.5}
+
+  // 各要素の逆双曲線余弦を求める
+  simd::vec<float, 4> r = simd::acosh(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::acosh[color ff0000]
+
+### 出力例
+```
+0 0.962424 1.31696 1.5668 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::cosh`](cosh.md)
+- [`std::simd::asinh`](asinh.md)
+- [`std::simd::atanh`](atanh.md)
+- [`std::simd::acos`](acos.md)
+- [`acosh`](/reference/cmath/acosh.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/alignment.md
+++ b/reference/simd/alignment.md
@@ -1,0 +1,65 @@
+# alignment
+* simd[meta header]
+* std::simd[meta namespace]
+* class template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class U = typename T::value_type>
+  struct alignment { /*see below*/ };
+
+  template<class T, class U = typename T::value_type>
+  constexpr std::size_t alignment_v = alignment<T, U>::value;
+}
+```
+
+## 概要
+`alignment`は、データ並列型`T`（[`basic_vec`](basic_vec.md)または[`basic_mask`](basic_mask.md)）を、要素型`U`の配列に対してアライメント済みで読み込み／書き込むために必要な、メモリ先頭のアライメント（バイト数）を取得する型特性である。
+
+[`flag_aligned`](flags.md)を指定して読み込み／書き込む場合、メモリ先頭はこの`alignment_v<T, U>`バイト境界にアライメントされていなければならない。
+
+メンバ定数`value`は、`T`がデータ並列型であり、要素型`U`との間で（変換）読み込み／書き込みが可能な場合にのみ存在する。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  using V = simd::vec<float, 4>;
+
+  std::println("{}", simd::alignment_v<V>);
+}
+```
+* simd::vec[link basic_vec.md]
+* simd::alignment_v[color ff0000]
+
+### 出力例
+```
+16
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::flags`](flags.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/all_of.md
+++ b/reference/simd/all_of.md
@@ -1,0 +1,75 @@
+# all_of
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<std::size_t Bytes, class Abi>
+  constexpr bool all_of(const basic_mask<Bytes, Abi>& k) noexcept; // (1) C++26
+
+  constexpr bool all_of(std::same_as<bool> auto x) noexcept;       // (2) C++26
+}
+```
+* basic_mask[link basic_mask.md]
+* std::same_as[link /reference/concepts/same_as.md]
+
+## 概要
+マスクの全要素が`true`であるかを判定する。
+
+- (1) : [`basic_mask`](basic_mask.md)`k`の全要素が`true`であるかを判定する。
+- (2) : スカラーの`bool`値`x`をそのまま返す（SIMD-genericなコードを書けるようにするためのオーバーロード）。
+
+## 戻り値
+- (1) : `k`のすべての要素が`true`であれば`true`、そうでなければ`false`を返す。
+- (2) : `x`を返す。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i; }); // {0, 1, 2, 3}
+
+  std::println("{}", simd::all_of(v < 4)); // 全要素が4未満
+  std::println("{}", simd::all_of(v < 2)); // 全要素が2未満ではない
+}
+```
+* simd::all_of[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+true
+false
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::any_of`](any_of.md)
+- [`std::simd::none_of`](none_of.md)
+- [`std::simd::reduce_count`](reduce_count.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/any_of.md
+++ b/reference/simd/any_of.md
@@ -1,0 +1,75 @@
+# any_of
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<std::size_t Bytes, class Abi>
+  constexpr bool any_of(const basic_mask<Bytes, Abi>& k) noexcept; // (1) C++26
+
+  constexpr bool any_of(std::same_as<bool> auto x) noexcept;       // (2) C++26
+}
+```
+* basic_mask[link basic_mask.md]
+* std::same_as[link /reference/concepts/same_as.md]
+
+## 概要
+マスクの要素のうち、いずれかが`true`であるかを判定する。
+
+- (1) : [`basic_mask`](basic_mask.md)`k`のいずれかの要素が`true`であるかを判定する。
+- (2) : スカラーの`bool`値`x`をそのまま返す（SIMD-genericなコードを書けるようにするためのオーバーロード）。
+
+## 戻り値
+- (1) : `k`の少なくともひとつの要素が`true`であれば`true`、そうでなければ`false`を返す。
+- (2) : `x`を返す。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i; }); // {0, 1, 2, 3}
+
+  std::println("{}", simd::any_of(v < 2)); // 2未満の要素が存在する
+  std::println("{}", simd::any_of(v < 0)); // 0未満の要素は存在しない
+}
+```
+* simd::any_of[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+true
+false
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::all_of`](all_of.md)
+- [`std::simd::none_of`](none_of.md)
+- [`std::simd::reduce_count`](reduce_count.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/arg.md
+++ b/reference/simd/arg.md
@@ -1,0 +1,86 @@
+# arg
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-complex V>
+  constexpr rebind_t<simd-complex-value-type<V>, V> arg(const V& v); // C++26
+}
+```
+* simd-complex-value-type[link /reference/simd/simd-complex-value-type.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+* complex[link /reference/complex/complex.md]
+
+## 概要
+要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素の偏角（位相角）を求め、実数型`T`を要素とする[`basic_vec`](basic_vec.md)として返す。
+
+制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`simd-complex-value-type<V>`](/reference/simd/simd-complex-value-type.md)は`V`の要素型`std::complex<T>`における`T`（実数型）を表す。戻り値の型は`V`の要素数はそのままに要素型を`T`とした[`basic_vec`](basic_vec.md)となる。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`v[i]`に[`<complex>`](/reference/complex/complex.md)の[`arg`](/reference/complex/complex/arg.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i + 1.0f, i + 1.0f); }
+  };  // {(1, 1), (2, 2)}
+
+  // 各要素の偏角を求める
+  simd::vec<float, 2> a = simd::arg(v);
+
+  for (std::size_t i = 0; i < a.size(); ++i)
+    std::print("{} ", a[i]);
+  std::println("");
+}
+```
+* simd::arg[color ff0000]
+
+### 出力例
+```
+0.785398 0.785398 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::abs`](abs.md)
+- [`std::simd::norm`](norm.md)
+- [`std::simd::polar`](polar.md)
+- [`std::simd::real`](real.md)
+- [`std::simd::imag`](imag.md)
+- [`std::complex::arg`](/reference/complex/complex/arg.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/asin.md
+++ b/reference/simd/asin.md
@@ -1,0 +1,80 @@
+# asin
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> asin(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の逆正弦（アークサイン）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`asin`](/reference/cmath/asin.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return -0.75f + i * 0.5f; }); // {-0.75, -0.25, 0.25, 0.75}
+
+  // 各要素の逆正弦を求める
+  simd::vec<float, 4> r = simd::asin(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::asin[color ff0000]
+
+### 出力例
+```
+-0.848062 -0.25268 0.25268 0.848062 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sin`](sin.md)
+- [`std::simd::acos`](acos.md)
+- [`std::simd::atan`](atan.md)
+- [`std::simd::asinh`](asinh.md)
+- [`asin`](/reference/cmath/asin.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/asinh.md
+++ b/reference/simd/asinh.md
@@ -1,0 +1,80 @@
+# asinh
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> asinh(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の逆双曲線正弦（エリアハイパボリックサイン）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`asinh`](/reference/cmath/asinh.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i * 0.5f; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の逆双曲線正弦を求める
+  simd::vec<float, 4> r = simd::asinh(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::asinh[color ff0000]
+
+### 出力例
+```
+0 0.481212 0.881374 1.19476 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sinh`](sinh.md)
+- [`std::simd::acosh`](acosh.md)
+- [`std::simd::atanh`](atanh.md)
+- [`std::simd::asin`](asin.md)
+- [`asinh`](/reference/cmath/asinh.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/assoc_laguerre.md
+++ b/reference/simd/assoc_laguerre.md
@@ -1,0 +1,86 @@
+# assoc_laguerre
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    assoc_laguerre(const rebind_t<unsigned, deduced-vec-t<V>>& n,
+                   const rebind_t<unsigned, deduced-vec-t<V>>& m,
+                   const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`assoc_laguerre`](/reference/cmath/assoc_laguerre.md)を適用し、各要素について、次数`n`・位数`m`のラゲール陪多項式の`x`での値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+`rebind_t<unsigned, deduced-vec-t<V>>`は、[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)と同じ要素数をもつ`unsigned`要素型の[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`n[i]`・`m[i]`・`x[i]`に[`<cmath>`](/reference/cmath.md)の[`assoc_laguerre`](/reference/cmath/assoc_laguerre.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<unsigned, 2> n = 1u;                          // 次数1
+  simd::vec<unsigned, 2> m = 0u;                          // 位数0
+  simd::vec<double, 2> x([](int i) { return i * 0.5 + 0.5; }); // {0.5, 1}
+
+  // 各要素について次数1・位数0のラゲール陪多項式の値を求める
+  simd::vec<double, 2> r = simd::assoc_laguerre(n, m, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::assoc_laguerre[color ff0000]
+
+### 出力例
+```
+0.5 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::laguerre`](laguerre.md)
+- [`std::assoc_laguerre`](/reference/cmath/assoc_laguerre.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/assoc_legendre.md
+++ b/reference/simd/assoc_legendre.md
@@ -1,0 +1,87 @@
+# assoc_legendre
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    assoc_legendre(const rebind_t<unsigned, deduced-vec-t<V>>& l,
+                   const rebind_t<unsigned, deduced-vec-t<V>>& m,
+                   const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`assoc_legendre`](/reference/cmath/assoc_legendre.md)を適用し、各要素について、次数`l`・位数`m`のルジャンドル陪多項式の`x`での値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+`rebind_t<unsigned, deduced-vec-t<V>>`は、[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)と同じ要素数をもつ`unsigned`要素型の[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`l[i]`・`m[i]`・`x[i]`に[`<cmath>`](/reference/cmath.md)の[`assoc_legendre`](/reference/cmath/assoc_legendre.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<unsigned, 2> l = 1u;                          // 次数1
+  simd::vec<unsigned, 2> m = 0u;                          // 位数0
+  simd::vec<double, 2> x([](int i) { return i * 0.5 + 0.5; }); // {0.5, 1}
+
+  // 各要素について次数1・位数0のルジャンドル陪多項式の値を求める
+  simd::vec<double, 2> r = simd::assoc_legendre(l, m, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::assoc_legendre[color ff0000]
+
+### 出力例
+```
+0.5 1 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::legendre`](legendre.md)
+- [`std::simd::sph_legendre`](sph_legendre.md)
+- [`std::assoc_legendre`](/reference/cmath/assoc_legendre.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/atan.md
+++ b/reference/simd/atan.md
@@ -1,0 +1,80 @@
+# atan
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> atan(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の逆正接（アークタンジェント）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`atan`](/reference/cmath/atan.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i * 0.5f; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の逆正接を求める
+  simd::vec<float, 4> r = simd::atan(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::atan[color ff0000]
+
+### 出力例
+```
+0 0.463648 0.785398 0.982794 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::tan`](tan.md)
+- [`std::simd::atan2`](atan2.md)
+- [`std::simd::asin`](asin.md)
+- [`std::simd::atanh`](atanh.md)
+- [`atan`](/reference/cmath/atan.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/atan2.md
+++ b/reference/simd/atan2.md
@@ -1,0 +1,91 @@
+# atan2
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    atan2(const V& y, const V& x);                // (1) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    atan2(const deduced-vec-t<V>& x, const V& y); // (2) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    atan2(const V& x, const deduced-vec-t<V>& y); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数の2つの引数`y`・`x`について、各要素の逆正接（`y/x`のアークタンジェント）を、両引数の符号から適切な象限を選択して求める。
+
+- (1) : 両引数を`V`として受け取る。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、対応する各要素に[`<cmath>`](/reference/cmath.md)の[`atan2`](/reference/cmath/atan2.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> y = 1.0f;                          // {1, 1, 1, 1}
+  simd::vec<float, 4> x([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+
+  // 各要素の逆正接を求める
+  simd::vec<float, 4> r = simd::atan2(y, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::atan2[color ff0000]
+
+### 出力例
+```
+0.785398 0.463648 0.321751 0.244979 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::atan`](atan.md)
+- [`std::simd::tan`](tan.md)
+- [`atan2`](/reference/cmath/atan2.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/atanh.md
+++ b/reference/simd/atanh.md
@@ -1,0 +1,80 @@
+# atanh
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> atanh(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の逆双曲線正接（エリアハイパボリックタンジェント）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`atanh`](/reference/cmath/atanh.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return -0.75f + i * 0.5f; }); // {-0.75, -0.25, 0.25, 0.75}
+
+  // 各要素の逆双曲線正接を求める
+  simd::vec<float, 4> r = simd::atanh(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::atanh[color ff0000]
+
+### 出力例
+```
+-0.972955 -0.255413 0.255413 0.972955 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::tanh`](tanh.md)
+- [`std::simd::asinh`](asinh.md)
+- [`std::simd::acosh`](acosh.md)
+- [`std::simd::atan`](atan.md)
+- [`atanh`](/reference/cmath/atanh.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/basic_mask.md
+++ b/reference/simd/basic_mask.md
@@ -1,0 +1,166 @@
+# basic_mask
+* simd[meta header]
+* std::simd[meta namespace]
+* class template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<std::size_t Bytes, class Abi>
+  class basic_mask;
+
+  template<simd-size-type N, class T = /*see below*/>
+  using mask = basic_mask</*see below*/>;
+}
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+
+## 概要
+`basic_mask`は、[`basic_vec`](basic_vec.md)の各要素に対応する真偽値（`bool`）をまとめて保持するデータ並列型である。比較演算子の結果や、要素ごとの条件選択（`select`）などで用いられる。
+
+`basic_mask<Bytes, Abi>`は、`Bytes`が対応する要素型のサイズ、`Abi`がABIタグを表す。要素数は対応する[`basic_vec`](basic_vec.md)と一致する。通常は、対応する`basic_vec`の`mask_type`メンバや、要素数を指定する別名`mask`を通じて利用する。
+
+- `Bytes`: 対応する要素型のバイトサイズ。ある[「vectorizable type」](/reference/simd.md#vectorizable-type)`T`について`sizeof(T)`と等しくなければならない
+- `Abi`: 要素数と内部表現を決定するABIタグ型
+
+### 有効な特殊化・無効な特殊化
+`basic_mask<Bytes, Abi>`の各特殊化は、対応する有効な[`basic_vec`](basic_vec.md)が存在するとき「有効」（enabled）となる。有効な`basic_mask`は[トリビアルコピー可能](/reference/type_traits/is_trivially_copyable.md)である。無効な特殊化は、デフォルトコンストラクタ・デストラクタ・コピーコンストラクタ・コピー代入演算子がすべて`delete`定義され、メンバとしては`value_type`・`abi_type`のみを持つ。
+
+
+## メンバ関数
+### 構築／代入
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`(constructor)`](basic_mask/op_constructor.md) | コンストラクタ | C++26 |
+| `(destructor)` | デストラクタ（トリビアル） | C++26 |
+
+### イテレータ
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`begin`](basic_mask/begin.md)   | 先頭要素を指すイテレータを取得する | C++26 |
+| [`end`](basic_mask/end.md)       | 番兵を取得する | C++26 |
+| [`cbegin`](basic_mask/cbegin.md) | 先頭要素を指す読み取り専用イテレータを取得する | C++26 |
+| [`cend`](basic_mask/cend.md)     | 番兵を取得する | C++26 |
+
+### 要素アクセス
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator[]`](basic_mask/op_at.md) | 要素または要素の並べ替えを取得する | C++26 |
+
+### 単項演算子
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator!`](basic_mask/op_not.md)        | 論理反転 | C++26 |
+| [`operator+`](basic_mask/op_unary_plus.md)  | 単項プラス（[`basic_vec`](basic_vec.md)へ変換） | C++26 |
+| [`operator-`](basic_mask/op_unary_minus.md) | 単項マイナス（[`basic_vec`](basic_vec.md)へ変換） | C++26 |
+| [`operator~`](basic_mask/op_flip.md)        | ビット反転（[`basic_vec`](basic_vec.md)へ変換） | C++26 |
+
+### 変換
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator basic_vec`](basic_mask/op_vec.md) | [`basic_vec`](basic_vec.md)への変換 | C++26 |
+| [`to_bitset`](basic_mask/to_bitset.md)       | [`std::bitset`](/reference/bitset/bitset.md)へ変換する | C++26 |
+| [`to_ullong`](basic_mask/to_ullong.md)       | `unsigned long long`へ変換する | C++26 |
+
+## 静的メンバ変数
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`size`](basic_mask/size.md) | 要素数を表す[`std::integral_constant`](/reference/type_traits/integral_constant.md) | C++26 |
+
+## メンバ型
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| `value_type`     | `bool` | C++26 |
+| `abi_type`       | ABIタグ型`Abi` | C++26 |
+| `iterator`       | イテレータ型（説明専用） | C++26 |
+| `const_iterator` | 読み取り専用イテレータ型（説明専用） | C++26 |
+
+## 非メンバ（*Hidden friends*）関数
+### 二項論理・ビット演算子
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator&&`](basic_mask/op_logical_and.md) | 論理積 | C++26 |
+| <code>[operator&#x7C;&#x7C;](basic_mask/op_logical_or.md)</code> | 論理和 | C++26 |
+| [`operator&`](basic_mask/op_and.md)           | ビット論理積 | C++26 |
+| <code>[operator&#x7C;](basic_mask/op_or.md)</code>           | ビット論理和 | C++26 |
+| [`operator^`](basic_mask/op_xor.md)           | ビット排他的論理和 | C++26 |
+
+### 複合代入演算子
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator&=`](basic_mask/op_and_assign.md) | ビット論理積の複合代入 | C++26 |
+| <code>[operator&#x7C;=](basic_mask/op_or_assign.md)</code> | ビット論理和の複合代入 | C++26 |
+| [`operator^=`](basic_mask/op_xor_assign.md) | ビット排他的論理和の複合代入 | C++26 |
+
+### 比較演算子
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator==`](basic_mask/op_equal.md)         | 等値比較 | C++26 |
+| [`operator!=`](basic_mask/op_not_equal.md)     | 非等値比較 | C++26 |
+| [`operator>=`](basic_mask/op_greater_equal.md) | 以上を判定する | C++26 |
+| [`operator<=`](basic_mask/op_less_equal.md)    | 以下を判定する | C++26 |
+| [`operator>`](basic_mask/op_greater.md)        | より大きいかを判定する | C++26 |
+| [`operator<`](basic_mask/op_less.md)           | より小さいかを判定する | C++26 |
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a([](int i) { return i; });  // {0, 1, 2, 3}
+
+  // 比較演算子の結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a < 2);       // {true, true, false, false}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+* m[i][link basic_mask/op_at.md]
+
+### 出力
+```
+true true false false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P3691R1 Reconsider naming of the namespace for "std::simd"](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3691r1.pdf)
+    - マスク型を`basic_mask`/`mask`に改名した
+- [P3922R1 Missing deduction guide from `simd::mask` to `simd::vec`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3922r1.pdf)
+    - `basic_mask`から`basic_vec`への推論補助が追加された

--- a/reference/simd/basic_mask/begin.md
+++ b/reference/simd/basic_mask/begin.md
@@ -1,0 +1,73 @@
+# begin
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr iterator begin() noexcept;             // (1) C++26
+constexpr const_iterator begin() const noexcept; // (2) C++26
+```
+
+## 概要
+先頭要素を指すイテレータを取得する。
+
+
+## 戻り値
+先頭要素（添字`0`の要素）を指すイテレータ
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::mask<int, 4> m([](int i) { return i % 2 == 0; });  // {true, false, true, false}
+
+  // begin()が返すイテレータで先頭から走査する
+  for (auto it = m.begin(); it != m.end(); ++it) {
+    std::print("{} ", *it);
+  }
+  std::println("");
+}
+```
+* simd::mask[link ../basic_mask.md]
+* m.begin()[color ff0000]
+* m.end()[link end.md]
+
+### 出力
+```
+true false true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`end`](end.md)
+- [`cbegin`](cbegin.md)
+- [`cend`](cend.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+- [P3480R6 `std::simd` is a range](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3480r6.pdf)
+    - イテレータを追加し、Rangeとして扱えるようになった

--- a/reference/simd/basic_mask/cbegin.md
+++ b/reference/simd/basic_mask/cbegin.md
@@ -1,0 +1,71 @@
+# cbegin
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr const_iterator cbegin() const noexcept; // (1) C++26
+```
+
+## 概要
+先頭要素を指す読み取り専用イテレータを取得する。
+
+
+## 戻り値
+先頭要素（添字`0`の要素）を指す読み取り専用イテレータ
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::mask<int, 4> m = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  for (auto it = m.cbegin(); it != m.cend(); ++it) {
+    std::print("{} ", *it);
+  }
+  std::println("");
+}
+```
+* simd::mask[link ../basic_mask.md]
+* m.cbegin()[color ff0000]
+* m.cend()[link cend.md]
+
+### 出力
+```
+true false true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`begin`](begin.md)
+- [`end`](end.md)
+- [`cend`](cend.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+- [P3480R6 `std::simd` is a range](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3480r6.pdf)
+    - イテレータを追加し、Rangeとして扱えるようになった

--- a/reference/simd/basic_mask/cend.md
+++ b/reference/simd/basic_mask/cend.md
@@ -1,0 +1,72 @@
+# cend
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr default_sentinel_t cend() const noexcept; // (1) C++26
+```
+* default_sentinel_t[link /reference/iterator/default_sentinel_t.md]
+
+## 概要
+読み取り専用イテレータの終端を表す番兵（[`std::default_sentinel_t`](/reference/iterator/default_sentinel_t.md)）を取得する。
+
+
+## 戻り値
+[`std::default_sentinel`](/reference/iterator/default_sentinel_t.md)
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::mask<int, 4> m = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  for (auto it = m.cbegin(); it != m.cend(); ++it) {
+    std::print("{} ", *it);
+  }
+  std::println("");
+}
+```
+* simd::mask[link ../basic_mask.md]
+* m.cbegin()[link cbegin.md]
+* m.cend()[color ff0000]
+
+### 出力
+```
+true false true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`begin`](begin.md)
+- [`end`](end.md)
+- [`cbegin`](cbegin.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+- [P3480R6 `std::simd` is a range](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3480r6.pdf)
+    - イテレータを追加し、Rangeとして扱えるようになった

--- a/reference/simd/basic_mask/end.md
+++ b/reference/simd/basic_mask/end.md
@@ -1,0 +1,73 @@
+# end
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr default_sentinel_t end() const noexcept; // (1) C++26
+```
+* default_sentinel_t[link /reference/iterator/default_sentinel_t.md]
+
+## 概要
+イテレータの終端を表す番兵（[`std::default_sentinel_t`](/reference/iterator/default_sentinel_t.md)）を取得する。
+
+
+## 戻り値
+[`std::default_sentinel`](/reference/iterator/default_sentinel_t.md)
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <ranges>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::mask<int, 4> m = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  for (auto it = m.begin(); it != m.end(); ++it) {
+    std::print("{} ", *it);
+  }
+  std::println("");
+}
+```
+* simd::mask[link ../basic_mask.md]
+* m.begin()[link begin.md]
+* m.end()[color ff0000]
+
+### 出力
+```
+true false true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`begin`](begin.md)
+- [`cbegin`](cbegin.md)
+- [`cend`](cend.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+- [P3480R6 `std::simd` is a range](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3480r6.pdf)
+    - イテレータを追加し、Rangeとして扱えるようになった

--- a/reference/simd/basic_mask/op_and.md
+++ b/reference/simd/basic_mask/op_and.md
@@ -1,0 +1,75 @@
+# operator&
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask
+  operator&(const basic_mask& lhs, const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つのマスクの要素ごとのビット論理積を求める。
+
+## 戻り値
+`lhs`と`rhs`に対して要素ごとにビット論理積を適用した結果で初期化された`basic_mask`オブジェクトを返す。
+
+## 例外
+投げない。
+
+## 備考
+この関数は[*Hidden friends*](/article/lib/hidden_friends.md)として定義される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  auto m1 = (a >= 1);                            // {false, true, true, true}
+  auto m2 = (a < 3);                             // {true, true, true, false}
+
+  auto r = m1 & m2;                              // {false, true, true, false}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* m1 & m2[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* r.size()[link size.md]
+* r[i][link op_at.md]
+
+### 出力
+```
+false true true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask::operator|`](op_or.md)
+- [`std::simd::basic_mask::operator^`](op_xor.md)
+- [`std::simd::basic_mask::operator&&`](op_logical_and.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_and_assign.md
+++ b/reference/simd/basic_mask/op_and_assign.md
@@ -1,0 +1,71 @@
+# operator&=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask& operator&=(basic_mask& lhs,
+                                        const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_mask`](../basic_mask.md)を要素ごとにビット論理積し、その結果を左辺に代入する。
+
+## 効果
+`lhs`と`rhs`の対応する要素それぞれに`&`を適用した結果を、`lhs`の各要素に代入する。
+
+## 戻り値
+`lhs`。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4>::mask_type a = [](int i) { return i < 2; };  // {true, true, false, false}
+  simd::vec<int, 4>::mask_type b = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  a &= b;  // {true, false, false, false}
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* a.size()[link size.md]
+* a[i][link op_at.md]
+
+### 出力
+```
+true false false false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_at.md
+++ b/reference/simd/basic_mask/op_at.md
@@ -1,0 +1,89 @@
+# operator[]
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr value_type operator[](simd-size-type i) const; // (1) C++26
+
+template<simd-integral I>
+constexpr resize_t<I::size(), basic_mask>
+  operator[](const I& indices) const;                        // (2) C++26
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* simd-integral[link /reference/simd/simd-integral.md]
+
+## 概要
+- (1) : 指定した位置の単一要素の値を取得する
+- (2) : 添字を保持したデータ並列型`indices`を渡し、それらの位置の要素を並べ替えた`basic_mask`を取得する
+
+
+## 事前条件
+- (1) : `i >= 0 && i < size()`であること
+
+
+## 効果
+- (2) : 以下と等価である。
+    ```cpp
+    return permute(*this, indices);
+    ```
+
+
+## 戻り値
+- (1) : `i`番目の要素の値
+- (2) : `indices`の第`j`要素が指すインデックスの要素を第`j`要素とする`basic_mask`。要素数は`indices`の要素数（`I::size()`）となる
+
+
+## 例外
+- (1) : 投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::mask<int, 4> m = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  // (1) 位置を指定して要素を取得する
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::mask[link ../basic_mask.md]
+* m.size()[link size.md]
+* m[i][color ff0000]
+
+### 出力
+```
+true false true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された
+- [P2876R3 Proposal to extend `std::simd` with more constructors and accessors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2876r3.html)
+    - インデックス列による並べ替えを取得する添字演算子が追加された

--- a/reference/simd/basic_mask/op_constructor.md
+++ b/reference/simd/basic_mask/op_constructor.md
@@ -1,0 +1,124 @@
+# コンストラクタ
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr basic_mask() noexcept = default;                     // (1) C++26
+
+constexpr explicit basic_mask(same_as<value_type> auto x) noexcept; // (2) C++26
+
+template<std::size_t UBytes, class UAbi>
+constexpr explicit basic_mask(const basic_mask<UBytes, UAbi>& x) noexcept; // (3) C++26
+
+template<class G>
+constexpr explicit basic_mask(G&& gen);                        // (4) C++26
+
+template<same_as<bitset<size()>> T>
+constexpr basic_mask(const T& b) noexcept;                     // (5) C++26
+
+template<unsigned_integral T>
+  requires (!same_as<T, value_type>)
+constexpr explicit basic_mask(T val) noexcept;                 // (6) C++26
+```
+* same_as[link /reference/concepts/same_as.md]
+* bitset[link /reference/bitset/bitset.md]
+* size()[link size.md]
+* unsigned_integral[link /reference/concepts/unsigned_integral.md]
+
+## 概要
+`basic_mask`オブジェクトを構築する。
+
+- (1) : デフォルトコンストラクタ。各要素は値初期化される
+- (2) : ブロードキャストコンストラクタ。すべての要素を単一の値`x`で初期化する
+- (3) : 変換コンストラクタ。要素数が等しい別の`basic_mask`から各要素を変換して初期化する
+- (4) : ジェネレータコンストラクタ。各要素の値を、添字を引数とする関数オブジェクト`gen`の呼び出し結果で初期化する
+- (5) : [`std::bitset`](/reference/bitset/bitset.md)の各ビットで対応する要素を初期化する
+- (6) : 符号なし整数値`val`の各ビットで対応する要素を初期化する
+
+
+## テンプレートパラメータ制約
+- (3) : `basic_mask<UBytes, UAbi>::size() == size()`が`true`であること
+- (4) : すべての`i`（`0 <= i < size()`）について、式`gen(std::integral_constant<simd-size-type, i>())`が適格であり、その型が`bool`であること
+- (6) : `T`が`value_type`（`bool`）と異なる符号なし整数型であること
+
+
+## 効果
+- (1) : 各要素を値初期化する
+- (2) : 各要素を`x`で初期化する
+- (3) : すべての`i`（`0 <= i < size()`）について、`i`番目の要素を`x[i]`で初期化する
+- (4) : すべての`i`（`0 <= i < size()`）について、`i`番目の要素を`gen(std::integral_constant<simd-size-type, i>())`で初期化する
+- (5) : すべての`i`（`0 <= i < size()`）について、`i`番目の要素を`b[i]`で初期化する
+- (6) : 先頭の`M`個の要素を`val`の対応するビット値で初期化する。ここで`M`は`size()`と、`val`の型の値表現のビット数のうち小さいほうである。`M`が`size()`より小さい場合、残りの要素は`false`で初期化される
+
+
+## 例外
+- (4) : `gen`の呼び出しが例外を送出する場合を除いて、投げない
+
+
+## 備考
+- (4) : `gen`は各`i`につき正確に1回、`i`の昇順で呼び出される
+
+
+## 例
+```cpp example
+#include <simd>
+#include <bitset>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // (2) ブロードキャスト：すべての要素をtrueにする
+  simd::mask<int, 4> allTrue{true};
+
+  // (4) ジェネレータ：偶数番目の要素をtrueにする
+  simd::mask<int, 4> gen = [](int i) { return i % 2 == 0; };
+
+  // (5) bitsetから構築する（0番目のビットが先頭要素）
+  simd::mask<int, 4> fromBitset{std::bitset<4>{"1010"}};
+
+  // (6) 符号なし整数のビット列から構築する
+  simd::mask<int, 4> fromBits{0b1010u};
+
+  for (int i = 0; i < allTrue.size(); ++i)
+    std::print("{} ", allTrue[i]);
+  std::println("");
+
+  for (int i = 0; i < gen.size(); ++i)
+    std::print("{} ", gen[i]);
+  std::println("");
+
+  for (int i = 0; i < fromBits.size(); ++i)
+    std::print("{} ", fromBits[i]);
+  std::println("");
+}
+```
+* simd::mask[link ../basic_mask.md]
+* allTrue.size()[link size.md]
+* allTrue[i][link op_at.md]
+
+### 出力
+```
+true true true true 
+true false true false 
+false true false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_equal.md
+++ b/reference/simd/basic_mask/op_equal.md
@@ -1,0 +1,71 @@
+# operator==
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask operator==(const basic_mask& lhs,
+                                       const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_mask`](../basic_mask.md)を要素ごとに等値比較する。
+
+比較結果は単一の`bool`ではなく、要素ごとの比較結果を保持する[`basic_mask`](../basic_mask.md)として返される。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`==`を適用した結果で初期化された`basic_mask`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] == rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4>::mask_type a = [](int i) { return i < 2; };  // {true, true, false, false}
+  simd::vec<int, 4>::mask_type b = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  // 要素ごとの等値比較。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a == b);  // {true, false, false, true}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link size.md]
+* m[i][link op_at.md]
+
+### 出力
+```
+true false false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_flip.md
+++ b/reference/simd/basic_mask/op_flip.md
@@ -1,0 +1,73 @@
+# operator~
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr /*see below*/ operator~() const noexcept;
+```
+
+## 概要
+各要素を[`basic_vec`](../basic_vec.md)へ変換したうえで、ビット反転演算を適用する。
+
+## 戻り値
+各要素`i`（`0`以上`size()`未満）が`~operator[](i)`で初期化された、[`basic_vec`](../basic_vec.md)のオブジェクトを返す。各要素の`bool`値は整数へ変換されたうえでビット反転演算が適用される。
+
+## 例外
+投げない。
+
+## 備考
+戻り値型は、`sizeof(I) == Bytes`となる符号付き整数型`I`が存在する場合、要素型がそのような符号付き整数型で要素数が`size()`と等しい、有効な[`basic_vec`](../basic_vec.md)の特殊化`R`となる。そのような符号付き整数型が存在しない場合、この演算子は`delete`定義され、戻り値型は未規定である。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4>::mask_type m = (a < 2);        // {true, true, false, false}
+
+  auto r = ~m;                                   // {-2, -2, -1, -1}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* ~m[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* r.size()[link ../basic_vec/size.md]
+* r[i][link ../basic_vec/op_at.md]
+
+### 出力
+```
+-2 -2 -1 -1 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask::operator+`](op_unary_plus.md)
+- [`std::simd::basic_mask::operator-`](op_unary_minus.md)
+- [`std::simd::basic_mask::operator basic_vec`](op_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_greater.md
+++ b/reference/simd/basic_mask/op_greater.md
@@ -1,0 +1,71 @@
+# operator>
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask operator>(const basic_mask& lhs,
+                                      const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_mask`](../basic_mask.md)を要素ごとに「より大きい」で比較する。各要素は`bool`であり、`true`が`false`より大きいものとして順序付けられる。
+
+比較結果は単一の`bool`ではなく、要素ごとの比較結果を保持する[`basic_mask`](../basic_mask.md)として返される。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`>`を適用した結果で初期化された`basic_mask`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] > rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4>::mask_type a = [](int i) { return i < 2; };  // {true, true, false, false}
+  simd::vec<int, 4>::mask_type b = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  // 要素ごとの「より大きい」比較。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a > b);  // {false, true, false, false}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link size.md]
+* m[i][link op_at.md]
+
+### 出力
+```
+false true false false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_greater_equal.md
+++ b/reference/simd/basic_mask/op_greater_equal.md
@@ -1,0 +1,71 @@
+# operator>=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask operator>=(const basic_mask& lhs,
+                                       const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_mask`](../basic_mask.md)を要素ごとに「以上」で比較する。各要素は`bool`であり、`true`が`false`より大きいものとして順序付けられる。
+
+比較結果は単一の`bool`ではなく、要素ごとの比較結果を保持する[`basic_mask`](../basic_mask.md)として返される。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`>=`を適用した結果で初期化された`basic_mask`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] >= rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4>::mask_type a = [](int i) { return i < 2; };  // {true, true, false, false}
+  simd::vec<int, 4>::mask_type b = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  // 要素ごとの「以上」比較。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a >= b);  // {true, true, false, true}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link size.md]
+* m[i][link op_at.md]
+
+### 出力
+```
+true true false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_less.md
+++ b/reference/simd/basic_mask/op_less.md
@@ -1,0 +1,71 @@
+# operator<
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask operator<(const basic_mask& lhs,
+                                      const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_mask`](../basic_mask.md)を要素ごとに「より小さい」で比較する。各要素は`bool`であり、`true`が`false`より大きいものとして順序付けられる。
+
+比較結果は単一の`bool`ではなく、要素ごとの比較結果を保持する[`basic_mask`](../basic_mask.md)として返される。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`<`を適用した結果で初期化された`basic_mask`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] < rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4>::mask_type a = [](int i) { return i < 2; };  // {true, true, false, false}
+  simd::vec<int, 4>::mask_type b = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  // 要素ごとの「より小さい」比較。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a < b);  // {false, false, true, false}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link size.md]
+* m[i][link op_at.md]
+
+### 出力
+```
+false false true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_less_equal.md
+++ b/reference/simd/basic_mask/op_less_equal.md
@@ -1,0 +1,71 @@
+# operator<=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask operator<=(const basic_mask& lhs,
+                                       const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_mask`](../basic_mask.md)を要素ごとに「以下」で比較する。各要素は`bool`であり、`true`が`false`より大きいものとして順序付けられる。
+
+比較結果は単一の`bool`ではなく、要素ごとの比較結果を保持する[`basic_mask`](../basic_mask.md)として返される。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`<=`を適用した結果で初期化された`basic_mask`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] <= rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4>::mask_type a = [](int i) { return i < 2; };  // {true, true, false, false}
+  simd::vec<int, 4>::mask_type b = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  // 要素ごとの「以下」比較。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a <= b);  // {true, false, true, true}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link size.md]
+* m[i][link op_at.md]
+
+### 出力
+```
+true false true true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_logical_and.md
+++ b/reference/simd/basic_mask/op_logical_and.md
@@ -1,0 +1,74 @@
+# operator&&
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask
+  operator&&(const basic_mask& lhs, const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つのマスクの要素ごとの論理積を求める。
+
+## 戻り値
+`lhs`と`rhs`に対して要素ごとに論理積を適用した結果で初期化された`basic_mask`オブジェクトを返す。
+
+## 例外
+投げない。
+
+## 備考
+この関数は[*Hidden friends*](/article/lib/hidden_friends.md)として定義される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  auto m1 = (a >= 1);                            // {false, true, true, true}
+  auto m2 = (a < 3);                             // {true, true, true, false}
+
+  auto r = m1 && m2;                             // {false, true, true, false}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* m1 && m2[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* r.size()[link size.md]
+* r[i][link op_at.md]
+
+### 出力
+```
+false true true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask::operator||`](op_logical_or.md)
+- [`std::simd::basic_mask::operator&`](op_and.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_logical_or.md
+++ b/reference/simd/basic_mask/op_logical_or.md
@@ -1,0 +1,74 @@
+# operator||
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask
+  operator||(const basic_mask& lhs, const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つのマスクの要素ごとの論理和を求める。
+
+## 戻り値
+`lhs`と`rhs`に対して要素ごとに論理和を適用した結果で初期化された`basic_mask`オブジェクトを返す。
+
+## 例外
+投げない。
+
+## 備考
+この関数は[*Hidden friends*](/article/lib/hidden_friends.md)として定義される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  auto m1 = (a >= 1);                            // {false, true, true, true}
+  auto m2 = (a < 3);                             // {true, true, true, false}
+
+  auto r = m1 || m2;                             // {true, true, true, true}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* m1 || m2[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* r.size()[link size.md]
+* r[i][link op_at.md]
+
+### 出力
+```
+true true true true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask::operator&&`](op_logical_and.md)
+- [`std::simd::basic_mask::operator|`](op_or.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_not.md
+++ b/reference/simd/basic_mask/op_not.md
@@ -1,0 +1,69 @@
+# operator!
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr basic_mask operator!() const noexcept;
+```
+
+## 概要
+各要素の論理値を反転する。
+
+## 戻り値
+各要素`i`（`0`以上`size()`未満）が`!operator[](i)`で初期化された`basic_mask`オブジェクトを返す。
+
+## 例外
+投げない。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4>::mask_type m = (a < 2);        // {true, true, false, false}
+
+  auto r = !m;                                   // {false, false, true, true}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* !m[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* r.size()[link size.md]
+* r[i][link op_at.md]
+
+### 出力
+```
+false false true true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask::operator&&`](op_logical_and.md)
+- [`std::simd::basic_mask::operator||`](op_logical_or.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_not_equal.md
+++ b/reference/simd/basic_mask/op_not_equal.md
@@ -1,0 +1,71 @@
+# operator!=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask operator!=(const basic_mask& lhs,
+                                       const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_mask`](../basic_mask.md)を要素ごとに非等値比較する。
+
+比較結果は単一の`bool`ではなく、要素ごとの比較結果を保持する[`basic_mask`](../basic_mask.md)として返される。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`!=`を適用した結果で初期化された`basic_mask`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] != rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4>::mask_type a = [](int i) { return i < 2; };  // {true, true, false, false}
+  simd::vec<int, 4>::mask_type b = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  // 要素ごとの非等値比較。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a != b);  // {false, true, true, false}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link size.md]
+* m[i][link op_at.md]
+
+### 出力
+```
+false true true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_or.md
+++ b/reference/simd/basic_mask/op_or.md
@@ -1,0 +1,75 @@
+# operator|
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask
+  operator|(const basic_mask& lhs, const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つのマスクの要素ごとのビット論理和を求める。
+
+## 戻り値
+`lhs`と`rhs`に対して要素ごとにビット論理和を適用した結果で初期化された`basic_mask`オブジェクトを返す。
+
+## 例外
+投げない。
+
+## 備考
+この関数は[*Hidden friends*](/article/lib/hidden_friends.md)として定義される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  auto m1 = (a >= 1);                            // {false, true, true, true}
+  auto m2 = (a < 3);                             // {true, true, true, false}
+
+  auto r = m1 | m2;                              // {true, true, true, true}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* m1 | m2[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* r.size()[link size.md]
+* r[i][link op_at.md]
+
+### 出力
+```
+true true true true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask::operator&`](op_and.md)
+- [`std::simd::basic_mask::operator^`](op_xor.md)
+- [`std::simd::basic_mask::operator||`](op_logical_or.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_or_assign.md
+++ b/reference/simd/basic_mask/op_or_assign.md
@@ -1,0 +1,71 @@
+# operator|=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask& operator|=(basic_mask& lhs,
+                                        const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_mask`](../basic_mask.md)を要素ごとにビット論理和し、その結果を左辺に代入する。
+
+## 効果
+`lhs`と`rhs`の対応する要素それぞれに`|`を適用した結果を、`lhs`の各要素に代入する。
+
+## 戻り値
+`lhs`。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4>::mask_type a = [](int i) { return i < 2; };  // {true, true, false, false}
+  simd::vec<int, 4>::mask_type b = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  a |= b;  // {true, true, true, false}
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* a.size()[link size.md]
+* a[i][link op_at.md]
+
+### 出力
+```
+true true true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_unary_minus.md
+++ b/reference/simd/basic_mask/op_unary_minus.md
@@ -1,0 +1,73 @@
+# operator-
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr /*see below*/ operator-() const noexcept;
+```
+
+## 概要
+各要素を[`basic_vec`](../basic_vec.md)へ変換したうえで、単項マイナス演算を適用する。
+
+## 戻り値
+各要素`i`（`0`以上`size()`未満）が`-operator[](i)`で初期化された、[`basic_vec`](../basic_vec.md)のオブジェクトを返す。各要素の`bool`値は整数へ変換されたうえで単項マイナス演算が適用される。
+
+## 例外
+投げない。
+
+## 備考
+戻り値型は、`sizeof(I) == Bytes`となる符号付き整数型`I`が存在する場合、要素型がそのような符号付き整数型で要素数が`size()`と等しい、有効な[`basic_vec`](../basic_vec.md)の特殊化`R`となる。そのような符号付き整数型が存在しない場合、この演算子は`delete`定義され、戻り値型は未規定である。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4>::mask_type m = (a < 2);        // {true, true, false, false}
+
+  auto r = -m;                                   // {-1, -1, 0, 0}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* -m[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* r.size()[link ../basic_vec/size.md]
+* r[i][link ../basic_vec/op_at.md]
+
+### 出力
+```
+-1 -1 0 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask::operator+`](op_unary_plus.md)
+- [`std::simd::basic_mask::operator~`](op_flip.md)
+- [`std::simd::basic_mask::operator basic_vec`](op_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_unary_plus.md
+++ b/reference/simd/basic_mask/op_unary_plus.md
@@ -1,0 +1,73 @@
+# operator+
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr /*see below*/ operator+() const noexcept;
+```
+
+## 概要
+各要素を[`basic_vec`](../basic_vec.md)へ変換したうえで、単項プラス演算を適用する。
+
+## 戻り値
+各要素`i`（`0`以上`size()`未満）が`+operator[](i)`で初期化された、[`basic_vec`](../basic_vec.md)のオブジェクトを返す。各要素の`bool`値は整数へ変換されたうえで単項プラス演算が適用される。
+
+## 例外
+投げない。
+
+## 備考
+戻り値型は、`sizeof(I) == Bytes`となる符号付き整数型`I`が存在する場合、要素型がそのような符号付き整数型で要素数が`size()`と等しい、有効な[`basic_vec`](../basic_vec.md)の特殊化`R`となる。そのような符号付き整数型が存在しない場合、この演算子は`delete`定義され、戻り値型は未規定である。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4>::mask_type m = (a < 2);        // {true, true, false, false}
+
+  auto r = +m;                                   // {1, 1, 0, 0}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* +m[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* r.size()[link ../basic_vec/size.md]
+* r[i][link ../basic_vec/op_at.md]
+
+### 出力
+```
+1 1 0 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask::operator-`](op_unary_minus.md)
+- [`std::simd::basic_mask::operator~`](op_flip.md)
+- [`std::simd::basic_mask::operator basic_vec`](op_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_vec.md
+++ b/reference/simd/basic_mask/op_vec.md
@@ -1,0 +1,83 @@
+# operator basic_vec
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+template<class U, class A>
+constexpr explicit(sizeof(U) != Bytes)
+  operator basic_vec<U, A>() const noexcept; // (1) C++26
+```
+* basic_vec[link ../basic_vec.md]
+
+## 概要
+マスクを、対応する要素型の[`basic_vec`](../basic_vec.md)へ変換する。各要素は`true`が`1`、`false`が`0`に変換される。
+
+要素型のサイズがマスクの`Bytes`と等しくない場合、この変換演算子は`explicit`となる。
+
+
+## テンプレートパラメータ制約
+- (1) : 変換先[`basic_vec`](../basic_vec.md)`<U, A>`の要素数がマスクの要素数と等しいこと
+
+
+## 戻り値
+- (1) : すべての`i`（`0`以上`size()`未満）について、第`i`要素が`static_cast<U>(operator[](i))`で初期化された[`basic_vec`](../basic_vec.md)オブジェクト
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::mask<int, 4> m = (a < 2);                  // {true, true, false, false}
+
+  // マスクをbasic_vecへ変換する（true→1, false→0）
+  simd::vec<int, 4> v = static_cast<simd::vec<int, 4>>(m);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::print("{} ", v[i]);
+  }
+  std::println("");
+}
+```
+* simd::mask[link ../basic_mask.md]
+* simd::vec[link ../basic_vec.md]
+* v.size()[link size.md]
+* v[i][link op_at.md]
+
+### 出力
+```
+1 1 0 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+- [`to_bitset`](to_bitset.md)
+- [`to_ullong`](to_ullong.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_xor.md
+++ b/reference/simd/basic_mask/op_xor.md
@@ -1,0 +1,74 @@
+# operator^
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask
+  operator^(const basic_mask& lhs, const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つのマスクの要素ごとのビット排他的論理和を求める。
+
+## 戻り値
+`lhs`と`rhs`に対して要素ごとにビット排他的論理和を適用した結果で初期化された`basic_mask`オブジェクトを返す。
+
+## 例外
+投げない。
+
+## 備考
+この関数は[*Hidden friends*](/article/lib/hidden_friends.md)として定義される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  auto m1 = (a >= 1);                            // {false, true, true, true}
+  auto m2 = (a < 3);                             // {true, true, true, false}
+
+  auto r = m1 ^ m2;                              // {true, false, false, true}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* m1 ^ m2[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* r.size()[link size.md]
+* r[i][link op_at.md]
+
+### 出力
+```
+true false false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask::operator&`](op_and.md)
+- [`std::simd::basic_mask::operator|`](op_or.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/op_xor_assign.md
+++ b/reference/simd/basic_mask/op_xor_assign.md
@@ -1,0 +1,71 @@
+# operator^=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_mask& operator^=(basic_mask& lhs,
+                                        const basic_mask& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_mask`](../basic_mask.md)を要素ごとにビット排他的論理和し、その結果を左辺に代入する。
+
+## 効果
+`lhs`と`rhs`の対応する要素それぞれに`^`を適用した結果を、`lhs`の各要素に代入する。
+
+## 戻り値
+`lhs`。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4>::mask_type a = [](int i) { return i < 2; };  // {true, true, false, false}
+  simd::vec<int, 4>::mask_type b = [](int i) { return i % 2 == 0; };  // {true, false, true, false}
+
+  a ^= b;  // {false, true, true, false}
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* a.size()[link size.md]
+* a[i][link op_at.md]
+
+### 出力
+```
+false true true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/size.md
+++ b/reference/simd/basic_mask/size.md
@@ -1,0 +1,65 @@
+# size
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* variable[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+static constexpr integral_constant<
+  simd-size-type, mask-size-v<Bytes, Abi>> size {};
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* mask-size-v[link /reference/simd/mask-size-v.md]
+* integral_constant[link /reference/type_traits/integral_constant.md]
+
+## 概要
+`basic_mask`が保持する要素数を表す静的メンバ変数である。
+
+要素数を型情報として保持する[`std::integral_constant`](/reference/type_traits/integral_constant.md)であり、`size`または`size()`のように関数呼び出し構文でも要素数を取得できる。
+
+対応する[`basic_vec`](../basic_vec.md)の要素数と一致する。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::mask<int, 4> m{true};
+
+  // 静的メンバ変数としてアクセスできる
+  std::println("{}", simd::mask<int, 4>::size);
+
+  // integral_constantであるため、関数呼び出し構文でも取得できる
+  std::println("{}", m.size());
+}
+```
+* simd::mask[link ../basic_mask.md]
+* size[color ff0000]
+* m.size()[color ff0000]
+
+### 出力
+```
+4
+4
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/to_bitset.md
+++ b/reference/simd/basic_mask/to_bitset.md
@@ -1,0 +1,72 @@
+# to_bitset
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr bitset<size()> to_bitset() const noexcept; // (1) C++26
+```
+* bitset[link /reference/bitset/bitset.md]
+* size()[link size.md]
+
+## 概要
+マスクの各要素を[`std::bitset`](/reference/bitset/bitset.md)の対応するビットに変換して返す。
+
+
+## 戻り値
+すべての`i`（`0`以上`size()`未満）について、第`i`ビットが`operator[](i)`で初期化された[`std::bitset`](/reference/bitset/bitset.md)`<size()>`オブジェクト
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <bitset>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::mask<int, 4> m = (a < 2);                  // {true, true, false, false}
+
+  std::bitset<4> bs = m.to_bitset();
+
+  // 第0ビットが先頭要素に対応する
+  std::println("{}", bs.to_string());
+}
+```
+* simd::mask[link ../basic_mask.md]
+* m.to_bitset()[color ff0000]
+* bs.to_string()[link /reference/bitset/bitset/to_string.md]
+
+### 出力
+```
+0011
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`to_ullong`](to_ullong.md)
+- [`operator basic_vec`](op_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_mask/to_ullong.md
+++ b/reference/simd/basic_mask/to_ullong.md
@@ -1,0 +1,74 @@
+# to_ullong
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_mask[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr unsigned long long to_ullong() const; // (1) C++26
+```
+
+## 概要
+マスクの各要素をビットとする整数値を`unsigned long long`型で返す。第`i`要素が第`i`ビットに対応する。
+
+
+## 事前条件
+`unsigned long long`のビット幅を`N`とする。以下のいずれかを満たすこと。
+
+- `size() <= N`である
+- すべての`i`（`N`以上`size()`未満）について、`operator[](i)`が`false`を返す
+
+
+## 戻り値
+`*this`のビットに対応する整数値
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::mask<int, 4> m = (a < 2);                  // {true, true, false, false}
+
+  // 第0要素が最下位ビットに対応する（0b0011 == 3）
+  unsigned long long value = m.to_ullong();
+  std::println("{}", value);
+}
+```
+* simd::mask[link ../basic_mask.md]
+* m.to_ullong()[color ff0000]
+
+### 出力
+```
+3
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`to_bitset`](to_bitset.md)
+- [`operator basic_vec`](op_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec.md
+++ b/reference/simd/basic_vec.md
@@ -1,0 +1,196 @@
+# basic_vec
+* simd[meta header]
+* std::simd[meta namespace]
+* class template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi = native-abi<T>>
+  class basic_vec;
+
+  template<class T, simd-size-type N = simd-size-v<T, native-abi<T>>>
+  using vec = basic_vec<T, deduce-abi-t<T, N>>;
+}
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* simd-size-v[link /reference/simd/simd-size-v.md]
+* native-abi[link /reference/simd/native-abi.md]
+* deduce-abi-t[link /reference/simd/deduce-abi-t.md]
+
+## 概要
+`basic_vec`は、複数の値をまとめて保持し、それらに対する演算を一度に（データ並列に）適用するためのクラスである。SIMD（Single Instruction Stream, Multiple Data Stream）命令やSIMDレジスタといった、データ並列実行資源による高速化を活用することを意図している。
+
+`basic_vec<T, Abi>`は、要素型`T`（[「vectorizable type」](/reference/simd.md#vectorizable-type)）の値を「width」（要素数）個だけ保持する。要素は`0`から`width - 1`まで添字付けされる。算術演算・比較演算などの各操作は、対応する要素同士に対して要素ごと（element-wise）に、互いに順序付けなく適用される。
+
+通常は、要素数を明示的に指定できる別名`vec<T, N>`、または処理系が推奨する既定の要素数を用いる`basic_vec<T>`を使用する。
+
+- `T`: 要素型。[「vectorizable type」](/reference/simd.md#vectorizable-type)でなければならない
+- `Abi`: 要素数と内部表現を決定するABIタグ型。既定では処理系ネイティブのABIタグが選択される
+
+`vec<T, N>`は、要素数を`N`に指定した`basic_vec`の別名である。
+
+### 有効な特殊化・無効な特殊化
+`basic_vec<T, Abi>`の各特殊化は、「有効」（enabled）か「無効」（disabled）のいずれかである。`T`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であり、`Abi`が`1`以上`64`以下の要素数に対応するABIタグを表すとき、その特殊化は有効となる。有効な`basic_vec`は[トリビアルコピー可能](/reference/type_traits/is_trivially_copyable.md)である。
+
+無効な特殊化は、デフォルトコンストラクタ・デストラクタ・コピーコンストラクタ・コピー代入演算子がすべて`delete`定義され、メンバとしては`value_type`・`abi_type`・`mask_type`のみを持つ。
+
+
+## メンバ関数
+### 構築／代入
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`(constructor)`](basic_vec/op_constructor.md) | コンストラクタ | C++26 |
+| `(destructor)` | デストラクタ（トリビアル） | C++26 |
+
+### イテレータ
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`begin`](basic_vec/begin.md)   | 先頭要素を指すイテレータを取得する | C++26 |
+| [`end`](basic_vec/end.md)       | 番兵を取得する | C++26 |
+| [`cbegin`](basic_vec/cbegin.md) | 先頭要素を指す読み取り専用イテレータを取得する | C++26 |
+| [`cend`](basic_vec/cend.md)     | 番兵を取得する | C++26 |
+
+### 要素アクセス
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator[]`](basic_vec/op_at.md) | 要素または要素の並べ替えを取得する | C++26 |
+| [`real`](basic_vec/real.md)        | 複素数要素の実部を取得／設定する | C++26 |
+| [`imag`](basic_vec/imag.md)        | 複素数要素の虚部を取得／設定する | C++26 |
+
+### 単項演算子
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator++`](basic_vec/op_increment.md) | インクリメント | C++26 |
+| [`operator--`](basic_vec/op_decrement.md) | デクリメント | C++26 |
+| [`operator!`](basic_vec/op_not.md)        | 論理反転 | C++26 |
+| [`operator~`](basic_vec/op_flip.md)       | ビット反転 | C++26 |
+| [`operator+`](basic_vec/op_unary_plus.md)  | 単項プラス | C++26 |
+| [`operator-`](basic_vec/op_unary_minus.md) | 単項マイナス（符号反転） | C++26 |
+
+## 静的メンバ変数
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`size`](basic_vec/size.md) | 要素数（「width」）を表す[`std::integral_constant`](/reference/type_traits/integral_constant.md) | C++26 |
+
+## メンバ型
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| `value_type`     | 要素型`T` | C++26 |
+| `mask_type`      | 対応するマスク型 [`basic_mask`](basic_mask.md)`<sizeof(T), Abi>` | C++26 |
+| `abi_type`       | ABIタグ型`Abi` | C++26 |
+| [`real-type`](basic_vec/real-type.md) | 複素数要素のとき、実数型を要素とする`basic_vec`（説明専用） | C++26 |
+| `iterator`       | イテレータ型（説明専用） | C++26 |
+| `const_iterator` | 読み取り専用イテレータ型（説明専用） | C++26 |
+
+## 非メンバ（*Hidden friends*）関数
+### 二項算術・ビット演算子
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator+`](basic_vec/op_plus.md)         | 加算 | C++26 |
+| [`operator-`](basic_vec/op_minus.md)        | 減算 | C++26 |
+| [`operator*`](basic_vec/op_multiply.md)     | 乗算 | C++26 |
+| [`operator/`](basic_vec/op_divide.md)       | 除算 | C++26 |
+| [`operator%`](basic_vec/op_modulo.md)       | 剰余 | C++26 |
+| [`operator&`](basic_vec/op_and.md)          | ビット論理積 | C++26 |
+| <code>[operator&#x7C;](basic_vec/op_or.md)</code>          | ビット論理和 | C++26 |
+| [`operator^`](basic_vec/op_xor.md)          | ビット排他的論理和 | C++26 |
+| [`operator<<`](basic_vec/op_left_shift.md)  | 左ビットシフト | C++26 |
+| [`operator>>`](basic_vec/op_right_shift.md) | 右ビットシフト | C++26 |
+
+### 複合代入演算子
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator+=`](basic_vec/op_plus_assign.md)         | 加算の複合代入 | C++26 |
+| [`operator-=`](basic_vec/op_minus_assign.md)        | 減算の複合代入 | C++26 |
+| [`operator*=`](basic_vec/op_multiply_assign.md)     | 乗算の複合代入 | C++26 |
+| [`operator/=`](basic_vec/op_divide_assign.md)       | 除算の複合代入 | C++26 |
+| [`operator%=`](basic_vec/op_modulo_assign.md)       | 剰余の複合代入 | C++26 |
+| [`operator&=`](basic_vec/op_and_assign.md)          | ビット論理積の複合代入 | C++26 |
+| <code>[operator&#x7C;=](basic_vec/op_or_assign.md)</code>          | ビット論理和の複合代入 | C++26 |
+| [`operator^=`](basic_vec/op_xor_assign.md)          | ビット排他的論理和の複合代入 | C++26 |
+| [`operator<<=`](basic_vec/op_left_shift_assign.md)  | 左ビットシフトの複合代入 | C++26 |
+| [`operator>>=`](basic_vec/op_right_shift_assign.md) | 右ビットシフトの複合代入 | C++26 |
+
+### 比較演算子
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`operator==`](basic_vec/op_equal.md)         | 等値比較（結果は[`basic_mask`](basic_mask.md)） | C++26 |
+| [`operator!=`](basic_vec/op_not_equal.md)     | 非等値比較 | C++26 |
+| [`operator>=`](basic_vec/op_greater_equal.md) | 以上を判定する | C++26 |
+| [`operator<=`](basic_vec/op_less_equal.md)    | 以下を判定する | C++26 |
+| [`operator>`](basic_vec/op_greater.md)        | より大きいかを判定する | C++26 |
+| [`operator<`](basic_vec/op_less.md)           | より小さいかを判定する | C++26 |
+
+## 推論補助
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`(deduction_guide)`](basic_vec/op_deduction_guide.md) | クラステンプレートの推論補助 | C++26 |
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // 4要素のintデータ並列型
+  simd::vec<int, 4> a([](int i) { return i + 1; });  // {1, 2, 3, 4}
+  simd::vec<int, 4> b = 10;                          // {10, 10, 10, 10}
+
+  // 要素ごとの加算
+  simd::vec<int, 4> c = a + b;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::print("{} ", c[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link basic_vec/size.md]
+
+### 出力
+```
+11 12 13 14 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P3287R3 Exploration of namespaces for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3287r3.pdf)
+    - `std::simd`名前空間に配置することが検討された
+- [P3691R1 Reconsider naming of the namespace for "std::simd"](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3691r1.pdf)
+    - 名前空間を`std::simd`とし、主要クラスを`basic_vec`/`vec`に改名した
+- [P2876R3 Proposal to extend `std::simd` with more constructors and accessors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2876r3.html)
+    - コンストラクタとアクセサが追加された
+- [P3480R6 `std::simd` is a range](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3480r6.pdf)
+    - イテレータを追加し、Rangeとして扱えるようになった

--- a/reference/simd/basic_vec/begin.md
+++ b/reference/simd/basic_vec/begin.md
@@ -1,0 +1,72 @@
+# begin
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr iterator begin() noexcept;             // (1) C++26
+constexpr const_iterator begin() const noexcept; // (2) C++26
+```
+
+## 概要
+先頭要素を指すイテレータを取得する。
+
+`basic_vec`は[`begin`](begin.md)/[`end`](end.md)を備えることで、要素を走査できるRangeとして扱える。
+
+
+## 戻り値
+先頭（`0`番目）の要素を指すイテレータ。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i + 1; });  // {1, 2, 3, 4}
+
+  for (auto it = v.begin(); it != v.end(); ++it) {
+    std::print("{} ", *it);
+  }
+  std::println("");
+}
+```
+* v.begin()[color ff0000]
+* v.end()[link end.md]
+
+### 出力
+```
+1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::end`](end.md)
+- [`std::simd::basic_vec::cbegin`](cbegin.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された
+- [P3480R6 `std::simd` is a range](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3480r6.pdf)
+    - イテレータを追加し、Rangeとして扱えるようになった

--- a/reference/simd/basic_vec/cbegin.md
+++ b/reference/simd/basic_vec/cbegin.md
@@ -1,0 +1,69 @@
+# cbegin
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr const_iterator cbegin() const noexcept;
+```
+
+## 概要
+先頭要素を指す読み取り専用イテレータを取得する。
+
+
+## 戻り値
+先頭（`0`番目）の要素を指す読み取り専用イテレータ。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i + 1; });  // {1, 2, 3, 4}
+
+  for (auto it = v.cbegin(); it != v.cend(); ++it) {
+    std::print("{} ", *it);
+  }
+  std::println("");
+}
+```
+* v.cbegin()[color ff0000]
+* v.cend()[link cend.md]
+
+### 出力
+```
+1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::cend`](cend.md)
+- [`std::simd::basic_vec::begin`](begin.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された
+- [P3480R6 `std::simd` is a range](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3480r6.pdf)
+    - イテレータを追加し、Rangeとして扱えるようになった

--- a/reference/simd/basic_vec/cend.md
+++ b/reference/simd/basic_vec/cend.md
@@ -1,0 +1,72 @@
+# cend
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr default_sentinel_t cend() const noexcept;
+```
+* default_sentinel_t[link /reference/iterator/default_sentinel_t.md]
+
+## 概要
+末尾を表す番兵を取得する。
+
+読み取り専用イテレータ[`cbegin`](cbegin.md)と対で用いる。要素数は静的に決まるため、末尾は番兵[`std::default_sentinel_t`](/reference/iterator/default_sentinel_t.md)で表される。
+
+
+## 戻り値
+番兵[`std::default_sentinel`](/reference/iterator/default_sentinel_t.md)。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i + 1; });  // {1, 2, 3, 4}
+
+  for (auto it = v.cbegin(); it != v.cend(); ++it) {
+    std::print("{} ", *it);
+  }
+  std::println("");
+}
+```
+* v.cend()[color ff0000]
+* v.cbegin()[link cbegin.md]
+
+### 出力
+```
+1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::cbegin`](cbegin.md)
+- [`std::simd::basic_vec::end`](end.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された
+- [P3480R6 `std::simd` is a range](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3480r6.pdf)
+    - イテレータを追加し、Rangeとして扱えるようになった

--- a/reference/simd/basic_vec/end.md
+++ b/reference/simd/basic_vec/end.md
@@ -1,0 +1,72 @@
+# end
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr default_sentinel_t end() const noexcept;
+```
+* default_sentinel_t[link /reference/iterator/default_sentinel_t.md]
+
+## 概要
+末尾を表す番兵を取得する。
+
+`basic_vec`は[`begin`](begin.md)/[`end`](end.md)を備えることで、要素を走査できるRangeとして扱える。要素数は静的に決まるため、末尾は番兵[`std::default_sentinel_t`](/reference/iterator/default_sentinel_t.md)で表される。
+
+
+## 戻り値
+番兵[`std::default_sentinel`](/reference/iterator/default_sentinel_t.md)。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i + 1; });  // {1, 2, 3, 4}
+
+  for (auto it = v.begin(); it != v.end(); ++it) {
+    std::print("{} ", *it);
+  }
+  std::println("");
+}
+```
+* v.end()[color ff0000]
+* v.begin()[link begin.md]
+
+### 出力
+```
+1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::begin`](begin.md)
+- [`std::simd::basic_vec::cend`](cend.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された
+- [P3480R6 `std::simd` is a range](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3480r6.pdf)
+    - イテレータを追加し、Rangeとして扱えるようになった

--- a/reference/simd/basic_vec/imag.md
+++ b/reference/simd/basic_vec/imag.md
@@ -1,0 +1,104 @@
+# imag
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr real-type imag() const noexcept;        // (1) C++26
+
+constexpr void imag(const real-type& v) noexcept; // (2) C++26
+```
+* real-type[link real-type.md]
+
+## 概要
+複素数要素型の虚部を取得／設定する。
+
+- (1) : 各要素の虚部を集めたデータ並列型を取得する。
+- (2) : 各要素の虚部を`v`の対応する要素で置き換える。
+
+[`real-type`](real-type.md)は、要素型`T`が[`std::complex`](/reference/complex/complex.md)`<U>`のとき、要素型を`U`に置き換えた`basic_vec`である。
+
+
+## テンプレートパラメータ制約
+- (1), (2) : `basic_vec`が複素数のデータ並列型（`simd-complex`）であること。
+
+
+## 効果
+- (2) : すべての`i`（`0`以上`size()`未満）について、第`i`要素を`value_type((*this)[i].real(), v[i])`で置き換える。
+
+
+## 戻り値
+- (1) : 第`i`要素を`(*this)[i].imag()`とするデータ並列型。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+template <class V>
+void print(const char* name, const V& v)
+{
+  std::print("{}: ", name);
+  for (int i = 0; i < v.size(); ++i) {
+    std::print("{} ", v[i]);
+  }
+  std::println("");
+}
+
+int main()
+{
+  simd::vec<float, 4> reals([](int i) { return float(i + 1); });        // {1, 2, 3, 4}
+  simd::vec<float, 4> imags([](int i) { return float((i + 1) * 10); }); // {10, 20, 30, 40}
+
+  // 実部と虚部からcomplexのデータ並列型を構築する
+  simd::vec<std::complex<float>, 4> v{reals, imags};
+
+  // 虚部を取得する
+  ::print("imag", v.imag());
+
+  // 虚部を設定する
+  v.imag(simd::vec<float, 4>(0.0f));
+  ::print("real", v.real());
+  ::print("imag", v.imag());
+}
+```
+* v.imag()[color ff0000]
+* v.real()[link real.md]
+
+### 出力
+```
+imag: 10 20 30 40 
+real: 1 2 3 4 
+imag: 0 0 0 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::real`](real.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された
+- [P2876R3 Proposal to extend `std::simd` with more constructors and accessors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2876r3.html)
+    - 複素数要素の実部・虚部にアクセスするアクセサが追加された

--- a/reference/simd/basic_vec/op_and.md
+++ b/reference/simd/basic_vec/op_and.md
@@ -1,0 +1,76 @@
+# operator&
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec operator&(const basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトの対応する要素同士でビットごとの論理積を求める。要素型が整数型である場合に使用できる。
+
+*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+式`a & b`（`a`と`b`は`value_type`型）が適格であること。
+
+
+## 戻り値
+`lhs`と`rhs`にビット論理積を要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::uint8_t av[] = {0b00001100, 0b00001010, 0b00000110, 0b00000101};
+  std::uint8_t bv[] = {0b00001010, 0b00000110, 0b00000011, 0b00000100};
+  simd::vec<std::uint8_t, 4> a = [&](int i) { return av[i]; };
+  simd::vec<std::uint8_t, 4> b = [&](int i) { return bv[i]; };
+
+  simd::vec<std::uint8_t, 4> c = a & b;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::println("{:08b} & {:08b} -> {:08b}", a[i], b[i], c[i]);
+  }
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+
+### 出力
+```
+00001100 & 00001010 -> 00001000
+00001010 & 00000110 -> 00000010
+00000110 & 00000011 -> 00000010
+00000101 & 00000100 -> 00000100
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_and_assign.md
+++ b/reference/simd/basic_vec/op_and_assign.md
@@ -1,0 +1,78 @@
+# operator&=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec& operator&=(basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+* basic_vec[color ff0000]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトを要素ごとにビット論理積し、その結果を左辺に代入する。
+
+## テンプレートパラメータ制約
+`value_type`型の値`a`, `b`に対して、式`a & b`が有効であること。
+
+## 効果
+`lhs`と`rhs`に対して、ビット論理積を要素ごとの演算として適用する。
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::uint8_t, 4> a = [](int i) { return static_cast<std::uint8_t>(i); };  // {0, 1, 2, 3}
+  simd::vec<std::uint8_t, 4> b = std::uint8_t{1};  // {1, 1, 1, 1}
+
+  simd::vec<std::uint8_t, 4> a0 = a;  // 演算前の値
+  a &= b;
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::println("{:08b} & {:08b} -> {:08b}", a0[i], b[i], a[i]);
+  }
+}
+```
+* a &= b[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+00000000 & 00000001 -> 00000000
+00000001 & 00000001 -> 00000001
+00000010 & 00000001 -> 00000000
+00000011 & 00000001 -> 00000001
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator&`](op_and.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_at.md
+++ b/reference/simd/basic_vec/op_at.md
@@ -1,0 +1,98 @@
+# operator[]
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr value_type
+  operator[](simd-size-type i) const;    // (1) C++26
+
+template<simd-integral I>
+constexpr resize_t<I::size(), basic_vec>
+  operator[](const I& indices) const;    // (2) C++26
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* simd-integral[link /reference/simd/simd-integral.md]
+
+## 概要
+要素を取得する、または複数のインデックスによって要素の並べ替えを取得する。
+
+- (1) : 指定した位置の単一要素の値を取得する。
+- (2) : インデックスを保持したデータ並列型`indices`によって、各要素を並べ替えた`basic_vec`を取得する。
+
+
+## 事前条件
+- (1) : `i >= 0 && i < size()`であること。
+
+
+## 効果
+- (2) : 以下と等価である。
+    ```cpp
+    return permute(*this, indices);
+    ```
+
+
+## 戻り値
+- (1) : 第`i`要素の値。
+- (2) : `indices`の第`j`要素が指すインデックスの要素を第`j`要素とする`basic_vec`。要素数は`indices`の要素数（`I::size()`）となる。
+
+
+## 例外
+- (1) : 投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return (i + 1) * 10; });  // {10, 20, 30, 40}
+
+  // (1) 単一要素の取得
+  std::println("{}", v[2]);
+
+  // (2) インデックス列による並べ替え
+  simd::vec<int, 4> indices([](int i) { return 3 - i; });   // {3, 2, 1, 0}
+  simd::vec<int, 4> r = v[indices];                         // {40, 30, 20, 10}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* v[2][color ff0000]
+* r.size()[link size.md]
+
+### 出力
+```
+30
+40 30 20 10 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された
+- [P2876R3 Proposal to extend `std::simd` with more constructors and accessors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2876r3.html)
+    - インデックス列による並べ替えを取得する添字演算子が追加された

--- a/reference/simd/basic_vec/op_constructor.md
+++ b/reference/simd/basic_vec/op_constructor.md
@@ -1,0 +1,155 @@
+# コンストラクタ
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr basic_vec() noexcept = default;                  // (1) C++26
+
+template<class U>
+constexpr basic_vec(U&& value) noexcept;                   // (2) C++26
+
+template<class U, class UAbi>
+constexpr explicit(/*see below*/)
+  basic_vec(const basic_vec<U, UAbi>& x) noexcept;         // (3) C++26
+
+template<class G>
+constexpr explicit basic_vec(G&& gen);                     // (4) C++26
+
+template<class R, class... Flags>
+constexpr basic_vec(R&& r, flags<Flags...> = {});          // (5) C++26
+
+template<class R, class... Flags>
+constexpr basic_vec(R&& r, const mask_type& mask,
+                    flags<Flags...> = {});                 // (6) C++26
+
+constexpr basic_vec(const real-type& reals,
+                    const real-type& imags = {}) noexcept; // (7) C++26
+```
+* real-type[link real-type.md]
+
+
+## 概要
+`basic_vec`オブジェクトを構築する。
+
+- (1) : デフォルトコンストラクタ。各要素をデフォルト初期化する。
+- (2) : ブロードキャストコンストラクタ。単一の値`value`を全要素にコピーする。
+- (3) : 変換コンストラクタ。要素数が等しい別の`basic_vec`から、要素ごとに要素型を変換して構築する。
+- (4) : ジェネレータコンストラクタ。各要素を、そのインデックスを渡した関数オブジェクト`gen`の呼び出し結果で構築する。
+- (5) : 連続範囲`r`の先頭から`size()`個の要素を読み込んで構築する。
+- (6) : マスク付き範囲読み込み。`mask`の`true`である要素だけを`r`から読み込み、`false`の要素は`value_type()`で初期化する。
+- (7) : 複素数要素型のとき、実部の並び`reals`と虚部の並び`imags`から構築する。
+
+
+## テンプレートパラメータ制約
+- (2) : `std::remove_cvref_t<U>`を`From`とする。次のいずれかを満たすこと。
+    - `U`が[`std::convertible_to`](/reference/concepts/convertible_to.md)`<value_type>`を満たし、かつ`From`が算術型ではないこと
+    - `From`が算術型であり、`From`から`value_type`への変換が値を保持する（value-preserving）こと
+    - `From`が定数ラッパー（[`std::integral_constant`](/reference/type_traits/integral_constant.md)等）であり、その`value`が算術型で、`value_type`で表現可能であること
+- (3) : `U`から`T`への明示的な変換が可能であり、変換元の要素数が`size()`と等しいこと
+- (4) : すべての`i`（`0`以上`size()`未満）について、`gen(std::integral_constant<simd-size-type, i>())`の型が[`std::convertible_to`](/reference/concepts/convertible_to.md)`<value_type>`を満たすこと。その型が算術型である場合は、`value_type`への変換が値を保持すること
+- (5), (6) : `R`が[`std::ranges::contiguous_range`](/reference/ranges/contiguous_range.md)かつ[`std::ranges::sized_range`](/reference/ranges/sized_range.md)であり、[`std::ranges::size`](/reference/ranges/size.md)`(r)`が定数式かつ`size()`と等しく、その要素型が[「vectorizable type」](/reference/simd.md#vectorizable-type)であって`T`へ明示的に変換可能であること
+- (7) : `basic_vec`が複素数のデータ並列型（`simd-complex`）であること
+
+
+## 適格要件
+- (5), (6) : テンプレートパラメータパック`Flags`が変換フラグを含まない場合、`r`の要素型から`value_type`への変換が値を保持すること
+
+
+## 事前条件
+- (5), (6) : `Flags`が整列フラグを含む場合、[`std::ranges::data`](/reference/ranges/data.md)`(r)`が要求される境界に整列していること
+
+
+## 効果
+- (1) : 各要素をデフォルト初期化する。
+- (2) : 引数を`value_type`へ変換した値で各要素を初期化する。
+- (3) : すべての`i`について、第`i`要素を`static_cast<T>(x[i])`で初期化する。
+- (4) : すべての`i`について、第`i`要素を`static_cast<value_type>(gen(std::integral_constant<simd-size-type, i>()))`で初期化する。`gen`は`i`ごとにちょうど1回、`i`の昇順で呼び出される。
+- (5), (6) : すべての`i`について、第`i`要素を`mask[i] ? static_cast<T>(std::ranges::data(r)[i]) : T()`で初期化する。(5)は`mask`をすべて`true`とみなす。
+- (7) : すべての`i`について、第`i`要素を`value_type(reals[i], imags[i])`で初期化する。
+
+
+## explicitになる条件
+- (3) : 次のいずれかを満たすとき`explicit`となる。
+    - `U`から`value_type`への変換が値を保持しない
+    - `U`と`value_type`がともに整数型であり、`U`の整数変換順位が`value_type`より高い
+    - `U`と`value_type`がともに浮動小数点型であり、`U`の浮動小数点変換順位が`value_type`より高い
+
+
+## 例外
+- (1), (2), (3), (6), (7) : 投げない
+- (4), (5) : 「例外を投げない」とは規定されない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <array>
+
+namespace simd = std::simd;
+
+template <class V>
+void print(const char* name, const V& v)
+{
+  std::print("{}: ", name);
+  for (int i = 0; i < v.size(); ++i) {
+    std::print("{} ", v[i]);
+  }
+  std::println("");
+}
+
+int main()
+{
+  // (2) ブロードキャスト：全要素を同じ値に
+  simd::vec<int, 4> b = 10;
+
+  // (4) ジェネレータ：各要素をインデックスから生成
+  simd::vec<int, 4> c([](int i) { return i + 1; });
+
+  // (5) 連続範囲から読み込み
+  std::array<int, 4> arr = {5, 6, 7, 8};
+  simd::vec<int, 4> d{arr};
+
+  // (3) 要素型を変換
+  simd::vec<float, 4> e = simd::vec<int, 4>(c);
+
+  ::print("b", b);
+  ::print("c", c);
+  ::print("d", d);
+  ::print("e", e);
+}
+```
+* simd::vec[link ../basic_vec.md]
+* v.size()[link size.md]
+
+### 出力
+```
+b: 10 10 10 10 
+c: 1 2 3 4 
+d: 5 6 7 8 
+e: 1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された
+- [P2876R3 Proposal to extend `std::simd` with more constructors and accessors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2876r3.html)
+    - 範囲読み込み・ジェネレータ・複素数用のコンストラクタが追加された

--- a/reference/simd/basic_vec/op_decrement.md
+++ b/reference/simd/basic_vec/op_decrement.md
@@ -1,0 +1,85 @@
+# operator--
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr basic_vec& operator--() noexcept;   // (1)
+constexpr basic_vec operator--(int) noexcept; // (2)
+```
+
+## 概要
+各要素をデクリメントする。
+
+- (1) : 前置デクリメント。各要素を1減らす。
+- (2) : 後置デクリメント。各要素を1減らす。
+
+
+## テンプレートパラメータ制約
+- (1) : `value_type`の値`a`に対して式`--a`が有効であること
+- (2) : `value_type`の値`a`に対して式`a--`が有効であること
+
+
+## 効果
+全ての要素を1減らす。
+
+
+## 戻り値
+- (1) : `*this`
+- (2) : デクリメントする前の`*this`のコピー
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+
+  // 各要素をデクリメントする
+  --a;                                          // {-1, 0, 1, 2}
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* --a;[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* a.size()[link size.md]
+* a[i][link op_at.md]
+
+### 出力
+```
+-1 0 1 2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator++`](op_increment.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_deduction_guide.md
+++ b/reference/simd/basic_vec/op_deduction_guide.md
@@ -1,0 +1,87 @@
+# 推論補助
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class R, class... Ts>
+  basic_vec(R&& r, Ts...) -> /*see below*/;           // (1)
+
+  template<std::size_t Bytes, class Abi>
+  basic_vec(basic_mask<Bytes, Abi>) -> /*see below*/; // (2)
+}
+```
+* basic_mask[link ../basic_mask.md]
+
+## 概要
+`basic_vec`クラステンプレートの型推論補助。
+
+- (1) : 連続範囲（contiguous range）かつ要素数が定数式となる範囲から推論する。推論される型は`vec<std::ranges::range_value_t<R>, std::ranges::size(r)>`と等価である。
+- (2) : [`basic_mask`](../basic_mask.md)から推論する。推論される型は`decltype(+k)`（マスクに単項プラスを適用して得られる`basic_vec`）と等価である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // (1) 要素数が定数となる連続範囲から推論する
+  std::array<int, 4> arr = {1, 2, 3, 4};
+  simd::basic_vec v {arr};                       // vec<int, 4>
+
+  // (2) マスクから推論する
+  simd::vec<int, 4> a = [](int i) { return i; }; // {0, 1, 2, 3}
+  auto m = (a < 2);                              // {true, true, false, false}
+  simd::basic_vec w {m};                         // {1, 1, 0, 0}
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::print("{} ", v[i]);
+  }
+  std::println("");
+
+  for (int i = 0; i < w.size(); ++i) {
+    std::print("{} ", w[i]);
+  }
+  std::println("");
+}
+```
+* simd::basic_vec[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* v.size()[link size.md]
+* w.size()[link size.md]
+* v[i][link op_at.md]
+* w[i][link op_at.md]
+
+### 出力
+```
+1 2 3 4 
+1 1 0 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+- [P3922R1 Missing deduction guide from `simd::mask` to `simd::vec`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3922r1.pdf)
+    - `basic_mask`から`basic_vec`への推論補助が追加された

--- a/reference/simd/basic_vec/op_divide.md
+++ b/reference/simd/basic_vec/op_divide.md
@@ -1,0 +1,72 @@
+# operator/
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec operator/(const basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトの対応する要素同士を除算する。
+
+*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+式`a / b`（`a`と`b`は`value_type`型）が適格であること。
+
+
+## 戻り値
+`lhs`と`rhs`に除算を要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return (i + 1) * 10; };  // {10, 20, 30, 40}
+  int bv[] = {2, 5, 3, 4};
+  simd::vec<int, 4> b = [&](int i) { return bv[i]; };        // {2, 5, 3, 4}
+
+  simd::vec<int, 4> c = a / b;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::print("{} ", c[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+
+### 出力
+```
+5 4 10 10 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_divide_assign.md
+++ b/reference/simd/basic_vec/op_divide_assign.md
@@ -1,0 +1,74 @@
+# operator/=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec& operator/=(basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+* basic_vec[color ff0000]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトを要素ごとに除算し、その結果を左辺に代入する。
+
+## テンプレートパラメータ制約
+`value_type`型の値`a`, `b`に対して、式`a / b`が有効であること。
+
+## 効果
+`lhs`と`rhs`に対して、除算を要素ごとの演算として適用する。
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return (i + 1) * 10; };  // {10, 20, 30, 40}
+  simd::vec<int, 4> b = 10;                                  // {10, 10, 10, 10}
+
+  a /= b;
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* a /= b[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator/`](op_divide.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_equal.md
+++ b/reference/simd/basic_vec/op_equal.md
@@ -1,0 +1,77 @@
+# operator==
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr mask_type operator==(const basic_vec& lhs,
+                                      const basic_vec& rhs) noexcept;
+```
+* operator==[color ff0000]
+* mask_type[link ../basic_mask.md]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)を要素ごとに等値比較する。
+
+比較結果は`bool`ではなく、要素ごとの比較結果を保持するマスク型`mask_type`（[`basic_mask`](../basic_mask.md)）として返される。
+
+## テンプレートパラメータ制約
+式`a == b`（`a`と`b`は`value_type`型の値）が有効であること。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`==`を適用した結果で初期化された`mask_type`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] == rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4> b = 2;                        // {2, 2, 2, 2}
+
+  // 要素ごとの等値比較。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a == b);      // {false, false, true, false}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link ../basic_mask/size.md]
+* m[i][link ../basic_mask/op_at.md]
+
+### 出力
+```
+false false true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_flip.md
+++ b/reference/simd/basic_vec/op_flip.md
@@ -1,0 +1,78 @@
+# operator~
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr basic_vec operator~() const noexcept;
+```
+
+## 概要
+各要素をビット反転する。要素型`T`が整数型である場合にのみ使用できる。
+
+
+## テンプレートパラメータ制約
+`value_type`の値`a`に対して式`~a`が有効であること。
+
+
+## 戻り値
+各要素`i`（`i`は`0`から`size() - 1`まで）を`~(*this)[i]`とした`basic_vec`オブジェクトを返す。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::uint8_t, 4> a = [](int i) { return static_cast<std::uint8_t>(i); };  // {0, 1, 2, 3}
+
+  // 各要素をビット反転する
+  simd::vec<std::uint8_t, 4> b = ~a;  // {0xff, 0xfe, 0xfd, 0xfc}
+
+  for (int i = 0; i < b.size(); ++i) {
+    std::println("{:08b} -> {:08b}", a[i], b[i]);
+  }
+}
+```
+* ~a[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* b.size()[link size.md]
+* b[i][link op_at.md]
+
+### 出力
+```
+00000000 -> 11111111
+00000001 -> 11111110
+00000010 -> 11111101
+00000011 -> 11111100
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator!`](op_not.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_greater.md
+++ b/reference/simd/basic_vec/op_greater.md
@@ -1,0 +1,77 @@
+# operator>
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr mask_type operator>(const basic_vec& lhs,
+                                     const basic_vec& rhs) noexcept;
+```
+* operator>[color ff0000]
+* mask_type[link ../basic_mask.md]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)を要素ごとに比較し、`lhs`の各要素が`rhs`の対応する要素より大きいかどうかを判定する。
+
+比較結果は`bool`ではなく、要素ごとの比較結果を保持するマスク型`mask_type`（[`basic_mask`](../basic_mask.md)）として返される。
+
+## テンプレートパラメータ制約
+式`a > b`（`a`と`b`は`value_type`型の値）が有効であること。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`>`を適用した結果で初期化された`mask_type`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] > rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4> b = 2;                        // {2, 2, 2, 2}
+
+  // 要素ごとに「より大きい」を判定する。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a > b);       // {false, false, false, true}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link ../basic_mask/size.md]
+* m[i][link ../basic_mask/op_at.md]
+
+### 出力
+```
+false false false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_greater_equal.md
+++ b/reference/simd/basic_vec/op_greater_equal.md
@@ -1,0 +1,77 @@
+# operator>=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr mask_type operator>=(const basic_vec& lhs,
+                                      const basic_vec& rhs) noexcept;
+```
+* operator>=[color ff0000]
+* mask_type[link ../basic_mask.md]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)を要素ごとに比較し、`lhs`の各要素が`rhs`の対応する要素以上かどうかを判定する。
+
+比較結果は`bool`ではなく、要素ごとの比較結果を保持するマスク型`mask_type`（[`basic_mask`](../basic_mask.md)）として返される。
+
+## テンプレートパラメータ制約
+式`a >= b`（`a`と`b`は`value_type`型の値）が有効であること。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`>=`を適用した結果で初期化された`mask_type`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] >= rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4> b = 2;                        // {2, 2, 2, 2}
+
+  // 要素ごとに「以上」を判定する。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a >= b);      // {false, false, true, true}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link ../basic_mask/size.md]
+* m[i][link ../basic_mask/op_at.md]
+
+### 出力
+```
+false false true true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_increment.md
+++ b/reference/simd/basic_vec/op_increment.md
@@ -1,0 +1,85 @@
+# operator++
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr basic_vec& operator++() noexcept;   // (1)
+constexpr basic_vec operator++(int) noexcept; // (2)
+```
+
+## 概要
+各要素をインクリメントする。
+
+- (1) : 前置インクリメント。各要素を1増やす。
+- (2) : 後置インクリメント。各要素を1増やす。
+
+
+## テンプレートパラメータ制約
+- (1) : `value_type`の値`a`に対して式`++a`が有効であること
+- (2) : `value_type`の値`a`に対して式`a++`が有効であること
+
+
+## 効果
+全ての要素を1増やす。
+
+
+## 戻り値
+- (1) : `*this`
+- (2) : インクリメントする前の`*this`のコピー
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; }; // {0, 1, 2, 3}
+
+  // 各要素をインクリメントする
+  ++a;                                           // {1, 2, 3, 4}
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* ++a;[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* a.size()[link size.md]
+* a[i][link op_at.md]
+
+### 出力
+```
+1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator--`](op_decrement.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_left_shift.md
+++ b/reference/simd/basic_vec/op_left_shift.md
@@ -1,0 +1,96 @@
+# operator<<
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec
+  operator<<(const basic_vec& lhs, const basic_vec& rhs) noexcept; // (1)
+
+friend constexpr basic_vec
+  operator<<(const basic_vec& v, simd-size-type n) noexcept;       // (2)
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+
+## 概要
+[`basic_vec`](../basic_vec.md)オブジェクトの各要素を左ビットシフトする。要素型が整数型である場合に使用できる。
+
+- (1) : 対応する要素同士で、`lhs`の各要素を`rhs`の対応する要素分だけ左シフトする。
+- (2) : `v`の各要素を、スカラ値`n`分だけ左シフトする。
+
+いずれも*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+- (1) : 式`a << b`（`a`と`b`は`value_type`型）が適格であること。
+- (2) : 式`a << b`（`a`は`value_type`型、`b`は`simd-size-type`型）が適格であること。
+
+
+## 戻り値
+- (1) : `lhs`と`rhs`に左シフトを要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+- (2) : `i`番目の要素を`v[i] << n`とした[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::uint8_t, 4> a = [](int i) { return static_cast<std::uint8_t>(i + 1); };  // {1, 2, 3, 4}
+  simd::vec<std::uint8_t, 4> b = [](int i) { return static_cast<std::uint8_t>(i + 1); };  // {1, 2, 3, 4}
+
+  // (1) 要素ごとのシフト量
+  simd::vec<std::uint8_t, 4> c = a << b;
+
+  // (2) スカラのシフト量
+  simd::vec<std::uint8_t, 4> d = a << 2;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::println("{:08b} << {:08b} -> {:08b}", a[i], b[i], c[i]);
+  }
+  for (int i = 0; i < d.size(); ++i) {
+    std::println("{:08b} << 2 -> {:08b}", a[i], d[i]);
+  }
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+* d.size()[link size.md]
+
+### 出力
+```
+00000001 << 00000001 -> 00000010
+00000010 << 00000010 -> 00001000
+00000011 << 00000011 -> 00011000
+00000100 << 00000100 -> 01000000
+00000001 << 2 -> 00000100
+00000010 << 2 -> 00001000
+00000011 << 2 -> 00001100
+00000100 << 2 -> 00010000
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_left_shift_assign.md
+++ b/reference/simd/basic_vec/op_left_shift_assign.md
@@ -1,0 +1,92 @@
+# operator<<=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec&
+  operator<<=(basic_vec& lhs, const basic_vec& rhs) noexcept; // (1)
+friend constexpr basic_vec&
+  operator<<=(basic_vec& lhs, simd-size-type n) noexcept;     // (2)
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* basic_vec[color ff0000]
+
+## 概要
+[`basic_vec`](../basic_vec.md)オブジェクトの各要素を左ビットシフトし、その結果を左辺に代入する。
+
+- (1) : 各要素を、`rhs`の対応する要素が示すビット数だけ左シフトする
+- (2) : 全要素を`n`ビットだけ左シフトする
+
+[`simd-size-type`](/reference/simd/simd-size-type.md)は、要素の添字を表現できる符号付き整数型の説明専用の別名である。
+
+## テンプレートパラメータ制約
+- (1) : `value_type`型の値`a`, `b`に対して、式`a << b`が有効であること
+- (2) : `value_type`型の値`a`と[`simd-size-type`](/reference/simd/simd-size-type.md)型の値`b`に対して、式`a << b`が有効であること
+
+## 効果
+- (1) : `lhs`と`rhs`に対して、左ビットシフトを要素ごとの演算として適用する
+- (2) : 以下と等価である
+
+    ```cpp
+    return operator<<(lhs, basic_vec(n));
+    ```
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::uint8_t, 4> a = [](int i) { return static_cast<std::uint8_t>(i + 1); };  // {1, 2, 3, 4}
+
+  simd::vec<std::uint8_t, 4> a0 = a;  // 演算前の値
+  a <<= 1; // 全要素を1ビット左シフト（2倍）
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::println("{:08b} << 1 -> {:08b}", a0[i], a[i]);
+  }
+}
+```
+* a <<= 1[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+00000001 << 1 -> 00000010
+00000010 << 1 -> 00000100
+00000011 << 1 -> 00000110
+00000100 << 1 -> 00001000
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator<<`](op_left_shift.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_less.md
+++ b/reference/simd/basic_vec/op_less.md
@@ -1,0 +1,77 @@
+# operator<
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr mask_type operator<(const basic_vec& lhs,
+                                     const basic_vec& rhs) noexcept;
+```
+* operator<[color ff0000]
+* mask_type[link ../basic_mask.md]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)を要素ごとに比較し、`lhs`の各要素が`rhs`の対応する要素より小さいかどうかを判定する。
+
+比較結果は`bool`ではなく、要素ごとの比較結果を保持するマスク型`mask_type`（[`basic_mask`](../basic_mask.md)）として返される。
+
+## テンプレートパラメータ制約
+式`a < b`（`a`と`b`は`value_type`型の値）が有効であること。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`<`を適用した結果で初期化された`mask_type`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] < rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4> b = 2;                        // {2, 2, 2, 2}
+
+  // 要素ごとに「より小さい」を判定する。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a < b);       // {true, true, false, false}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link ../basic_mask/size.md]
+* m[i][link ../basic_mask/op_at.md]
+
+### 出力
+```
+true true false false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_less_equal.md
+++ b/reference/simd/basic_vec/op_less_equal.md
@@ -1,0 +1,77 @@
+# operator<=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr mask_type operator<=(const basic_vec& lhs,
+                                      const basic_vec& rhs) noexcept;
+```
+* operator<=[color ff0000]
+* mask_type[link ../basic_mask.md]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)を要素ごとに比較し、`lhs`の各要素が`rhs`の対応する要素以下かどうかを判定する。
+
+比較結果は`bool`ではなく、要素ごとの比較結果を保持するマスク型`mask_type`（[`basic_mask`](../basic_mask.md)）として返される。
+
+## テンプレートパラメータ制約
+式`a <= b`（`a`と`b`は`value_type`型の値）が有効であること。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`<=`を適用した結果で初期化された`mask_type`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] <= rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4> b = 2;                        // {2, 2, 2, 2}
+
+  // 要素ごとに「以下」を判定する。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a <= b);      // {true, true, true, false}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link ../basic_mask/size.md]
+* m[i][link ../basic_mask/op_at.md]
+
+### 出力
+```
+true true true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_minus.md
+++ b/reference/simd/basic_vec/op_minus.md
@@ -1,0 +1,71 @@
+# operator-
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec operator-(const basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトの対応する要素同士を減算する。
+
+*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+式`a - b`（`a`と`b`は`value_type`型）が適格であること。
+
+
+## 戻り値
+`lhs`と`rhs`に減算を要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return (i + 1) * 10; };  // {10, 20, 30, 40}
+  simd::vec<int, 4> b = [](int i) { return i + 1; };         // {1, 2, 3, 4}
+
+  simd::vec<int, 4> c = a - b;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::print("{} ", c[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+
+### 出力
+```
+9 18 27 36 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_minus_assign.md
+++ b/reference/simd/basic_vec/op_minus_assign.md
@@ -1,0 +1,74 @@
+# operator-=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec& operator-=(basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+* basic_vec[color ff0000]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトを要素ごとに減算し、その結果を左辺に代入する。
+
+## テンプレートパラメータ制約
+`value_type`型の値`a`, `b`に対して、式`a - b`が有効であること。
+
+## 効果
+`lhs`と`rhs`に対して、減算を要素ごとの演算として適用する。
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i + 1; };  // {1, 2, 3, 4}
+  simd::vec<int, 4> b = 10;                           // {10, 10, 10, 10}
+
+  a -= b;
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* a -= b[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+-9 -8 -7 -6 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator-`](op_minus.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_modulo.md
+++ b/reference/simd/basic_vec/op_modulo.md
@@ -1,0 +1,72 @@
+# operator%
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec operator%(const basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトの対応する要素同士で剰余を求める。要素型が整数型である場合に使用できる。
+
+*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+式`a % b`（`a`と`b`は`value_type`型）が適格であること。
+
+
+## 戻り値
+`lhs`と`rhs`に剰余演算を要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return (i + 1) * 10; };  // {10, 20, 30, 40}
+  int bv[] = {3, 3, 7, 6};
+  simd::vec<int, 4> b = [&](int i) { return bv[i]; };        // {3, 3, 7, 6}
+
+  simd::vec<int, 4> c = a % b;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::print("{} ", c[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+
+### 出力
+```
+1 2 2 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_modulo_assign.md
+++ b/reference/simd/basic_vec/op_modulo_assign.md
@@ -1,0 +1,74 @@
+# operator%=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec& operator%=(basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+* basic_vec[color ff0000]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトを要素ごとに剰余算し、その結果を左辺に代入する。
+
+## テンプレートパラメータ制約
+`value_type`型の値`a`, `b`に対して、式`a % b`が有効であること。
+
+## 効果
+`lhs`と`rhs`に対して、剰余算を要素ごとの演算として適用する。
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i + 10; };  // {10, 11, 12, 13}
+  simd::vec<int, 4> b = 3;                             // {3, 3, 3, 3}
+
+  a %= b;
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* a %= b[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+1 2 0 1 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator%`](op_modulo.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_multiply.md
+++ b/reference/simd/basic_vec/op_multiply.md
@@ -1,0 +1,71 @@
+# operator*
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec operator*(const basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトの対応する要素同士を乗算する。
+
+*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+式`a * b`（`a`と`b`は`value_type`型）が適格であること。
+
+
+## 戻り値
+`lhs`と`rhs`に乗算を要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i + 1; };  // {1, 2, 3, 4}
+  simd::vec<int, 4> b = 2;                            // {2, 2, 2, 2}
+
+  simd::vec<int, 4> c = a * b;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::print("{} ", c[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+
+### 出力
+```
+2 4 6 8 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_multiply_assign.md
+++ b/reference/simd/basic_vec/op_multiply_assign.md
@@ -1,0 +1,74 @@
+# operator*=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec& operator*=(basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+* basic_vec[color ff0000]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトを要素ごとに乗算し、その結果を左辺に代入する。
+
+## テンプレートパラメータ制約
+`value_type`型の値`a`, `b`に対して、式`a * b`が有効であること。
+
+## 効果
+`lhs`と`rhs`に対して、乗算を要素ごとの演算として適用する。
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i + 1; };  // {1, 2, 3, 4}
+  simd::vec<int, 4> b = 10;                           // {10, 10, 10, 10}
+
+  a *= b;
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* a *= b[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+10 20 30 40 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator*`](op_multiply.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_not.md
+++ b/reference/simd/basic_vec/op_not.md
@@ -47,7 +47,7 @@ int main()
 ```
 * !a[color ff0000]
 * simd::vec[link ../basic_vec.md]
-* mask_type[link ../basic_vec.md]
+* mask_type[link ../basic_mask.md]
 * m.size()[link ../basic_mask/size.md]
 * m[i][link ../basic_mask/op_at.md]
 

--- a/reference/simd/basic_vec/op_not.md
+++ b/reference/simd/basic_vec/op_not.md
@@ -1,0 +1,76 @@
+# operator!
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr mask_type operator!() const noexcept;
+```
+
+## 概要
+各要素を論理反転する。
+
+
+## テンプレートパラメータ制約
+`value_type`の値`a`に対して式`!a`が有効であること。
+
+
+## 戻り値
+各要素`i`（`i`は`0`から`size() - 1`まで）を`!(*this)[i]`とした[`basic_mask`](../basic_mask.md)オブジェクトを返す。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+
+  // 各要素を論理反転し、マスクとして得る
+  simd::vec<int, 4>::mask_type m = !a;            // {true, false, false, false}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* !a[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* mask_type[link ../basic_vec.md]
+* m.size()[link ../basic_mask/size.md]
+* m[i][link ../basic_mask/op_at.md]
+
+### 出力
+```
+true false false false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_not_equal.md
+++ b/reference/simd/basic_vec/op_not_equal.md
@@ -1,0 +1,77 @@
+# operator!=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr mask_type operator!=(const basic_vec& lhs,
+                                      const basic_vec& rhs) noexcept;
+```
+* operator!=[color ff0000]
+* mask_type[link ../basic_mask.md]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)を要素ごとに非等値比較する。
+
+比較結果は`bool`ではなく、要素ごとの比較結果を保持するマスク型`mask_type`（[`basic_mask`](../basic_mask.md)）として返される。
+
+## テンプレートパラメータ制約
+式`a != b`（`a`と`b`は`value_type`型の値）が有効であること。
+
+## 戻り値
+`lhs`と`rhs`の対応する要素それぞれに`!=`を適用した結果で初期化された`mask_type`オブジェクトを返す。すなわち、戻り値のマスクの`i`番目の要素は`lhs[i] != rhs[i]`となる。
+
+## 備考
+*Hidden friends*として定義されるため、引数依存の名前探索 (ADL) でのみ発見される。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i; };  // {0, 1, 2, 3}
+  simd::vec<int, 4> b = 2;                        // {2, 2, 2, 2}
+
+  // 要素ごとの非等値比較。結果はマスクとして得られる
+  simd::vec<int, 4>::mask_type m = (a != b);      // {true, true, false, true}
+
+  for (int i = 0; i < m.size(); ++i) {
+    std::print("{} ", m[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[link ../basic_vec.md]
+* m.size()[link ../basic_mask/size.md]
+* m[i][link ../basic_mask/op_at.md]
+
+### 出力
+```
+true true false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+- [`std::simd::basic_mask`](../basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_or.md
+++ b/reference/simd/basic_vec/op_or.md
@@ -1,0 +1,76 @@
+# operator|
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec operator|(const basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトの対応する要素同士でビットごとの論理和を求める。要素型が整数型である場合に使用できる。
+
+*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+式`a | b`（`a`と`b`は`value_type`型）が適格であること。
+
+
+## 戻り値
+`lhs`と`rhs`にビット論理和を要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::uint8_t av[] = {0b00001100, 0b00001010, 0b00000110, 0b00000101};
+  std::uint8_t bv[] = {0b00001010, 0b00000110, 0b00000011, 0b00000100};
+  simd::vec<std::uint8_t, 4> a = [&](int i) { return av[i]; };
+  simd::vec<std::uint8_t, 4> b = [&](int i) { return bv[i]; };
+
+  simd::vec<std::uint8_t, 4> c = a | b;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::println("{:08b} | {:08b} -> {:08b}", a[i], b[i], c[i]);
+  }
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+
+### 出力
+```
+00001100 | 00001010 -> 00001110
+00001010 | 00000110 -> 00001110
+00000110 | 00000011 -> 00000111
+00000101 | 00000100 -> 00000101
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_or_assign.md
+++ b/reference/simd/basic_vec/op_or_assign.md
@@ -1,0 +1,78 @@
+# operator|=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec& operator|=(basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+* basic_vec[color ff0000]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトを要素ごとにビット論理和し、その結果を左辺に代入する。
+
+## テンプレートパラメータ制約
+`value_type`型の値`a`, `b`に対して、式`a | b`が有効であること。
+
+## 効果
+`lhs`と`rhs`に対して、ビット論理和を要素ごとの演算として適用する。
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::uint8_t, 4> a = [](int i) { return static_cast<std::uint8_t>(i); };  // {0, 1, 2, 3}
+  simd::vec<std::uint8_t, 4> b = std::uint8_t{4};  // {4, 4, 4, 4}
+
+  simd::vec<std::uint8_t, 4> a0 = a;  // 演算前の値
+  a |= b;
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::println("{:08b} | {:08b} -> {:08b}", a0[i], b[i], a[i]);
+  }
+}
+```
+* a |= b[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+00000000 | 00000100 -> 00000100
+00000001 | 00000100 -> 00000101
+00000010 | 00000100 -> 00000110
+00000011 | 00000100 -> 00000111
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator|`](op_or.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_plus.md
+++ b/reference/simd/basic_vec/op_plus.md
@@ -1,0 +1,71 @@
+# operator+
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec operator+(const basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトの対応する要素同士を加算する。
+
+*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+式`a + b`（`a`と`b`は`value_type`型）が適格であること。
+
+
+## 戻り値
+`lhs`と`rhs`に加算を要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i + 1; };  // {1, 2, 3, 4}
+  simd::vec<int, 4> b = 10;                           // {10, 10, 10, 10}
+
+  simd::vec<int, 4> c = a + b;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::print("{} ", c[i]);
+  }
+  std::println("");
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+
+### 出力
+```
+11 12 13 14 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_plus_assign.md
+++ b/reference/simd/basic_vec/op_plus_assign.md
@@ -1,0 +1,74 @@
+# operator+=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec& operator+=(basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+* basic_vec[color ff0000]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトを要素ごとに加算し、その結果を左辺に代入する。
+
+## テンプレートパラメータ制約
+`value_type`型の値`a`, `b`に対して、式`a + b`が有効であること。
+
+## 効果
+`lhs`と`rhs`に対して、加算を要素ごとの演算として適用する。
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i + 1; };  // {1, 2, 3, 4}
+  simd::vec<int, 4> b = 10;                           // {10, 10, 10, 10}
+
+  a += b;
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::print("{} ", a[i]);
+  }
+  std::println("");
+}
+```
+* a += b[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+11 12 13 14 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator+`](op_plus.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_right_shift.md
+++ b/reference/simd/basic_vec/op_right_shift.md
@@ -1,0 +1,97 @@
+# operator>>
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec
+  operator>>(const basic_vec& lhs, const basic_vec& rhs) noexcept; // (1)
+
+friend constexpr basic_vec
+  operator>>(const basic_vec& v, simd-size-type n) noexcept;       // (2)
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+
+## 概要
+[`basic_vec`](../basic_vec.md)オブジェクトの各要素を右ビットシフトする。要素型が整数型である場合に使用できる。
+
+- (1) : 対応する要素同士で、`lhs`の各要素を`rhs`の対応する要素分だけ右シフトする。
+- (2) : `v`の各要素を、スカラ値`n`分だけ右シフトする。
+
+いずれも*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+- (1) : 式`a >> b`（`a`と`b`は`value_type`型）が適格であること。
+- (2) : 式`a >> b`（`a`は`value_type`型、`b`は`simd-size-type`型）が適格であること。
+
+
+## 戻り値
+- (1) : `lhs`と`rhs`に右シフトを要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+- (2) : `i`番目の要素を`v[i] >> n`とした[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::uint8_t, 4> a = std::uint8_t{16};    // {16, 16, 16, 16}
+  simd::vec<std::uint8_t, 4> b = [](int i) { return static_cast<std::uint8_t>(i + 1); };  // {1, 2, 3, 4}
+
+  // (1) 要素ごとのシフト量
+  simd::vec<std::uint8_t, 4> c = a >> b;
+
+  // (2) スカラのシフト量
+  simd::vec<std::uint8_t, 4> e = [](int i) { return static_cast<std::uint8_t>(16 << i); };  // {16, 32, 64, 128}
+  simd::vec<std::uint8_t, 4> d = e >> 2;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::println("{:08b} >> {:08b} -> {:08b}", a[i], b[i], c[i]);
+  }
+  for (int i = 0; i < d.size(); ++i) {
+    std::println("{:08b} >> 2 -> {:08b}", e[i], d[i]);
+  }
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+* d.size()[link size.md]
+
+### 出力
+```
+00010000 >> 00000001 -> 00001000
+00010000 >> 00000010 -> 00000100
+00010000 >> 00000011 -> 00000010
+00010000 >> 00000100 -> 00000001
+00010000 >> 2 -> 00000100
+00100000 >> 2 -> 00001000
+01000000 >> 2 -> 00010000
+10000000 >> 2 -> 00100000
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_right_shift_assign.md
+++ b/reference/simd/basic_vec/op_right_shift_assign.md
@@ -1,0 +1,92 @@
+# operator>>=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec&
+  operator>>=(basic_vec& lhs, const basic_vec& rhs) noexcept; // (1)
+friend constexpr basic_vec&
+  operator>>=(basic_vec& lhs, simd-size-type n) noexcept;     // (2)
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* basic_vec[color ff0000]
+
+## 概要
+[`basic_vec`](../basic_vec.md)オブジェクトの各要素を右ビットシフトし、その結果を左辺に代入する。
+
+- (1) : 各要素を、`rhs`の対応する要素が示すビット数だけ右シフトする
+- (2) : 全要素を`n`ビットだけ右シフトする
+
+[`simd-size-type`](/reference/simd/simd-size-type.md)は、要素の添字を表現できる符号付き整数型の説明専用の別名である。
+
+## テンプレートパラメータ制約
+- (1) : `value_type`型の値`a`, `b`に対して、式`a >> b`が有効であること
+- (2) : `value_type`型の値`a`と[`simd-size-type`](/reference/simd/simd-size-type.md)型の値`b`に対して、式`a >> b`が有効であること
+
+## 効果
+- (1) : `lhs`と`rhs`に対して、右ビットシフトを要素ごとの演算として適用する
+- (2) : 以下と等価である
+
+    ```cpp
+    return operator>>(lhs, basic_vec(n));
+    ```
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::uint8_t, 4> a = [](int i) { return static_cast<std::uint8_t>((i + 1) * 8); };  // {8, 16, 24, 32}
+
+  simd::vec<std::uint8_t, 4> a0 = a;  // 演算前の値
+  a >>= 1; // 全要素を1ビット右シフト（1/2倍）
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::println("{:08b} >> 1 -> {:08b}", a0[i], a[i]);
+  }
+}
+```
+* a >>= 1[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+00001000 >> 1 -> 00000100
+00010000 >> 1 -> 00001000
+00011000 >> 1 -> 00001100
+00100000 >> 1 -> 00010000
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator>>`](op_right_shift.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_unary_minus.md
+++ b/reference/simd/basic_vec/op_unary_minus.md
@@ -1,0 +1,75 @@
+# operator-
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr basic_vec operator-() const noexcept;
+```
+
+## 概要
+各要素の符号を反転する。
+
+
+## テンプレートパラメータ制約
+`value_type`の値`a`に対して式`-a`が有効であること。
+
+
+## 戻り値
+各要素`i`（`i`は`0`から`size() - 1`まで）を`-(*this)[i]`とした`basic_vec`オブジェクトを返す。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i - 1; };  // {-1, 0, 1, 2}
+
+  // 各要素の符号を反転する
+  simd::vec<int, 4> b = -a;                           // {1, 0, -1, -2}
+
+  for (int i = 0; i < b.size(); ++i) {
+    std::print("{} ", b[i]);
+  }
+  std::println("");
+}
+```
+* -a[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* b.size()[link size.md]
+* b[i][link op_at.md]
+
+### 出力
+```
+1 0 -1 -2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator+`](op_unary_plus.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_unary_plus.md
+++ b/reference/simd/basic_vec/op_unary_plus.md
@@ -1,0 +1,75 @@
+# operator+
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr basic_vec operator+() const noexcept;
+```
+
+## 概要
+各要素に単項プラスを適用する。
+
+
+## テンプレートパラメータ制約
+`value_type`の値`a`に対して式`+a`が有効であること。
+
+
+## 戻り値
+`*this`
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a = [](int i) { return i - 1; };  // {-1, 0, 1, 2}
+
+  // 各要素に単項プラスを適用する
+  simd::vec<int, 4> b = +a;                           // {-1, 0, 1, 2}
+
+  for (int i = 0; i < b.size(); ++i) {
+    std::print("{} ", b[i]);
+  }
+  std::println("");
+}
+```
+* +a[color ff0000]
+* simd::vec[link ../basic_vec.md]
+* b.size()[link size.md]
+* b[i][link op_at.md]
+
+### 出力
+```
+-1 0 1 2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator-`](op_unary_minus.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_xor.md
+++ b/reference/simd/basic_vec/op_xor.md
@@ -1,0 +1,76 @@
+# operator^
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec operator^(const basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトの対応する要素同士でビットごとの排他的論理和を求める。要素型が整数型である場合に使用できる。
+
+*Hidden friends*として定義される。
+
+
+## テンプレートパラメータ制約
+式`a ^ b`（`a`と`b`は`value_type`型）が適格であること。
+
+
+## 戻り値
+`lhs`と`rhs`にビット排他的論理和を要素ごとに適用した結果で初期化された[`basic_vec`](../basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::uint8_t av[] = {0b00001100, 0b00001010, 0b00000110, 0b00000101};
+  std::uint8_t bv[] = {0b00001010, 0b00000110, 0b00000011, 0b00000100};
+  simd::vec<std::uint8_t, 4> a = [&](int i) { return av[i]; };
+  simd::vec<std::uint8_t, 4> b = [&](int i) { return bv[i]; };
+
+  simd::vec<std::uint8_t, 4> c = a ^ b;
+
+  for (int i = 0; i < c.size(); ++i) {
+    std::println("{:08b} ^ {:08b} -> {:08b}", a[i], b[i], c[i]);
+  }
+}
+```
+* simd::vec[color ff0000]
+* c.size()[link size.md]
+
+### 出力
+```
+00001100 ^ 00001010 -> 00000110
+00001010 ^ 00000110 -> 00001100
+00000110 ^ 00000011 -> 00000101
+00000101 ^ 00000100 -> 00000001
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/op_xor_assign.md
+++ b/reference/simd/basic_vec/op_xor_assign.md
@@ -1,0 +1,78 @@
+# operator^=
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+friend constexpr basic_vec& operator^=(basic_vec& lhs, const basic_vec& rhs) noexcept;
+```
+* basic_vec[color ff0000]
+
+## 概要
+2つの[`basic_vec`](../basic_vec.md)オブジェクトを要素ごとにビット排他的論理和し、その結果を左辺に代入する。
+
+## テンプレートパラメータ制約
+`value_type`型の値`a`, `b`に対して、式`a ^ b`が有効であること。
+
+## 効果
+`lhs`と`rhs`に対して、ビット排他的論理和を要素ごとの演算として適用する。
+
+## 戻り値
+`lhs`
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::uint8_t, 4> a = [](int i) { return static_cast<std::uint8_t>(i); };  // {0, 1, 2, 3}
+  simd::vec<std::uint8_t, 4> b = std::uint8_t{1};  // {1, 1, 1, 1}
+
+  simd::vec<std::uint8_t, 4> a0 = a;  // 演算前の値
+  a ^= b;
+
+  for (int i = 0; i < a.size(); ++i) {
+    std::println("{:08b} ^ {:08b} -> {:08b}", a0[i], b[i], a[i]);
+  }
+}
+```
+* a ^= b[color ff0000]
+* a.size()[link size.md]
+
+### 出力
+```
+00000000 ^ 00000001 -> 00000001
+00000001 ^ 00000001 -> 00000000
+00000010 ^ 00000001 -> 00000011
+00000011 ^ 00000001 -> 00000010
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::operator^`](op_xor.md)
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/basic_vec/real-type.md
+++ b/reference/simd/basic_vec/real-type.md
@@ -1,0 +1,37 @@
+# real-type
+* [meta exposition-only]
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* type-alias[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi>
+  class basic_vec {
+    using real-type = /*see below*/;
+  };
+}
+```
+
+## 概要
+`real-type`は、[`basic_vec`](../basic_vec.md)の説明専用のメンバ型エイリアスである。
+
+要素型`T`が[`std::complex`](/reference/complex/complex.md)の特殊化のとき、`real-type`は[`rebind_t`](../rebind.md)`<typename T::value_type, basic_vec<T, Abi>>`（要素型を`complex<U>`から実数型`U`に置き換えた[`basic_vec`](../basic_vec.md)）と同じ型を表す。それ以外の場合は、未規定の非配列オブジェクト型を表す。
+
+複素数を要素とする[`basic_vec`](../basic_vec.md)の実部・虚部を扱う[コンストラクタ](op_constructor.md)や、[`real`](real.md)・[`imag`](imag.md)メンバ関数の引数型・戻り値型として使用される。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+- [`std::simd::basic_vec::real`](real.md)
+- [`std::simd::basic_vec::imag`](imag.md)
+- [`std::simd::rebind`](../rebind.md)
+
+## 参照
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 複素数を要素とする`basic_vec`のサポートが追加された

--- a/reference/simd/basic_vec/real.md
+++ b/reference/simd/basic_vec/real.md
@@ -1,0 +1,104 @@
+# real
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr real-type real() const noexcept;        // (1) C++26
+
+constexpr void real(const real-type& v) noexcept; // (2) C++26
+```
+* real-type[link real-type.md]
+
+## 概要
+複素数要素型の実部を取得／設定する。
+
+- (1) : 各要素の実部を集めたデータ並列型を取得する。
+- (2) : 各要素の実部を`v`の対応する要素で置き換える。
+
+[`real-type`](real-type.md)は、要素型`T`が[`std::complex`](/reference/complex/complex.md)`<U>`のとき、要素型を`U`に置き換えた`basic_vec`である。
+
+
+## テンプレートパラメータ制約
+- (1), (2) : `basic_vec`が複素数のデータ並列型（`simd-complex`）であること。
+
+
+## 効果
+- (2) : すべての`i`（`0`以上`size()`未満）について、第`i`要素を`value_type(v[i], (*this)[i].imag())`で置き換える。
+
+
+## 戻り値
+- (1) : 第`i`要素を`(*this)[i].real()`とするデータ並列型。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+template <class V>
+void print(const char* name, const V& v)
+{
+  std::print("{}: ", name);
+  for (int i = 0; i < v.size(); ++i) {
+    std::print("{} ", v[i]);
+  }
+  std::println("");
+}
+
+int main()
+{
+  simd::vec<float, 4> reals([](int i) { return float(i + 1); });        // {1, 2, 3, 4}
+  simd::vec<float, 4> imags([](int i) { return float((i + 1) * 10); }); // {10, 20, 30, 40}
+
+  // 実部と虚部からcomplexのデータ並列型を構築する
+  simd::vec<std::complex<float>, 4> v{reals, imags};
+
+  // 実部を取得する
+  ::print("real", v.real());
+
+  // 実部を設定する
+  v.real(simd::vec<float, 4>(0.0f));
+  ::print("real", v.real());
+  ::print("imag", v.imag());
+}
+```
+* v.real()[color ff0000]
+* v.imag()[link imag.md]
+
+### 出力
+```
+real: 1 2 3 4 
+real: 0 0 0 0 
+imag: 10 20 30 40 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec::imag`](imag.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された
+- [P2876R3 Proposal to extend `std::simd` with more constructors and accessors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2876r3.html)
+    - 複素数要素の実部・虚部にアクセスするアクセサが追加された

--- a/reference/simd/basic_vec/size.md
+++ b/reference/simd/basic_vec/size.md
@@ -1,0 +1,68 @@
+# size
+* simd[meta header]
+* std::simd[meta namespace]
+* basic_vec[meta class]
+* variable[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+static constexpr integral_constant<
+  simd-size-type, simd-size-v<T, Abi>> size {};
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* simd-size-v[link /reference/simd/simd-size-v.md]
+* integral_constant[link /reference/type_traits/integral_constant.md]
+
+## 概要
+`basic_vec`が保持する要素数（「width」）を表す静的メンバ変数。
+
+型は[`std::integral_constant`](/reference/type_traits/integral_constant.md)であり、その値が要素数を表す。
+
+
+## 備考
+`size`は[`std::integral_constant`](/reference/type_traits/integral_constant.md)であるため、関数呼び出し演算子によって`v.size()`のように要素数を取得できるほか、`v.size`のように直接値としても参照できる。いずれもコンパイル時定数である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v = 0;
+
+  // 関数呼び出しの形式で要素数を取得する
+  std::println("{}", v.size());
+
+  // コンパイル時定数として使える
+  static_assert(simd::vec<int, 4>::size() == 4);
+}
+```
+* v.size()[color ff0000]
+
+### 出力
+```
+4
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](../basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`が追加された

--- a/reference/simd/beta.md
+++ b/reference/simd/beta.md
@@ -1,0 +1,86 @@
+# beta
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> beta(const V& x, const V& y);                // (1) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> beta(const deduced-vec-t<V>& x, const V& y); // (2) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> beta(const V& x, const deduced-vec-t<V>& y); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`beta`](/reference/cmath/beta.md)を適用し、各要素`x`・`y`に対するベータ関数の値を求める。
+
+- (1) : 両引数を`V`として受け取る。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`と`y[i]`に[`<cmath>`](/reference/cmath.md)の[`beta`](/reference/cmath/beta.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> x([](int i) { return i + 1.0; }); // {1, 2}
+  simd::vec<double, 2> y([](int i) { return i + 1.0; }); // {1, 2}
+
+  // 各要素に対するベータ関数を求める
+  simd::vec<double, 2> r = simd::beta(x, y);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::beta[color ff0000]
+
+### 出力例
+```
+1 0.16666666666666666 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::tgamma`](tgamma.md)
+- [`std::beta`](/reference/cmath/beta.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/bit_ceil.md
+++ b/reference/simd/bit_ceil.md
@@ -1,0 +1,90 @@
+# bit_ceil
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr V bit_ceil(const V& v); // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::bit_ceil`](/reference/bit/bit_ceil.md)を要素ごとに適用し、各要素以上で最小の2の累乗を求める。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 事前条件
+すべての要素`v[i]`について、`v[i]`以上で最小の2の累乗が`V::value_type`型で表現可能であること。
+
+
+## 戻り値
+`i`番目の要素が[`std::bit_ceil`](/reference/bit/bit_ceil.md)`(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+
+## 例外
+投げない
+
+
+## 備考
+- 事前条件に違反する関数呼び出し式は、定数式として評価されない。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <array>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::array data = {0b0011u, 0b0101u, 0b1000u, 0b1001u};
+  simd::vec<std::uint32_t, 4> v {[&](int i) { return data[i]; }};
+
+  simd::vec<std::uint32_t, 4> r = simd::bit_ceil(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::bit_ceil[color ff0000]
+
+### 出力
+```
+0000000000000011 -> 0000000000000100
+0000000000000101 -> 0000000000001000
+0000000000001000 -> 0000000000001000
+0000000000001001 -> 0000000000010000
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::bit_ceil`](/reference/bit/bit_ceil.md)
+- [`std::simd::bit_floor`](bit_floor.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/bit_compress.md
+++ b/reference/simd/bit_compress.md
@@ -1,0 +1,92 @@
+# bit_compress
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-integral V>
+  constexpr V
+    bit_compress(const V& v, const V& m) noexcept;               // (1) C++29
+
+  template<simd-integral V>
+  constexpr V
+    bit_compress(const V& v, typename V::value_type m) noexcept; // (2) C++29
+}
+```
+* simd-integral[link /reference/simd/simd-integral.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、`<bit>`ヘッダの[`std::bit_compress`](/reference/bit/bit_compress.md)を要素ごとに適用する。各要素について、マスクのビットが立っている位置の値`v`のビットを集め、下位ビットへ詰めて配置する。
+
+- (1) : 各要素についてマスクを`m[i]`で指定する
+- (2) : すべての要素について同一のマスク`m`を指定する
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+- (1) : `i`番目の要素が`std::bit_compress(v[i], m[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+- (2) : `i`番目の要素が`std::bit_compress(v[i], m)`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0010, 0x0020, 0x0030, 0x0040}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>((i + 1) << 4);
+  }};
+
+  // マスク0x00f0で立っているビット（第4〜7ビット）を下位へ詰める
+  simd::vec<std::uint16_t, 4> r = simd::bit_compress(v, std::uint16_t{0x00f0});
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::bit_compress[color ff0000]
+
+### 出力
+```
+0000000000010000 -> 0000000000000001
+0000000000100000 -> 0000000000000010
+0000000000110000 -> 0000000000000011
+0000000001000000 -> 0000000000000100
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::bit_expand`](bit_expand.md)
+
+
+## 参照
+- [P3104R3 Bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3104r3.html)
+    - C++29で`<bit>`ヘッダにスカラー版の`bit_compress`が追加された
+- [P3772R1 std::simd overloads for bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3772r1.html)
+    - C++29で`std::simd`版のオーバーロードが追加された

--- a/reference/simd/bit_expand.md
+++ b/reference/simd/bit_expand.md
@@ -1,0 +1,92 @@
+# bit_expand
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-integral V>
+  constexpr V
+    bit_expand(const V& v, const V& m) noexcept;               // (1) C++29
+
+  template<simd-integral V>
+  constexpr V
+    bit_expand(const V& v, typename V::value_type m) noexcept; // (2) C++29
+}
+```
+* simd-integral[link /reference/simd/simd-integral.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、`<bit>`ヘッダの[`std::bit_expand`](/reference/bit/bit_expand.md)を要素ごとに適用する。各要素について、値`v`の下位ビットを、マスクのビットが立っている位置へ順に配置する。[`bit_compress`](bit_compress.md)の逆操作である。
+
+- (1) : 各要素についてマスクを`m[i]`で指定する
+- (2) : すべての要素について同一のマスク`m`を指定する
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+- (1) : `i`番目の要素が`std::bit_expand(v[i], m[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+- (2) : `i`番目の要素が`std::bit_expand(v[i], m)`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0002, 0x0003, 0x0004}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(i + 1);
+  }};
+
+  // 値の下位ビットをマスク0x00f0（第4〜7ビット）へ展開する
+  simd::vec<std::uint16_t, 4> r = simd::bit_expand(v, std::uint16_t{0x00f0});
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::bit_expand[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 0000000000010000
+0000000000000010 -> 0000000000100000
+0000000000000011 -> 0000000000110000
+0000000000000100 -> 0000000001000000
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::bit_compress`](bit_compress.md)
+
+
+## 参照
+- [P3104R3 Bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3104r3.html)
+    - C++29で`<bit>`ヘッダにスカラー版の`bit_expand`が追加された
+- [P3772R1 std::simd overloads for bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3772r1.html)
+    - C++29で`std::simd`版のオーバーロードが追加された

--- a/reference/simd/bit_floor.md
+++ b/reference/simd/bit_floor.md
@@ -1,0 +1,82 @@
+# bit_floor
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr V bit_floor(const V& v) noexcept; // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::bit_floor`](/reference/bit/bit_floor.md)を要素ごとに適用し、各要素以下で最大の2の累乗を求める。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+`i`番目の要素が[`std::bit_floor`](/reference/bit/bit_floor.md)`(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <array>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::array data = {0b0011u, 0b0101u, 0b1000u, 0b1001u};
+  simd::vec<std::uint32_t, 4> v {[&](int i) { return data[i]; }};
+
+  simd::vec<std::uint32_t, 4> r = simd::bit_floor(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::bit_floor[color ff0000]
+
+### 出力
+```
+0000000000000011 -> 0000000000000010
+0000000000000101 -> 0000000000000100
+0000000000001000 -> 0000000000001000
+0000000000001001 -> 0000000000001000
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::bit_floor`](/reference/bit/bit_floor.md)
+- [`std::simd::bit_ceil`](bit_ceil.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/bit_repeat.md
+++ b/reference/simd/bit_repeat.md
@@ -1,0 +1,105 @@
+# bit_repeat
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-integral V0, simd-integral V1>
+  constexpr V0 bit_repeat(const V0& v0, const V1& v1); // (1) C++29
+
+  template<simd-integral V>
+  constexpr V bit_repeat(const V& v, int l);           // (2) C++29
+}
+```
+* simd-integral[link /reference/simd/simd-integral.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、`<bit>`ヘッダの[`std::bit_repeat`](/reference/bit/bit_repeat.md)を要素ごとに適用し、各要素の最下位から`l`ビットのパターンを、要素の幅を埋めるように繰り返す。
+
+- (1) : 各要素について繰り返すビット数を`v1[i]`で指定する
+- (2) : すべての要素について繰り返すビット数を同一の`l`で指定する
+
+
+## テンプレートパラメータ制約
+- (1) :
+    - `V0::value_type`が符号なし整数型であること
+    - `V1::value_type`が整数型であること
+    - `V0::size() == V1::size()`が`true`であること
+    - `sizeof(typename V0::value_type) == sizeof(typename V1::value_type)`が`true`であること
+- (2) :
+    - `V::value_type`が符号なし整数型であること
+
+
+## 事前条件
+- (1) : すべての要素について`v1[i] > 0`が`true`であること
+- (2) : `l > 0`が`true`であること
+
+
+## 戻り値
+- (1) : `i`番目の要素が`std::bit_repeat(v0[i], static_cast<int>(v1[i]))`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+- (2) : `i`番目の要素が`std::bit_repeat(v[i], l)`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+
+
+## 例外
+投げない
+
+
+## 備考
+- 事前条件に違反する関数呼び出し式は、定数式として評価されない。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0003, 0x0005, 0x0007}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(2 * i + 1);
+  }};
+
+  // 各要素の最下位4ビットのパターンを繰り返す
+  simd::vec<std::uint16_t, 4> r = simd::bit_repeat(v, 4);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::bit_repeat[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 0001000100010001
+0000000000000011 -> 0011001100110011
+0000000000000101 -> 0101010101010101
+0000000000000111 -> 0111011101110111
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P3104R3 Bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3104r3.html)
+    - C++29で`<bit>`ヘッダにスカラー版の`bit_repeat`が追加された
+- [P3772R1 std::simd overloads for bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3772r1.html)
+    - C++29で`std::simd`版のオーバーロードが追加された

--- a/reference/simd/bit_reverse.md
+++ b/reference/simd/bit_reverse.md
@@ -1,0 +1,82 @@
+# bit_reverse
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-integral V>
+  constexpr V bit_reverse(const V& v) noexcept; // C++29
+}
+```
+* simd-integral[link /reference/simd/simd-integral.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、`<bit>`ヘッダの[`std::bit_reverse`](/reference/bit/bit_reverse.md)を要素ごとに適用し、各要素のビット列の並びを反転する。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+`i`番目の要素が`std::bit_reverse(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0002, 0x0004, 0x0008}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(1u << i);
+  }};
+
+  simd::vec<std::uint16_t, 4> r = simd::bit_reverse(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::bit_reverse[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 1000000000000000
+0000000000000010 -> 0100000000000000
+0000000000000100 -> 0010000000000000
+0000000000001000 -> 0001000000000000
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P3104R3 Bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3104r3.html)
+    - C++29で`<bit>`ヘッダにスカラー版の`bit_reverse`が追加された
+- [P3772R1 std::simd overloads for bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3772r1.html)
+    - C++29で`std::simd`版のオーバーロードが追加された

--- a/reference/simd/bit_width.md
+++ b/reference/simd/bit_width.md
@@ -1,0 +1,83 @@
+# bit_width
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+    bit_width(const V& v) noexcept; // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* make_signed_t[link /reference/type_traits/make_signed.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::bit_width`](/reference/bit/bit_width.md)を要素ごとに適用し、各要素を表現するのに必要なビット数を求める。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+`i`番目の要素が[`std::bit_width`](/reference/bit/bit_width.md)`(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。要素型は`V::value_type`を符号付き整数型にしたものである。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <array>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::array data = {0b000u, 0b001u, 0b100u, 0b111u};
+  simd::vec<std::uint32_t, 4> v {[&](int i) { return data[i]; }};
+
+  auto r = simd::bit_width(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {}", v[i], r[i]);
+  }
+}
+```
+* simd::bit_width[color ff0000]
+
+### 出力
+```
+0000000000000000 -> 0
+0000000000000001 -> 1
+0000000000000100 -> 3
+0000000000000111 -> 3
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::bit_width`](/reference/bit/bit_width.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/byteswap.md
+++ b/reference/simd/byteswap.md
@@ -1,0 +1,81 @@
+# byteswap
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr V byteswap(const V& v) noexcept; // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+
+## 概要
+整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::byteswap`](/reference/bit/byteswap.md)を要素ごとに適用し、各要素を構成するバイト列の順序を反転する。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が整数型であること
+
+
+## 戻り値
+`i`番目の要素が[`std::byteswap`](/reference/bit/byteswap.md)`(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x1122, 0xaabb}
+  simd::vec<std::uint16_t, 2> v {[](int i) {
+    return static_cast<std::uint16_t>(i == 0 ? 0x1122 : 0xaabb);
+  }};
+
+  simd::vec<std::uint16_t, 2> r = simd::byteswap(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::byteswap[color ff0000]
+
+### 出力
+```
+0001000100100010 -> 0010001000010001
+1010101010111011 -> 1011101110101010
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::byteswap`](/reference/bit/byteswap.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/cat.md
+++ b/reference/simd/cat.md
@@ -1,0 +1,85 @@
+# cat
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class... Abis>
+  constexpr resize_t<
+    (basic_vec<T, Abis>::size() + ...),
+    basic_vec<T, Abis...[0]>
+  >
+    cat(const basic_vec<T, Abis>&... xs) noexcept;      // (1) C++26
+
+  template<std::size_t Bytes, class... Abis>
+  constexpr resize_t<
+    (basic_mask<Bytes, Abis>::size() + ...),
+    basic_mask<Bytes, Abis...[0]>
+  >
+    cat(const basic_mask<Bytes, Abis>&... xs) noexcept; // (2) C++26
+}
+```
+
+## 概要
+`cat`は、複数の[`basic_vec`](basic_vec.md)（(1)）または[`basic_mask`](basic_mask.md)（(2)）を連結して、1つの大きなデータ並列オブジェクトを生成する関数である。
+
+引数として渡したオブジェクトが、引数の順に前から並べられる。結果の要素数は、各引数の要素数の総和となる。
+
+逆に、大きなデータ並列オブジェクトを分割する操作は[`chunk`](chunk.md)である。
+
+## 戻り値
+引数`xs`を順に連結したデータ並列オブジェクト。`j`番目の引数の`i`番目の要素は、結果のうち「`i` + 先頭から`j`番目までの引数の要素数の合計」の位置へコピーされる。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 2> a([](int i) { return i; });      // {0, 1}
+  simd::vec<int, 2> b([](int i) { return i + 10; }); // {10, 11}
+
+  // 2つのvecを連結して要素数4のvecを得る
+  auto r = simd::cat(a, b);  // {0, 1, 10, 11}
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::cat[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0 1 10 11 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+- [`std::simd::chunk`](chunk.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/cbrt.md
+++ b/reference/simd/cbrt.md
@@ -1,0 +1,80 @@
+# cbrt
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> cbrt(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素の立方根（3乗根）を求める。各要素に[`<cmath>`](/reference/cmath.md)の[`cbrt`](/reference/cmath/cbrt.md)を要素ごとに適用したものである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`cbrt`](/reference/cmath/cbrt.md)を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    float table[] = {1.0f, 8.0f, 27.0f, 64.0f};
+    return table[i];
+  }};
+
+  // 各要素の立方根を求める
+  simd::vec<float, 4> r = simd::cbrt(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::cbrt[color ff0000]
+
+### 出力例
+```
+1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sqrt`](sqrt.md)
+- [`std::simd::pow`](pow.md)
+- [`std::cbrt`](/reference/cmath/cbrt.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/ceil.md
+++ b/reference/simd/ceil.md
@@ -1,0 +1,82 @@
+# ceil
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> ceil(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、その要素以上の最小の整数値（天井関数）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`ceil`](/reference/cmath/ceil.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {1.2f, 2.7f, -1.2f, -2.7f};
+    return a[i];
+  }};
+
+  // 各要素の天井関数を求める
+  simd::vec<float, 4> r = simd::ceil(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::ceil[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+2 3 -1 -2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::floor`](floor.md)
+- [`std::simd::trunc`](trunc.md)
+- [`std::simd::round`](round.md)
+- [`std::ceil`](/reference/cmath/ceil.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/chunk.md
+++ b/reference/simd/chunk.md
@@ -1,0 +1,99 @@
+# chunk
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  // 型Tと同じ要素数の断片へ分割する
+  template<class T, class Abi>
+  constexpr auto
+    chunk(const basic_vec<typename T::value_type, Abi>& x) noexcept; // (1) C++26
+  template<class T, class Abi>
+  constexpr auto
+    chunk(const basic_mask<mask-element-size<T>, Abi>& x) noexcept;  // (2) C++26
+
+  // 要素数Nの断片へ分割する
+  template<simd-size-type N, class T, class Abi>
+  constexpr auto
+    chunk(const basic_vec<T, Abi>& x) noexcept;       // (3) C++26
+  template<simd-size-type N, std::size_t Bytes, class Abi>
+  constexpr auto
+    chunk(const basic_mask<Bytes, Abi>& x) noexcept;  // (4) C++26
+}
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* mask-element-size[link /reference/simd/mask-element-size.md]
+
+## 概要
+`chunk`は、大きな[`basic_vec`](basic_vec.md)や[`basic_mask`](basic_mask.md)を、より小さなデータ並列オブジェクトへ分割する関数である。
+
+- (1), (2) : 分割後の断片の型`T`を明示的に指定する。`T`の要素数を単位として先頭から順に分割する
+- (3), (4) : 分割後の断片の要素数`N`を指定する
+
+元の要素数が断片の要素数で割り切れる場合は、すべての断片が同じ型となるため、[`std::array`](/reference/array/array.md)で返される。割り切れない場合は、末尾に端数の断片が付くため、[`std::tuple`](/reference/tuple/tuple.md)で返される。
+
+逆に、複数のデータ並列オブジェクトを連結する操作は[`cat`](cat.md)である。
+
+## 戻り値
+元のオブジェクト`x`を先頭から順に分割した断片の列。
+
+- 要素数が割り切れる場合 : すべての断片を格納した[`std::array`](/reference/array/array.md)
+- 割り切れない場合 : 先頭の等分割された断片群と、末尾の端数の断片を格納した[`std::tuple`](/reference/tuple/tuple.md)
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 8> v([](int i) { return i; });  // {0, 1, 2, 3, 4, 5, 6, 7}
+
+  // 要素数4の断片2つに分割する（割り切れるのでarrayが返る）
+  auto chunks = simd::chunk<4>(v);
+
+  for (auto& c : chunks) {
+    for (int i = 0; i < c.size(); ++i)
+      std::print("{} ", c[i]);
+    std::println("");
+  }
+}
+```
+* simd::chunk[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0 1 2 3 
+4 5 6 7 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+- [`std::simd::cat`](cat.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P3441R2 Rename `simd_split` to `simd_chunk`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3441r2.html)
+    - 分割関数の名前が`simd_split`から`chunk`に改名された

--- a/reference/simd/clamp.md
+++ b/reference/simd/clamp.md
@@ -1,0 +1,81 @@
+# clamp
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi>
+  constexpr basic_vec<T, Abi>
+    clamp(const basic_vec<T, Abi>& v,
+          const basic_vec<T, Abi>& lo,
+          const basic_vec<T, Abi>& hi);  // C++26
+}
+```
+
+## 概要
+`clamp`は、[`basic_vec`](basic_vec.md)の各要素を、要素ごとに指定した範囲`[lo, hi]`に収める関数である。各要素が`lo`より小さければ`lo`に、`hi`より大きければ`hi`に切り詰められる。
+
+## テンプレートパラメータ制約
+- `T`が[`std::totally_ordered`](/reference/concepts/totally_ordered.md)のモデルであること
+
+## 事前条件
+- `lo`のどの要素も、`hi`の対応する要素より大きくないこと
+
+## 戻り値
+`i`番目の要素が`clamp(v[i], lo[i], hi[i])`となる`basic_vec`。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i * 2; });  // {0, 2, 4, 6}
+  simd::vec<int, 4> lo = 1;                          // {1, 1, 1, 1}
+  simd::vec<int, 4> hi = 5;                          // {5, 5, 5, 5}
+
+  // 各要素を範囲[1, 5]に収める
+  auto r = simd::clamp(v, lo, hi);  // {1, 2, 4, 5}
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::clamp[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+1 2 4 5 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::min`](min.md)
+- [`std::simd::max`](max.md)
+- [`std::simd::minmax`](minmax.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/comp_ellint_1.md
+++ b/reference/simd/comp_ellint_1.md
@@ -1,0 +1,80 @@
+# comp_ellint_1
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> comp_ellint_1(const V& k); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`comp_ellint_1`](/reference/cmath/comp_ellint_1.md)を適用し、各要素を母数`k`とする第一種完全楕円積分の値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`k[i]`に[`<cmath>`](/reference/cmath.md)の[`comp_ellint_1`](/reference/cmath/comp_ellint_1.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> k([](int i) { return i * 0.5; }); // {0, 0.5}
+
+  // 各要素を母数とする第一種完全楕円積分を求める
+  simd::vec<double, 2> r = simd::comp_ellint_1(k);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::comp_ellint_1[color ff0000]
+
+### 出力例
+```
+1.5707963267948966 1.6857503548125961 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::comp_ellint_2`](comp_ellint_2.md)
+- [`std::simd::comp_ellint_3`](comp_ellint_3.md)
+- [`std::simd::ellint_1`](ellint_1.md)
+- [`std::comp_ellint_1`](/reference/cmath/comp_ellint_1.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/comp_ellint_2.md
+++ b/reference/simd/comp_ellint_2.md
@@ -1,0 +1,80 @@
+# comp_ellint_2
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> comp_ellint_2(const V& k); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`comp_ellint_2`](/reference/cmath/comp_ellint_2.md)を適用し、各要素を母数`k`とする第二種完全楕円積分の値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`k[i]`に[`<cmath>`](/reference/cmath.md)の[`comp_ellint_2`](/reference/cmath/comp_ellint_2.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> k([](int i) { return i * 0.5; }); // {0, 0.5}
+
+  // 各要素を母数とする第二種完全楕円積分を求める
+  simd::vec<double, 2> r = simd::comp_ellint_2(k);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::comp_ellint_2[color ff0000]
+
+### 出力例
+```
+1.5707963267948966 1.4674622093394272 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::comp_ellint_1`](comp_ellint_1.md)
+- [`std::simd::comp_ellint_3`](comp_ellint_3.md)
+- [`std::simd::ellint_2`](ellint_2.md)
+- [`std::comp_ellint_2`](/reference/cmath/comp_ellint_2.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/comp_ellint_3.md
+++ b/reference/simd/comp_ellint_3.md
@@ -1,0 +1,88 @@
+# comp_ellint_3
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> comp_ellint_3(const V& k, const V& nu);                // (1) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> comp_ellint_3(const deduced-vec-t<V>& k, const V& nu); // (2) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> comp_ellint_3(const V& k, const deduced-vec-t<V>& nu); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`comp_ellint_3`](/reference/cmath/comp_ellint_3.md)を適用し、各要素を母数`k`・特性`nu`とする第三種完全楕円積分の値を求める。
+
+- (1) : すべての引数を`V`として受け取る。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`k[i]`と`nu[i]`に[`<cmath>`](/reference/cmath.md)の[`comp_ellint_3`](/reference/cmath/comp_ellint_3.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> k([](int i) { return i * 0.5; }); // {0, 0.5}
+  simd::vec<double, 2> nu = 0.0;                         // {0, 0}
+
+  // 各要素を母数・特性とする第三種完全楕円積分を求める
+  simd::vec<double, 2> r = simd::comp_ellint_3(k, nu);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::comp_ellint_3[color ff0000]
+
+### 出力例
+```
+1.5707963267948966 1.6857503548125961 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::comp_ellint_1`](comp_ellint_1.md)
+- [`std::simd::comp_ellint_2`](comp_ellint_2.md)
+- [`std::simd::ellint_3`](ellint_3.md)
+- [`std::comp_ellint_3`](/reference/cmath/comp_ellint_3.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/compress.md
+++ b/reference/simd/compress.md
@@ -1,0 +1,99 @@
+# compress
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr V
+    compress(const V& v,
+             const typename V::mask_type& selector); // (1) C++26
+  template<simd-mask-type V>
+  constexpr V
+    compress(const V& v,
+             const type_identity_t<V>& selector);    // (2) C++26
+
+  template<simd-vec-type V>
+  constexpr V
+    compress(const V& v,
+             const typename V::mask_type& selector,
+             const typename V::value_type& fill_value); // (3) C++26
+  template<simd-mask-type V>
+  constexpr V
+    compress(const V& v,
+             const type_identity_t<V>& selector,
+             const typename V::value_type& fill_value); // (4) C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* simd-mask-type[link /reference/simd/simd-mask-type.md]
+
+## 概要
+`compress`は、[`basic_vec`](basic_vec.md)や[`basic_mask`](basic_mask.md)の要素のうち、マスク`selector`が`true`である要素だけを、順序を維持したまま先頭に詰めたデータ並列オブジェクトを返す関数である。
+
+`true`である要素の個数を`n`とすると、結果の先頭`n`要素に、元のオブジェクトで`selector`が`true`だった要素が昇順に並ぶ。残りの要素の値は以下のように決まる。
+
+- (1), (2) `fill_value`を指定しない場合 : 残りの要素は妥当だが未規定の値となる
+- (3), (4) `fill_value`を指定する場合 : 残りの要素は`fill_value`で埋められる
+
+逆の操作は[`expand`](expand.md)である。
+
+## 戻り値
+`selector`が`true`である`i`番目の要素を`v`から昇順に取り出して先頭に詰め、残りを未規定値（(1), (2)）または`fill_value`（(3), (4)）で埋めたデータ並列オブジェクト。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i + 1; });  // {1, 2, 3, 4}
+
+  // 偶数の要素だけを先頭に詰める。残りは0で埋める
+  auto selector = (v % 2 == 0);             // {false, true, false, true}
+  auto r = simd::compress(v, selector, 0);  // {2, 4, 0, 0}
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::compress[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+2 4 0 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+- [`std::simd::expand`](expand.md)
+- [`std::simd::permute`](permute.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2664R11 Proposal to extend `std::simd` with permutation API](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2664r11.html)
+    - C++26で置換API（`compress`）が追加された

--- a/reference/simd/conj.md
+++ b/reference/simd/conj.md
@@ -1,0 +1,85 @@
+# conj
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-complex V>
+  constexpr V conj(const V& v); // C++26
+}
+```
+* simd-complex[link /reference/simd/simd-complex.md]
+
+## 概要
+要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素の共役複素数を求める。
+
+制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`v[i]`に[`<complex>`](/reference/complex/complex.md)の[`conj`](/reference/complex/complex/conj.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i + 1.0f, i + 1.0f); }
+  };  // {(1, 1), (2, 2)}
+
+  // 各要素の共役複素数を求める
+  simd::vec<std::complex<float>, 2> r = simd::conj(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::complex<float> c = r[i];
+    std::print("({}, {}) ", c.real(), c.imag());
+  }
+  std::println("");
+}
+```
+* simd::conj[color ff0000]
+
+### 出力例
+```
+(1, -1) (2, -2) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::norm`](norm.md)
+- [`std::simd::proj`](proj.md)
+- [`std::simd::real`](real.md)
+- [`std::simd::imag`](imag.md)
+- [`std::complex::conj`](/reference/complex/complex/conj.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/copysign.md
+++ b/reference/simd/copysign.md
@@ -1,0 +1,91 @@
+# copysign
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    copysign(const V& x, const V& y);                // (1) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    copysign(const deduced-vec-t<V>& x, const V& y); // (2) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    copysign(const V& x, const deduced-vec-t<V>& y); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`の大きさと`y[i]`の符号を合成した値を求める。各要素に[`std::copysign`](/reference/cmath/copysign.md)を適用する。
+
+- (1) : 両オペランドが同じ型の場合のオーバーロード。
+- (2), (3) : 一方のオペランドがスカラー値であり、[`basic_vec`](basic_vec.md)へと変換される場合のオーバーロード。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`の大きさと`y[i]`の符号を持つ値（`x[i]`と`y[i]`に[`std::copysign`](/reference/cmath/copysign.md)を適用した結果）で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> mag([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+  simd::vec<float, 4> sign([](int i) { return i % 2 ? 1.0f : -1.0f; }); // {-1, 1, -1, 1}
+
+  // magの大きさとsignの符号を合成する
+  simd::vec<float, 4> r = simd::copysign(mag, sign);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::copysign[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+-1 2 -3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::signbit`](signbit.md)
+- [`std::simd::nextafter`](nextafter.md)
+- [`std::copysign`](/reference/cmath/copysign.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/cos.md
+++ b/reference/simd/cos.md
@@ -1,0 +1,125 @@
+# cos
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> cos(const V& x);  // (1) C++26
+
+  template<simd-complex V>
+  constexpr V cos(const V& v);                 // (2) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、余弦（コサイン）を求める。
+
+- (1) : 要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の余弦を求める。
+- (2) : 要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素の余弦を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。
+
+
+## 戻り値
+- (1) : 各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`cos`](/reference/cmath/cos.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+- (2) : 各要素`i`（`0`以上`V::size()`未満）について、`v[i]`に[`<complex>`](/reference/complex/complex.md)の[`cos`](/reference/complex/complex/cos.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+### 基本的な使い方
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i * 0.5f; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の余弦を求める
+  simd::vec<float, 4> r = simd::cos(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::cos[color ff0000]
+
+#### 出力例
+```
+1 0.877583 0.540302 0.0707372 
+```
+
+### 複素数版
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i * 1.0f, 0.0f); }
+  };  // {(0, 0), (1, 0)}
+
+  // 各要素の余弦を求める
+  simd::vec<std::complex<float>, 2> r = simd::cos(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::complex<float> c = r[i];
+    std::print("({}, {}) ", c.real(), c.imag());
+  }
+  std::println("");
+}
+```
+* simd::cos[color ff0000]
+
+#### 出力例
+```
+(1, 0) (0.540302, 0) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sin`](sin.md)
+- [`std::simd::tan`](tan.md)
+- [`std::simd::acos`](acos.md)
+- [`std::simd::cosh`](cosh.md)
+- [`cos`](/reference/cmath/cos.md)
+- [`std::complex::cos`](/reference/complex/complex/cos.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/cosh.md
+++ b/reference/simd/cosh.md
@@ -1,0 +1,80 @@
+# cosh
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> cosh(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の双曲線余弦（ハイパボリックコサイン）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`cosh`](/reference/cmath/cosh.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i * 0.5f; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の双曲線余弦を求める
+  simd::vec<float, 4> r = simd::cosh(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::cosh[color ff0000]
+
+### 出力例
+```
+1 1.12763 1.54308 2.35241 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sinh`](sinh.md)
+- [`std::simd::tanh`](tanh.md)
+- [`std::simd::acosh`](acosh.md)
+- [`std::simd::cos`](cos.md)
+- [`cosh`](/reference/cmath/cosh.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/countl_one.md
+++ b/reference/simd/countl_one.md
@@ -1,0 +1,85 @@
+# countl_one
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+    countl_one(const V& v) noexcept; // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* make_signed_t[link /reference/type_traits/make_signed.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::countl_one`](/reference/bit/countl_one.md)を要素ごとに適用し、各要素について最上位ビットから連続する1ビットの数を数える。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+`i`番目の要素が[`std::countl_one`](/reference/bit/countl_one.md)`(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。要素型は`V::value_type`を符号付き整数型にしたものである。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0xffff, 0xfffe, 0xfffc, 0xfff8}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(0xffffu << i);
+  }};
+
+  auto r = simd::countl_one(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {}", v[i], r[i]);
+  }
+}
+```
+* simd::countl_one[color ff0000]
+
+### 出力
+```
+1111111111111111 -> 16
+1111111111111110 -> 15
+1111111111111100 -> 14
+1111111111111000 -> 13
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::countl_one`](/reference/bit/countl_one.md)
+- [`std::simd::countl_zero`](countl_zero.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/countl_zero.md
+++ b/reference/simd/countl_zero.md
@@ -1,0 +1,85 @@
+# countl_zero
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+    countl_zero(const V& v) noexcept; // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* make_signed_t[link /reference/type_traits/make_signed.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::countl_zero`](/reference/bit/countl_zero.md)を要素ごとに適用し、各要素について最上位ビットから連続する0ビットの数を数える。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+`i`番目の要素が[`std::countl_zero`](/reference/bit/countl_zero.md)`(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。要素型は`V::value_type`を符号付き整数型にしたものである。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0010, 0x0100, 0x1000}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(1u << (i * 4));
+  }};
+
+  auto r = simd::countl_zero(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {}", v[i], r[i]);
+  }
+}
+```
+* simd::countl_zero[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 15
+0000000000010000 -> 11
+0000000100000000 -> 7
+0001000000000000 -> 3
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::countl_zero`](/reference/bit/countl_zero.md)
+- [`std::simd::countl_one`](countl_one.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/countr_one.md
+++ b/reference/simd/countr_one.md
@@ -1,0 +1,85 @@
+# countr_one
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+    countr_one(const V& v) noexcept; // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* make_signed_t[link /reference/type_traits/make_signed.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::countr_one`](/reference/bit/countr_one.md)を要素ごとに適用し、各要素について最下位ビットから連続する1ビットの数を数える。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+`i`番目の要素が[`std::countr_one`](/reference/bit/countr_one.md)`(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。要素型は`V::value_type`を符号付き整数型にしたものである。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0003, 0x0007, 0x000f}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>((1u << (i + 1)) - 1);
+  }};
+
+  auto r = simd::countr_one(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {}", v[i], r[i]);
+  }
+}
+```
+* simd::countr_one[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 1
+0000000000000011 -> 2
+0000000000000111 -> 3
+0000000000001111 -> 4
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::countr_one`](/reference/bit/countr_one.md)
+- [`std::simd::countr_zero`](countr_zero.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/countr_zero.md
+++ b/reference/simd/countr_zero.md
@@ -1,0 +1,85 @@
+# countr_zero
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+    countr_zero(const V& v) noexcept; // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* make_signed_t[link /reference/type_traits/make_signed.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::countr_zero`](/reference/bit/countr_zero.md)を要素ごとに適用し、各要素について最下位ビットから連続する0ビットの数を数える。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+`i`番目の要素が[`std::countr_zero`](/reference/bit/countr_zero.md)`(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。要素型は`V::value_type`を符号付き整数型にしたものである。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0010, 0x0100, 0x1000}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(1u << (i * 4));
+  }};
+
+  auto r = simd::countr_zero(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {}", v[i], r[i]);
+  }
+}
+```
+* simd::countr_zero[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 0
+0000000000010000 -> 4
+0000000100000000 -> 8
+0001000000000000 -> 12
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::countr_zero`](/reference/bit/countr_zero.md)
+- [`std::simd::countr_one`](countr_one.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/cyl_bessel_i.md
+++ b/reference/simd/cyl_bessel_i.md
@@ -1,0 +1,88 @@
+# cyl_bessel_i
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_bessel_i(const V& nu, const V& x);                // (1) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_bessel_i(const deduced-vec-t<V>& nu, const V& x); // (2) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_bessel_i(const V& nu, const deduced-vec-t<V>& x); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`cyl_bessel_i`](/reference/cmath/cyl_bessel_i.md)を適用し、各要素を階数`nu`・引数`x`とする第一種変形（双曲）ベッセル関数の値を求める。
+
+- (1) : すべての引数を`V`として受け取る。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`nu[i]`と`x[i]`に[`<cmath>`](/reference/cmath.md)の[`cyl_bessel_i`](/reference/cmath/cyl_bessel_i.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> nu = 0.0;                         // {0, 0}
+  simd::vec<double, 2> x([](int i) { return i + 1.0; }); // {1, 2}
+
+  // 各要素を階数・引数とする第一種変形ベッセル関数を求める
+  simd::vec<double, 2> r = simd::cyl_bessel_i(nu, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::cyl_bessel_i[color ff0000]
+
+### 出力例
+```
+1.2660658777520082 2.279585302336067 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::cyl_bessel_j`](cyl_bessel_j.md)
+- [`std::simd::cyl_bessel_k`](cyl_bessel_k.md)
+- [`std::simd::cyl_neumann`](cyl_neumann.md)
+- [`std::cyl_bessel_i`](/reference/cmath/cyl_bessel_i.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/cyl_bessel_j.md
+++ b/reference/simd/cyl_bessel_j.md
@@ -1,0 +1,88 @@
+# cyl_bessel_j
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_bessel_j(const V& nu, const V& x);                // (1) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_bessel_j(const deduced-vec-t<V>& nu, const V& x); // (2) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_bessel_j(const V& nu, const deduced-vec-t<V>& x); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`cyl_bessel_j`](/reference/cmath/cyl_bessel_j.md)を適用し、各要素を階数`nu`・引数`x`とする第一種ベッセル関数の値を求める。
+
+- (1) : すべての引数を`V`として受け取る。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`nu[i]`と`x[i]`に[`<cmath>`](/reference/cmath.md)の[`cyl_bessel_j`](/reference/cmath/cyl_bessel_j.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> nu = 0.0;                         // {0, 0}
+  simd::vec<double, 2> x([](int i) { return i + 1.0; }); // {1, 2}
+
+  // 各要素を階数・引数とする第一種ベッセル関数を求める
+  simd::vec<double, 2> r = simd::cyl_bessel_j(nu, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::cyl_bessel_j[color ff0000]
+
+### 出力例
+```
+0.7651976865579665 0.22389077914123567 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::cyl_bessel_i`](cyl_bessel_i.md)
+- [`std::simd::cyl_bessel_k`](cyl_bessel_k.md)
+- [`std::simd::cyl_neumann`](cyl_neumann.md)
+- [`std::cyl_bessel_j`](/reference/cmath/cyl_bessel_j.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/cyl_bessel_k.md
+++ b/reference/simd/cyl_bessel_k.md
@@ -1,0 +1,88 @@
+# cyl_bessel_k
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_bessel_k(const V& nu, const V& x);                // (1) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_bessel_k(const deduced-vec-t<V>& nu, const V& x); // (2) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_bessel_k(const V& nu, const deduced-vec-t<V>& x); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`cyl_bessel_k`](/reference/cmath/cyl_bessel_k.md)を適用し、各要素を階数`nu`・引数`x`とする第二種変形（双曲）ベッセル関数の値を求める。
+
+- (1) : すべての引数を`V`として受け取る。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`nu[i]`と`x[i]`に[`<cmath>`](/reference/cmath.md)の[`cyl_bessel_k`](/reference/cmath/cyl_bessel_k.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> nu = 0.0;                         // {0, 0}
+  simd::vec<double, 2> x([](int i) { return i + 1.0; }); // {1, 2}
+
+  // 各要素を階数・引数とする第二種変形ベッセル関数を求める
+  simd::vec<double, 2> r = simd::cyl_bessel_k(nu, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::cyl_bessel_k[color ff0000]
+
+### 出力例
+```
+0.42102443824070834 0.11389387274953349 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::cyl_bessel_i`](cyl_bessel_i.md)
+- [`std::simd::cyl_bessel_j`](cyl_bessel_j.md)
+- [`std::simd::cyl_neumann`](cyl_neumann.md)
+- [`std::cyl_bessel_k`](/reference/cmath/cyl_bessel_k.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/cyl_neumann.md
+++ b/reference/simd/cyl_neumann.md
@@ -1,0 +1,88 @@
+# cyl_neumann
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_neumann(const V& nu, const V& x);                // (1) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_neumann(const deduced-vec-t<V>& nu, const V& x); // (2) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> cyl_neumann(const V& nu, const deduced-vec-t<V>& x); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`cyl_neumann`](/reference/cmath/cyl_neumann.md)を適用し、各要素を階数`nu`・引数`x`とする第二種ベッセル関数（ノイマン関数）の値を求める。
+
+- (1) : すべての引数を`V`として受け取る。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`nu[i]`と`x[i]`に[`<cmath>`](/reference/cmath.md)の[`cyl_neumann`](/reference/cmath/cyl_neumann.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> nu = 0.0;                         // {0, 0}
+  simd::vec<double, 2> x([](int i) { return i + 1.0; }); // {1, 2}
+
+  // 各要素を階数・引数とする第二種ベッセル関数を求める
+  simd::vec<double, 2> r = simd::cyl_neumann(nu, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::cyl_neumann[color ff0000]
+
+### 出力例
+```
+0.08825696421567697 0.5103756726497451 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::cyl_bessel_i`](cyl_bessel_i.md)
+- [`std::simd::cyl_bessel_j`](cyl_bessel_j.md)
+- [`std::simd::cyl_bessel_k`](cyl_bessel_k.md)
+- [`std::cyl_neumann`](/reference/cmath/cyl_neumann.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/deduce-abi-t.md
+++ b/reference/simd/deduce-abi-t.md
@@ -1,0 +1,34 @@
+# deduce-abi-t
+* [meta exposition-only]
+* simd[meta header]
+* type-alias[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, simd-size-type N>
+  using deduce-abi-t = /*see below*/;
+}
+```
+* simd-size-type[link simd-size-type.md]
+
+## 概要
+`deduce-abi-t`は、要素型`T`と要素数`N`から、対応するABIタグを導出する説明専用の型エイリアスである。
+
+`T`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であり、`N`が`0`より大きく処理系定義の最大値以下である場合、`deduce-abi-t<T, N>`はABIタグ型を表す。このとき[`simd-size-v`](simd-size-v.md)`<T, deduce-abi-t<T, N>>`は`N`に等しく、`basic_vec<T, deduce-abi-t<T, N>>`は有効な特殊化となる。条件を満たさない場合は未規定の型を表す。
+
+要素数`N`を指定する[`vec`](basic_vec.md)`<T, N>`・[`mask`](basic_mask.md)の別名定義に使用される。`N`の最大値は`T`ごとに異なりうるが、64以上であることが保証される。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::simd-size-v`](simd-size-v.md)
+- [`std::simd::native-abi`](native-abi.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/deduced-vec-t.md
+++ b/reference/simd/deduced-vec-t.md
@@ -1,0 +1,36 @@
+# deduced-vec-t
+* [meta exposition-only]
+* simd[meta header]
+* type-alias[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T>
+  using deduced-vec-t = /*see below*/;
+}
+```
+
+## 概要
+`deduced-vec-t`は、型`T`から導出されるデータ並列型を表す説明専用の型エイリアスである。
+
+`x`を型`const T`の左辺値とするとき、`deduced-vec-t<T>`は`decltype(x + x)`のエイリアスである。これにより、次のように振る舞う。
+
+- `T`が[`basic_vec`](basic_vec.md)であれば、その`T`自身
+- `T`がスカラーの算術型であれば、それを要素型とする既定ABI（[`native-abi`](native-abi.md)）の[`basic_vec`](basic_vec.md)
+
+数学関数（[`exp`](exp.md)・[`sin`](sin.md)など）は、この型エイリアスを引数型や戻り値型に用いることで、データ並列型とスカラーの両方を統一的に扱う。説明専用コンセプト[`math-floating-point`](math-floating-point.md)の定義にも使用される。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::math-floating-point`](math-floating-point.md)
+- [`std::simd::native-abi`](native-abi.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/ellint_1.md
+++ b/reference/simd/ellint_1.md
@@ -1,0 +1,88 @@
+# ellint_1
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> ellint_1(const V& k, const V& phi);                // (1) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> ellint_1(const deduced-vec-t<V>& k, const V& phi); // (2) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> ellint_1(const V& k, const deduced-vec-t<V>& phi); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`ellint_1`](/reference/cmath/ellint_1.md)を適用し、各要素を母数`k`・振幅`phi`とする第一種不完全楕円積分の値を求める。
+
+- (1) : すべての引数を`V`として受け取る。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`k[i]`と`phi[i]`に[`<cmath>`](/reference/cmath.md)の[`ellint_1`](/reference/cmath/ellint_1.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> k = 0.0;                                  // {0, 0}
+  simd::vec<double, 2> phi([](int i) { return i * 0.5 + 0.5; }); // {0.5, 1}
+
+  // 各要素を母数・振幅とする第一種不完全楕円積分を求める
+  simd::vec<double, 2> r = simd::ellint_1(k, phi);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::ellint_1[color ff0000]
+
+### 出力例
+```
+0.5 1 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::ellint_2`](ellint_2.md)
+- [`std::simd::ellint_3`](ellint_3.md)
+- [`std::simd::comp_ellint_1`](comp_ellint_1.md)
+- [`std::ellint_1`](/reference/cmath/ellint_1.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/ellint_2.md
+++ b/reference/simd/ellint_2.md
@@ -1,0 +1,88 @@
+# ellint_2
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> ellint_2(const V& k, const V& phi);                // (1) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> ellint_2(const deduced-vec-t<V>& k, const V& phi); // (2) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V> ellint_2(const V& k, const deduced-vec-t<V>& phi); // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`ellint_2`](/reference/cmath/ellint_2.md)を適用し、各要素を母数`k`・振幅`phi`とする第二種不完全楕円積分の値を求める。
+
+- (1) : すべての引数を`V`として受け取る。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`k[i]`と`phi[i]`に[`<cmath>`](/reference/cmath.md)の[`ellint_2`](/reference/cmath/ellint_2.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> k = 0.0;                                  // {0, 0}
+  simd::vec<double, 2> phi([](int i) { return i * 0.5 + 0.5; }); // {0.5, 1}
+
+  // 各要素を母数・振幅とする第二種不完全楕円積分を求める
+  simd::vec<double, 2> r = simd::ellint_2(k, phi);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::ellint_2[color ff0000]
+
+### 出力例
+```
+0.5 1 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::ellint_1`](ellint_1.md)
+- [`std::simd::ellint_3`](ellint_3.md)
+- [`std::simd::comp_ellint_2`](comp_ellint_2.md)
+- [`std::ellint_2`](/reference/cmath/ellint_2.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/ellint_3.md
+++ b/reference/simd/ellint_3.md
@@ -1,0 +1,118 @@
+# ellint_3
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    ellint_3(const V& k,
+             const V& nu,
+             const V& phi);                 // (1) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    ellint_3(const deduced-vec-t<V>& k,
+             const V& nu,
+             const V& phi);                 // (2) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    ellint_3(const V& k,
+             const deduced-vec-t<V>& nu,
+             const V& phi);                 // (3) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    ellint_3(const V& k,
+             const V& nu,
+             const deduced-vec-t<V>& phi);  // (4) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    ellint_3(const deduced-vec-t<V>& k,
+             const deduced-vec-t<V>& nu,
+             const V& phi);                 // (5) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    ellint_3(const deduced-vec-t<V>& k,
+             const V& nu,
+             const deduced-vec-t<V>& phi);  // (6) C++26
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    ellint_3(const V& k,
+             const deduced-vec-t<V>& nu,
+             const deduced-vec-t<V>& phi);  // (7) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`ellint_3`](/reference/cmath/ellint_3.md)を適用し、各要素を母数`k`・特性`nu`・振幅`phi`とする第三種不完全楕円積分の値を求める。
+
+- (1) : すべての引数を`V`として受け取る。
+- (2)〜(7) : 一部の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`k[i]`・`nu[i]`・`phi[i]`に[`<cmath>`](/reference/cmath.md)の[`ellint_3`](/reference/cmath/ellint_3.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> k = 0.0;  // {0, 0}
+  simd::vec<double, 2> nu = 0.0; // {0, 0}
+  simd::vec<double, 2> phi([](int i) { return i * 0.5 + 0.5; }); // {0.5, 1}
+
+  // 各要素を母数・特性・振幅とする第三種不完全楕円積分を求める
+  simd::vec<double, 2> r = simd::ellint_3(k, nu, phi);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::ellint_3[color ff0000]
+
+### 出力例
+```
+0.5 1 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::ellint_1`](ellint_1.md)
+- [`std::simd::ellint_2`](ellint_2.md)
+- [`std::simd::comp_ellint_3`](comp_ellint_3.md)
+- [`std::ellint_3`](/reference/cmath/ellint_3.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/erf.md
+++ b/reference/simd/erf.md
@@ -1,0 +1,78 @@
+# erf
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> erf(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`erf`](/reference/cmath/erf.md)を適用し、各要素の誤差関数（error function）の値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`erf`](/reference/cmath/erf.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 4> v([](int i) { return i * 0.5; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の誤差関数を求める
+  simd::vec<double, 4> r = simd::erf(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::erf[color ff0000]
+
+### 出力例
+```
+0 0.5204998778130465 0.8427007929497149 0.9661051464753107 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::erfc`](erfc.md)
+- [`std::erf`](/reference/cmath/erf.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/erfc.md
+++ b/reference/simd/erfc.md
@@ -1,0 +1,78 @@
+# erfc
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> erfc(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`erfc`](/reference/cmath/erfc.md)を適用し、各要素の相補誤差関数（complementary error function、`1 - erf`）の値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`erfc`](/reference/cmath/erfc.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 4> v([](int i) { return i * 0.5; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の相補誤差関数を求める
+  simd::vec<double, 4> r = simd::erfc(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::erfc[color ff0000]
+
+### 出力例
+```
+1 0.4795001221869535 0.15729920705028513 0.033894853524689274 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::erf`](erf.md)
+- [`std::erfc`](/reference/cmath/erfc.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/exp.md
+++ b/reference/simd/exp.md
@@ -1,0 +1,125 @@
+# exp
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> exp(const V& x); // (1) C++26
+
+  template<simd-complex V>
+  constexpr V exp(const V& v);                // (2) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、自然対数の底`e`を底とする指数関数（`e`を要素の値で累乗した値）を求める。
+
+- (1) : 浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素に[`<cmath>`](/reference/cmath.md)の[`exp`](/reference/cmath/exp.md)を要素ごとに適用する。
+- (2) : 要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素に[`<complex>`](/reference/complex/complex.md)の[`exp`](/reference/complex/complex/exp.md)を要素ごとに適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`v[i]`（`x[i]`）に対応する`exp`を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+- (1) : [`<cmath>`](/reference/cmath.md)の[`exp`](/reference/cmath/exp.md)を適用する。
+- (2) : [`<complex>`](/reference/complex/complex.md)の[`exp`](/reference/complex/complex/exp.md)を適用する。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+### 基本的な使い方
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return float(i); }); // {0, 1, 2, 3}
+
+  // 各要素の指数関数を求める
+  simd::vec<float, 4> r = simd::exp(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::exp[color ff0000]
+
+#### 出力例
+```
+1 2.71828 7.38906 20.0855 
+```
+
+### 複素数版 (2)
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i * 1.0f, i * 1.0f); }
+  };  // {(0, 0), (1, 1)}
+
+  // 各要素の指数関数を求める
+  simd::vec<std::complex<float>, 2> r = simd::exp(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::complex<float> c = r[i];
+    std::print("({}, {}) ", c.real(), c.imag());
+  }
+  std::println("");
+}
+```
+* simd::exp[color ff0000]
+
+#### 出力例
+```
+(1, 0) (1.4687, 2.28736) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::exp2`](exp2.md)
+- [`std::simd::expm1`](expm1.md)
+- [`std::simd::log`](log.md)
+- [`std::simd::pow`](pow.md)
+- [`std::simd::sqrt`](sqrt.md)
+- [`std::exp`](/reference/cmath/exp.md)
+- [`std::complex::exp`](/reference/complex/complex/exp.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加され、実数版の`exp` (1) が追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数版の`exp` (2) が追加された

--- a/reference/simd/exp2.md
+++ b/reference/simd/exp2.md
@@ -1,0 +1,77 @@
+# exp2
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> exp2(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素の`2`を底とする指数関数（2を`x`乗した値）を求める。各要素に[`<cmath>`](/reference/cmath.md)の[`exp2`](/reference/cmath/exp2.md)を要素ごとに適用したものである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`exp2`](/reference/cmath/exp2.md)を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return float(i + 1); }); // {1, 2, 3, 4}
+
+  // 各要素の2の指数関数を求める
+  simd::vec<float, 4> r = simd::exp2(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::exp2[color ff0000]
+
+### 出力例
+```
+2 4 8 16 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::exp`](exp.md)
+- [`std::simd::log2`](log2.md)
+- [`std::exp2`](/reference/cmath/exp2.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/expand.md
+++ b/reference/simd/expand.md
@@ -1,0 +1,87 @@
+# expand
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr V
+    expand(const V& v,
+           const typename V::mask_type& selector,
+           const V& original = {});                // (1) C++26
+  template<simd-mask-type V>
+  constexpr V
+    expand(const V& v,
+           const type_identity_t<V>& selector,
+           const V& original = {});                // (2) C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* simd-mask-type[link /reference/simd/simd-mask-type.md]
+
+## 概要
+`expand`は、[`compress`](compress.md)の逆操作を行う関数である。先頭に詰められたデータ並列オブジェクト`v`の要素を、マスク`selector`が`true`である位置へ順番に展開する。
+
+`selector`が`true`である位置には、`v`の先頭から昇順に要素が配置される。`selector`が`false`である位置には、`original`の対応する要素が配置される。
+
+## 戻り値
+`i`番目の要素について、`selector[i]`が`true`ならば`v`の対応する要素、`false`ならば`original[i]`で初期化されたデータ並列オブジェクト。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // 先頭に詰められた値
+  simd::vec<int, 4> v([](int i) { return i + 1; });  // {1, 2, 3, 4}
+
+  // trueの位置へ v の先頭から順に展開する。falseの位置は original(=0) となる
+  simd::vec<int, 4>::mask_type selector([](int i) { return i % 2 == 1; });
+                                             // {false, true, false, true}
+  auto r = simd::expand(v, selector);   // {0, 1, 0, 2}
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::expand[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0 1 0 2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+- [`std::simd::compress`](compress.md)
+- [`std::simd::permute`](permute.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2664R11 Proposal to extend `std::simd` with permutation API](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2664r11.html)
+    - C++26で置換API（`expand`）が追加された

--- a/reference/simd/expint.md
+++ b/reference/simd/expint.md
@@ -1,0 +1,77 @@
+# expint
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> expint(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`expint`](/reference/cmath/expint.md)を適用し、各要素の指数積分（exponential integral）の値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`expint`](/reference/cmath/expint.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> v([](int i) { return i + 1.0; }); // {1, 2}
+
+  // 各要素の指数積分を求める
+  simd::vec<double, 2> r = simd::expint(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::expint[color ff0000]
+
+### 出力例
+```
+1.8951178163559366 4.954234356001891 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::expint`](/reference/cmath/expint.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/explicitly-convertible-to.md
+++ b/reference/simd/explicitly-convertible-to.md
@@ -1,0 +1,33 @@
+# explicitly-convertible-to
+* [meta exposition-only]
+* simd[meta header]
+* concept[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class From, class To>
+  concept explicitly-convertible-to =
+    requires {
+      static_cast<To>(declval<From>());
+    };
+}
+```
+* declval[link /reference/utility/declval.md]
+
+## 概要
+`explicitly-convertible-to`は、型`From`の値が型`To`へ明示的に変換可能（`static_cast<To>`が適格）であることを表す説明専用のコンセプトである。
+
+[`basic_vec`](basic_vec.md)の変換コンストラクタなど、要素型どうしの明示的な変換を要求する箇所のテンプレートパラメータ制約として使用される。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/expm1.md
+++ b/reference/simd/expm1.md
@@ -1,0 +1,77 @@
+# expm1
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> expm1(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素の自然対数の底`e`を底とする指数関数から`1`を引いた値（<code>e<sup>x</sup> - 1</code>）を求める。各要素に[`<cmath>`](/reference/cmath.md)の[`expm1`](/reference/cmath/expm1.md)を要素ごとに適用したものである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`expm1`](/reference/cmath/expm1.md)を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return float(i); }); // {0, 1, 2, 3}
+
+  // 各要素の e^x - 1 を求める
+  simd::vec<float, 4> r = simd::expm1(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::expm1[color ff0000]
+
+### 出力例
+```
+0 1.71828 6.38906 19.0855 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::exp`](exp.md)
+- [`std::simd::log1p`](log1p.md)
+- [`std::expm1`](/reference/cmath/expm1.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/fabs.md
+++ b/reference/simd/fabs.md
@@ -1,0 +1,79 @@
+# fabs
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fabs(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、絶対値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`fabs`](/reference/cmath/fabs.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) { return (i % 2 == 0 ? -1.0f : 1.0f) * (i + 1); }};
+  // {-1, 2, -3, 4}
+
+  // 各要素の絶対値を求める
+  simd::vec<float, 4> r = simd::fabs(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::fabs[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::abs`](abs.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::fabs`](/reference/cmath/fabs.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/fdim.md
+++ b/reference/simd/fdim.md
@@ -1,0 +1,86 @@
+# fdim
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fdim(const V& x, const V& y);                     // (1) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fdim(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fdim(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、正の差（`x > y`なら`x - y`、そうでなければ`+0`）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+- (1) : 両引数が同じ型`V`の場合。
+- (2), (3) : 一方の引数を[`basic_vec`](basic_vec.md)、他方をスカラー値として、スカラー側を全要素に対して適用する場合。
+
+
+## 戻り値
+各要素`i`について、`x`・`y`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`fdim`](/reference/cmath/fdim.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x{[](int i) { constexpr float a[] = {5, 2, 7, 1}; return a[i]; }};
+  simd::vec<float, 4> y{[](int i) { constexpr float a[] = {3, 4, 2, 1}; return a[i]; }};
+
+  // 各要素の正の差
+  simd::vec<float, 4> r = simd::fdim(x, y);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::fdim[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+2 0 5 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::fmax`](fmax.md)
+- [`std::simd::fmin`](fmin.md)
+- [`std::fdim`](/reference/cmath/fdim.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/flags.md
+++ b/reference/simd/flags.md
@@ -1,0 +1,91 @@
+# flags
+* simd[meta header]
+* std::simd[meta namespace]
+* class template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class... Flags>
+  struct flags {
+    template<class... Other>
+    friend consteval auto operator|(flags, flags<Other...>);
+  };
+
+  inline constexpr flags<> flag_default{};
+  inline constexpr flags</*convert-flag*/> flag_convert{};
+  inline constexpr flags</*aligned-flag*/> flag_aligned{};
+  template<std::size_t N> requires (has_single_bit(N))
+  constexpr flags</*overaligned-flag*/<N>> flag_overaligned{};
+}
+```
+
+## 概要
+`flags`は、[`basic_vec`](basic_vec.md)の読み込み／書き込み（[`unchecked_load`](unchecked_load.md)・[`unchecked_store`](unchecked_store.md)や、範囲を取るコンストラクタなど）の動作を制御するためのフラグをまとめて表すクラステンプレートである。整数のビットフラグのように、`operator|`で複数のフラグを合成できる。
+
+通常は、以下の定義済みフラグオブジェクトを使用する。
+
+| フラグ | 説明 |
+|--------|------|
+| `flag_default`         | 既定の動作（フラグなし）。要素型とメモリの型が一致し、アライメント要件を仮定しない |
+| `flag_convert`         | メモリの要素型が`basic_vec`の要素型と異なる場合に、変換読み込み／書き込みを許可する |
+| `flag_aligned`         | メモリ先頭が`basic_vec`のアライメント要件（[`alignment_v`](alignment.md)）を満たしていると仮定する |
+| `flag_overaligned<N>`  | メモリ先頭が`N`バイト境界にアライメントされていると仮定する（`N`は2の冪） |
+
+
+## メンバ関数
+### 非メンバ（*Hidden friends*）関数
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| <code>operator&#x7C;</code> | 2つの`flags`を合成する | C++26 |
+
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::array<float, 4> data = {1.0f, 2.0f, 3.0f, 4.0f};
+
+  // アライメント済みメモリからの読み込みを指定
+  simd::vec<float, 4> v = simd::unchecked_load(data, simd::flag_aligned);
+
+  std::print("{}", v[0]);
+  std::println("");
+}
+```
+* simd::vec[link basic_vec.md]
+* simd::unchecked_load[link unchecked_load.md]
+* simd::flag_aligned[color ff0000]
+
+### 出力
+```
+1
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::unchecked_load`](unchecked_load.md)
+- [`std::simd::unchecked_store`](unchecked_store.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/floor.md
+++ b/reference/simd/floor.md
@@ -1,0 +1,82 @@
+# floor
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> floor(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、その要素以下の最大の整数値（床関数）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`floor`](/reference/cmath/floor.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {1.2f, 2.7f, -1.2f, -2.7f};
+    return a[i];
+  }};
+
+  // 各要素の床関数を求める
+  simd::vec<float, 4> r = simd::floor(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::floor[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+1 2 -2 -3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::ceil`](ceil.md)
+- [`std::simd::trunc`](trunc.md)
+- [`std::simd::round`](round.md)
+- [`std::floor`](/reference/cmath/floor.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/fma.md
+++ b/reference/simd/fma.md
@@ -1,0 +1,102 @@
+# fma
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fma(const V& x, const V& y, const V& z);  // (1) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    fma(const deduced-vec-t<V>& x, const V& y, const V& z);            // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    fma(const V& x, const deduced-vec-t<V>& y, const V& z);            // (3) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    fma(const V& x, const V& y, const deduced-vec-t<V>& z);            // (4) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    fma(const deduced-vec-t<V>& x, const deduced-vec-t<V>& y, const V& z); // (5) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    fma(const deduced-vec-t<V>& x, const V& y, const deduced-vec-t<V>& z); // (6) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    fma(const V& x, const deduced-vec-t<V>& y, const deduced-vec-t<V>& z); // (7) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、積和演算`x * y + z`を、途中結果を丸めずに1回の丸めで計算する（fused multiply-add）。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+- (1) : 3引数が同じ型`V`の場合。
+- (2)-(7) : 一部の引数を[`basic_vec`](basic_vec.md)、残りをスカラー値として、スカラー側を全要素に対して適用する場合。
+
+
+## 戻り値
+各要素`i`について、`x`・`y`・`z`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`fma`](/reference/cmath/fma.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x{[](int i) { return i + 1.0f; }}; // {1, 2, 3, 4}
+  simd::vec<float, 4> y = 2.0f;                          // {2, 2, 2, 2}
+  simd::vec<float, 4> z = 1.0f;                          // {1, 1, 1, 1}
+
+  // 各要素について x * y + z を計算する
+  simd::vec<float, 4> r = simd::fma(x, y, z);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::fma[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+3 5 7 9 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::lerp`](lerp.md)
+- [`std::fma`](/reference/cmath/fma.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/fmax.md
+++ b/reference/simd/fmax.md
@@ -1,0 +1,87 @@
+# fmax
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fmax(const V& x, const V& y);                     // (1) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fmax(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fmax(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、大きいほうの値を求める。一方がNaNの場合はもう一方の値を返す。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+- (1) : 両引数が同じ型`V`の場合。
+- (2), (3) : 一方の引数を[`basic_vec`](basic_vec.md)、他方をスカラー値として、スカラー側を全要素に対して適用する場合。
+
+
+## 戻り値
+各要素`i`について、`x`・`y`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`fmax`](/reference/cmath/fmax.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x{[](int i) { constexpr float a[] = {1, 5, 3, 8}; return a[i]; }};
+  simd::vec<float, 4> y{[](int i) { constexpr float a[] = {4, 2, 6, 7}; return a[i]; }};
+
+  // 各要素の最大値
+  simd::vec<float, 4> r = simd::fmax(x, y);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::fmax[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+4 5 6 8 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::fmin`](fmin.md)
+- [`std::simd::fdim`](fdim.md)
+- [`std::simd::max`](max.md)
+- [`std::fmax`](/reference/cmath/fmax.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/fmin.md
+++ b/reference/simd/fmin.md
@@ -1,0 +1,87 @@
+# fmin
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fmin(const V& x, const V& y);                     // (1) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fmin(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fmin(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、小さいほうの値を求める。一方がNaNの場合はもう一方の値を返す。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+- (1) : 両引数が同じ型`V`の場合。
+- (2), (3) : 一方の引数を[`basic_vec`](basic_vec.md)、他方をスカラー値として、スカラー側を全要素に対して適用する場合。
+
+
+## 戻り値
+各要素`i`について、`x`・`y`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`fmin`](/reference/cmath/fmin.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x{[](int i) { constexpr float a[] = {1, 5, 3, 8}; return a[i]; }};
+  simd::vec<float, 4> y{[](int i) { constexpr float a[] = {4, 2, 6, 7}; return a[i]; }};
+
+  // 各要素の最小値
+  simd::vec<float, 4> r = simd::fmin(x, y);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::fmin[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+1 2 3 7 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::fmax`](fmax.md)
+- [`std::simd::fdim`](fdim.md)
+- [`std::simd::min`](min.md)
+- [`std::fmin`](/reference/cmath/fmin.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/fmod.md
+++ b/reference/simd/fmod.md
@@ -1,0 +1,85 @@
+# fmod
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fmod(const V& x, const V& y);                     // (1) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fmod(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> fmod(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、`x`を`y`で割った剰余（`x - n * y`、`n`は`x / y`を0方向へ丸めた整数）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+- (1) : 両引数が同じ型`V`の場合。
+- (2), (3) : 一方の引数を[`basic_vec`](basic_vec.md)、他方をスカラー値として、スカラー側を全要素に対して適用する場合。
+
+
+## 戻り値
+各要素`i`について、`x`・`y`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`fmod`](/reference/cmath/fmod.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x{[](int i) { return i + 5.0f; }}; // {5, 6, 7, 8}
+
+  // 各要素を3.0で割った剰余（スカラーとの演算）
+  simd::vec<float, 4> r = simd::fmod(x, 3.0f);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::fmod[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+2 0 1 2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::remainder`](remainder.md)
+- [`std::simd::remquo`](remquo.md)
+- [`std::fmod`](/reference/cmath/fmod.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/fpclassify.md
+++ b/reference/simd/fpclassify.md
@@ -1,0 +1,83 @@
+# fpclassify
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr rebind_t<int, deduced-vec-t<V>>
+    fpclassify(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素を浮動小数点数の種別に分類する。各要素に[`std::fpclassify`](/reference/cmath/fpclassify.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型は、要素型を`int`とした整数の[`basic_vec`](basic_vec.md)となる。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`に[`std::fpclassify`](/reference/cmath/fpclassify.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。各要素の値は、[`FP_INFINITE`](/reference/cmath/fp_infinite.md)・[`FP_NAN`](/reference/cmath/fp_nan.md)・[`FP_NORMAL`](/reference/cmath/fp_normal.md)・[`FP_SUBNORMAL`](/reference/cmath/fp_subnormal.md)・[`FP_ZERO`](/reference/cmath/fp_zero.md)、または処理系が定義する分類のいずれかである。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cmath>
+#include <limits>
+#include <array>
+
+namespace simd = std::simd;
+
+int main()
+{
+  constexpr float inf = std::numeric_limits<float>::infinity();
+  constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+  simd::vec<float, 4> v{
+    [&](int i) { return std::array{1.0f, 0.0f, inf, nan}[i]; }
+  }; // {1, 0, inf, nan}
+
+  simd::rebind_t<int, simd::vec<float, 4>> r = simd::fpclassify(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i] == FP_NORMAL);
+  std::println("");
+}
+```
+* simd::fpclassify[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+* FP_NORMAL[link /reference/cmath/fp_normal.md]
+
+### 出力
+```
+true false false false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isnan`](isnan.md)
+- [`std::simd::isinf`](isinf.md)
+- [`std::simd::isnormal`](isnormal.md)
+- [`std::fpclassify`](/reference/cmath/fpclassify.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/frexp.md
+++ b/reference/simd/frexp.md
@@ -1,0 +1,81 @@
+# frexp
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    frexp(const V& value,
+          rebind_t<int, deduced-vec-t<V>>* exp); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素を正規化された仮数部と2を底とする指数部に分解する。各要素に[`std::frexp`](/reference/cmath/frexp.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。
+
+
+## 効果
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`value[i]`の指数部を格納した整数要素の[`basic_vec`](basic_vec.md)を`*exp`に設定する。
+
+
+## 戻り値
+各要素`i`について、`value[i]`の仮数部（絶対値が`0.5`以上`1`未満、または`0`）で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+
+  simd::rebind_t<int, simd::vec<float, 4>> exp;
+  simd::vec<float, 4> m = simd::frexp(v, &exp);
+
+  for (std::size_t i = 0; i < v.size(); ++i)
+    std::print("{}*2^{} ", m[i], exp[i]);
+  std::println("");
+}
+```
+* simd::frexp[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力
+```
+0.5*2^1 0.5*2^2 0.75*2^2 0.5*2^3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::ldexp`](ldexp.md)
+- [`std::simd::modf`](modf.md)
+- [`std::simd::logb`](logb.md)
+- [`std::frexp`](/reference/cmath/frexp.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/has_single_bit.md
+++ b/reference/simd/has_single_bit.md
@@ -1,0 +1,81 @@
+# has_single_bit
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr typename V::mask_type has_single_bit(const V& v) noexcept; // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::has_single_bit`](/reference/bit/has_single_bit.md)を要素ごとに適用し、各要素がちょうど1つのビットだけを立てているか（2の累乗であるか）を判定する。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+`i`番目の要素が[`std::has_single_bit`](/reference/bit/has_single_bit.md)`(v[i])`で初期化された[`basic_mask`](basic_mask.md)オブジェクトを返す。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {1, 2, 3, 4}
+  simd::vec<std::uint32_t, 4> v {[](int i) { return i + 1; }};
+
+  auto m = simd::has_single_bit(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {}", v[i], m[i]);
+  }
+}
+```
+* simd::has_single_bit[color ff0000]
+
+### 出力
+```
+0000000000000001 -> true
+0000000000000010 -> true
+0000000000000011 -> false
+0000000000000100 -> true
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::has_single_bit`](/reference/bit/has_single_bit.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/hermite.md
+++ b/reference/simd/hermite.md
@@ -1,0 +1,83 @@
+# hermite
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> hermite(const rebind_t<unsigned, deduced-vec-t<V>>& n, const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`hermite`](/reference/cmath/hermite.md)を適用し、各要素について、次数`n`のエルミート多項式の`x`での値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+`rebind_t<unsigned, deduced-vec-t<V>>`は、[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)と同じ要素数をもつ`unsigned`要素型の[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`n[i]`と`x[i]`に[`<cmath>`](/reference/cmath.md)の[`hermite`](/reference/cmath/hermite.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<unsigned, 2> n = 2u;                          // 次数2
+  simd::vec<double, 2> x([](int i) { return i * 0.5 + 0.5; }); // {0.5, 1}
+
+  // 各要素について次数2のエルミート多項式の値を求める
+  simd::vec<double, 2> r = simd::hermite(n, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::hermite[color ff0000]
+
+### 出力例
+```
+-1 2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::laguerre`](laguerre.md)
+- [`std::simd::legendre`](legendre.md)
+- [`std::hermite`](/reference/cmath/hermite.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/hypot.md
+++ b/reference/simd/hypot.md
@@ -1,0 +1,111 @@
+# hypot
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const V& x, const V& y);                          // (1) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const deduced-vec-t<V>& x, const V& y);       // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const V& x, const deduced-vec-t<V>& y);       // (3) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const V& x, const V& y, const V& z);              // (4) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const deduced-vec-t<V>& x,
+                                       const V& y, const V& z);                          // (5) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const V& x,
+                                       const deduced-vec-t<V>& y, const V& z);       // (6) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const V& x, const V& y,
+                                       const deduced-vec-t<V>& z);                   // (7) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const deduced-vec-t<V>& x,
+                                       const deduced-vec-t<V>& y, const V& z);       // (8) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const deduced-vec-t<V>& x, const V& y,
+                                       const deduced-vec-t<V>& z);                   // (9) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> hypot(const V& x, const deduced-vec-t<V>& y,
+                                       const deduced-vec-t<V>& z);                   // (10) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素の直角三角形の斜辺の長さ（引数の平方和の平方根）を求める。各要素に[`<cmath>`](/reference/cmath.md)の[`hypot`](/reference/cmath/hypot.md)を要素ごとに適用したものである。
+
+- (1) : 2引数版。両引数を`V`として受け取り、各要素について<code>&#x221A;<span style="text-decoration:overline">&#xA0;x<sup>2</sup> + y<sup>2</sup>&#xA0;</span></code>を求める。
+- (2), (3) : 2引数版で、一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+- (4) : 3引数版。3引数を`V`として受け取り、各要素について<code>&#x221A;<span style="text-decoration:overline">&#xA0;x<sup>2</sup> + y<sup>2</sup> + z<sup>2</sup>&#xA0;</span></code>を求める。
+- (5)〜(10) : 3引数版で、一部の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。一部の引数を[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)とするオーバーロードにより、スカラー値を渡して全要素にブロードキャストできる。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、各引数の第`i`要素に[`<cmath>`](/reference/cmath.md)の[`hypot`](/reference/cmath/hypot.md)を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x([](int i) { return float(i + 1); }); // {1, 2, 3, 4}
+  simd::vec<float, 4> y{[](int i) {
+    float table[] = {0.0f, 0.0f, 4.0f, 3.0f};
+    return table[i];
+  }};
+
+  // 各要素について sqrt(x^2 + y^2) を求める
+  simd::vec<float, 4> r = simd::hypot(x, y);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::hypot[color ff0000]
+
+### 出力例
+```
+1 2 5 5 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sqrt`](sqrt.md)
+- [`std::simd::pow`](pow.md)
+- [`std::hypot`](/reference/cmath/hypot.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/ilogb.md
+++ b/reference/simd/ilogb.md
@@ -1,0 +1,82 @@
+# ilogb
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr rebind_t<int, deduced-vec-t<V>>
+    ilogb(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素の指数部を`int`型の整数として取り出す。各要素に[`std::ilogb`](/reference/cmath/ilogb.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型は、要素型を`int`とした整数の[`basic_vec`](basic_vec.md)となる。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`に[`std::ilogb`](/reference/cmath/ilogb.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{
+    [](int i) { return 1.0f * (1 << i); }
+  }; // {1, 2, 4, 8}
+
+  simd::rebind_t<int, simd::vec<float, 4>> r = simd::ilogb(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::ilogb[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力
+```
+0 1 2 3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::logb`](logb.md)
+- [`std::simd::frexp`](frexp.md)
+- [`std::ilogb`](/reference/cmath/ilogb.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/imag.md
+++ b/reference/simd/imag.md
@@ -1,0 +1,81 @@
+# imag
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-complex V>
+  constexpr rebind_t<simd-complex-value-type<V>, V> imag(const V& v) noexcept; // C++26
+}
+```
+* simd-complex-value-type[link /reference/simd/simd-complex-value-type.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+* complex[link /reference/complex/complex.md]
+
+## 概要
+要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素の虚部を取り出し、実数型`T`を要素とする[`basic_vec`](basic_vec.md)として返す。
+
+制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`simd-complex-value-type<V>`](/reference/simd/simd-complex-value-type.md)は`V`の要素型`std::complex<T>`における`T`（実数型）を表す。戻り値の型は`V`の要素数はそのままに要素型を`T`とした[`basic_vec`](basic_vec.md)となる。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`v[i]`に[`<complex>`](/reference/complex/complex.md)の[`imag`](/reference/complex/complex/imag_free.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // 各要素が複素数のデータ並列型
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i + 1.0f, i + 0.5f); }
+  };  // {(1, 0.5), (2, 1.5)}
+
+  // 各要素の虚部を取り出す
+  simd::vec<float, 2> im = simd::imag(v);
+
+  for (std::size_t i = 0; i < im.size(); ++i)
+    std::print("{} ", im[i]);
+  std::println("");
+}
+```
+* simd::imag[color ff0000]
+
+### 出力例
+```
+0.5 1.5 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::real`](real.md)
+- [`std::simd::abs`](abs.md)
+- [`std::simd::arg`](arg.md)
+- [`std::simd::norm`](norm.md)
+- [`std::simd::conj`](conj.md)
+- [`std::complex::imag`](/reference/complex/complex/imag_free.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/iota.md
+++ b/reference/simd/iota.md
@@ -1,0 +1,80 @@
+# iota
+* simd[meta header]
+* std::simd[meta namespace]
+* variable[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T>
+  constexpr T iota = /*see below*/;
+}
+```
+
+## 概要
+`iota`は、`0, 1, 2, …`という連番を要素とするデータ並列オブジェクトを表す変数テンプレートである。
+
+SIMDプログラミングでは、各レーンのインデックスに相当する連番`0, 1, 2, …`が頻出する。`iota`を使うと、ジェネレータコンストラクタ（`vec<int>([](int i) { return i; })`）よりも簡潔に、かつSIMD幅に応じてスケールする形でこの定数を記述できる。スケールやオフセットを組み合わせて任意の等差数列を作れる。
+
+- `T`が[`basic_vec`](basic_vec.md)の場合: 各要素がそのインデックスに等しいデータ並列オブジェクト（`{0, 1, …, T::size() - 1}`）となる。
+- `T`がスカラーの算術型の場合: 値`0`（`T()`）となる。SIMD-genericなコードで、データ並列型とスカラーを統一的に扱うための縮退ケースである。
+
+
+## 適格要件
+次のいずれかを満たすこと。
+
+- `T`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であり、[`std::is_arithmetic_v`](/reference/type_traits/is_arithmetic.md)`<T>`が`true`であること
+- `T`が[`basic_vec`](basic_vec.md)の有効な特殊化であり、[`std::is_arithmetic_v`](/reference/type_traits/is_arithmetic.md)`<typename T::value_type>`が`true`であり、かつ`T::size() - 1`が[`std::numeric_limits`](/reference/limits/numeric_limits.md)`<typename T::value_type>::max()`以下であること（連番が要素型で表現でき、オーバーフローしないこと）
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // 各要素がインデックスに等しい連番
+  simd::vec<int, 4> a = simd::iota<simd::vec<int, 4>>;         // {0, 1, 2, 3}
+
+  // スケールとオフセットを適用した等差数列
+  simd::vec<int, 4> b = 2 + 3 * simd::iota<simd::vec<int, 4>>; // {2, 5, 8, 11}
+
+  for (int i = 0; i < a.size(); ++i)
+    std::print("{} ", a[i]);
+  std::println("");
+  for (int i = 0; i < b.size(); ++i)
+    std::print("{} ", b[i]);
+  std::println("");
+}
+```
+* simd::iota[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0 1 2 3 
+2 5 8 11 
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::iota`](/reference/numeric/iota.md)
+
+
+## 参照
+- [P3319R6 Add an iota object for simd (and more)](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3319r6.pdf)
+    - C++29で追加された

--- a/reference/simd/isfinite.md
+++ b/reference/simd/isfinite.md
@@ -1,0 +1,80 @@
+# isfinite
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isfinite(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素が有限値（無限大でもNaNでもない）であるかを判定する。各要素に[`std::isfinite`](/reference/cmath/isfinite.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`が有限値であれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <limits>
+#include <array>
+
+namespace simd = std::simd;
+
+int main()
+{
+  constexpr float inf = std::numeric_limits<float>::infinity();
+  constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+  simd::vec<float, 4> v{
+    [&](int i) { return std::array{1.0f, inf, nan, 2.0f}[i]; }
+  }; // {1, inf, nan, 2}
+
+  simd::vec<float, 4>::mask_type m = simd::isfinite(v);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::isfinite[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+true false false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isinf`](isinf.md)
+- [`std::simd::isnan`](isnan.md)
+- [`std::simd::isnormal`](isnormal.md)
+- [`std::isfinite`](/reference/cmath/isfinite.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/isgreater.md
+++ b/reference/simd/isgreater.md
@@ -1,0 +1,85 @@
+# isgreater
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isgreater(const V& x, const V& y);                            // (1) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isgreater(const deduced-vec-t<V>& x, const V& y);         // (2) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isgreater(const V& x, const deduced-vec-t<V>& y);         // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`が`y[i]`より大きいかを判定する。各要素に[`std::isgreater`](/reference/cmath/isgreater.md)を適用する。浮動小数点例外を発生させずに比較を行う。
+
+- (1) : 両オペランドが同じ型の場合のオーバーロード。
+- (2), (3) : 一方のオペランドがスカラー値であり、[`basic_vec`](basic_vec.md)へと変換される場合のオーバーロード。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i] > y[i]`であれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。いずれかがNaNである要素は`false`となる。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+  simd::vec<float, 4> y = 2.5f;                          // 全要素が 2.5
+
+  simd::vec<float, 4>::mask_type m = simd::isgreater(x, y);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::isgreater[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+false false true true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isgreaterequal`](isgreaterequal.md)
+- [`std::simd::isless`](isless.md)
+- [`std::isgreater`](/reference/cmath/isgreater.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/isgreaterequal.md
+++ b/reference/simd/isgreaterequal.md
@@ -1,0 +1,85 @@
+# isgreaterequal
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isgreaterequal(const V& x, const V& y);                            // (1) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isgreaterequal(const deduced-vec-t<V>& x, const V& y);         // (2) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isgreaterequal(const V& x, const deduced-vec-t<V>& y);         // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`が`y[i]`以上であるかを判定する。各要素に[`std::isgreaterequal`](/reference/cmath/isgreaterequal.md)を適用する。浮動小数点例外を発生させずに比較を行う。
+
+- (1) : 両オペランドが同じ型の場合のオーバーロード。
+- (2), (3) : 一方のオペランドがスカラー値であり、[`basic_vec`](basic_vec.md)へと変換される場合のオーバーロード。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i] >= y[i]`であれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。いずれかがNaNである要素は`false`となる。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+  simd::vec<float, 4> y = 3.0f;                          // 全要素が 3
+
+  simd::vec<float, 4>::mask_type m = simd::isgreaterequal(x, y);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::isgreaterequal[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+false false true true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isgreater`](isgreater.md)
+- [`std::simd::islessequal`](islessequal.md)
+- [`std::isgreaterequal`](/reference/cmath/isgreaterequal.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/isinf.md
+++ b/reference/simd/isinf.md
@@ -1,0 +1,79 @@
+# isinf
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isinf(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素が無限大（正または負）であるかを判定する。各要素に[`std::isinf`](/reference/cmath/isinf.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`が無限大であれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <limits>
+#include <array>
+
+namespace simd = std::simd;
+
+int main()
+{
+  constexpr float inf = std::numeric_limits<float>::infinity();
+  constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+  simd::vec<float, 4> v{
+    [&](int i) { return std::array{1.0f, inf, nan, -inf}[i]; }
+  }; // {1, inf, nan, -inf}
+
+  simd::vec<float, 4>::mask_type m = simd::isinf(v);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::isinf[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+false true false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isfinite`](isfinite.md)
+- [`std::simd::isnan`](isnan.md)
+- [`std::isinf`](/reference/cmath/isinf.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/isless.md
+++ b/reference/simd/isless.md
@@ -1,0 +1,85 @@
+# isless
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isless(const V& x, const V& y);                 // (1) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isless(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isless(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`が`y[i]`より小さいかを判定する。各要素に[`std::isless`](/reference/cmath/isless.md)を適用する。浮動小数点例外を発生させずに比較を行う。
+
+- (1) : 両オペランドが同じ型の場合のオーバーロード。
+- (2), (3) : 一方のオペランドがスカラー値であり、[`basic_vec`](basic_vec.md)へと変換される場合のオーバーロード。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i] < y[i]`であれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。いずれかがNaNである要素は`false`となる。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+  simd::vec<float, 4> y = 2.5f;                          // 全要素が 2.5
+
+  simd::vec<float, 4>::mask_type m = simd::isless(x, y);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::isless[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+true true false false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::islessequal`](islessequal.md)
+- [`std::simd::isgreater`](isgreater.md)
+- [`std::isless`](/reference/cmath/isless.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/islessequal.md
+++ b/reference/simd/islessequal.md
@@ -1,0 +1,85 @@
+# islessequal
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    islessequal(const V& x, const V& y);                 // (1) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    islessequal(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    islessequal(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`が`y[i]`以下であるかを判定する。各要素に[`std::islessequal`](/reference/cmath/islessequal.md)を適用する。浮動小数点例外を発生させずに比較を行う。
+
+- (1) : 両オペランドが同じ型の場合のオーバーロード。
+- (2), (3) : 一方のオペランドがスカラー値であり、[`basic_vec`](basic_vec.md)へと変換される場合のオーバーロード。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i] <= y[i]`であれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。いずれかがNaNである要素は`false`となる。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+  simd::vec<float, 4> y = 3.0f;                          // 全要素が 3
+
+  simd::vec<float, 4>::mask_type m = simd::islessequal(x, y);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::islessequal[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+true true true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isless`](isless.md)
+- [`std::simd::isgreaterequal`](isgreaterequal.md)
+- [`std::islessequal`](/reference/cmath/islessequal.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/islessgreater.md
+++ b/reference/simd/islessgreater.md
@@ -1,0 +1,86 @@
+# islessgreater
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    islessgreater(const V& x, const V& y);                 // (1) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    islessgreater(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    islessgreater(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`が`y[i]`より小さいか大きいか（等しくなく、かつ順序付け可能）を判定する。各要素に[`std::islessgreater`](/reference/cmath/islessgreater.md)を適用する。浮動小数点例外を発生させずに比較を行う。
+
+- (1) : 両オペランドが同じ型の場合のオーバーロード。
+- (2), (3) : 一方のオペランドがスカラー値であり、[`basic_vec`](basic_vec.md)へと変換される場合のオーバーロード。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i] < y[i] || x[i] > y[i]`であれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。いずれかがNaNである要素、または両者が等しい要素は`false`となる。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+  simd::vec<float, 4> y = 3.0f;                          // 全要素が 3
+
+  simd::vec<float, 4>::mask_type m = simd::islessgreater(x, y);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::islessgreater[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+true true false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isless`](isless.md)
+- [`std::simd::isgreater`](isgreater.md)
+- [`std::simd::isunordered`](isunordered.md)
+- [`std::islessgreater`](/reference/cmath/islessgreater.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/isnan.md
+++ b/reference/simd/isnan.md
@@ -1,0 +1,80 @@
+# isnan
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isnan(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素がNaN（非数）であるかを判定する。各要素に[`std::isnan`](/reference/cmath/isnan.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`がNaNであれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <limits>
+#include <array>
+
+namespace simd = std::simd;
+
+int main()
+{
+  constexpr float inf = std::numeric_limits<float>::infinity();
+  constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+  simd::vec<float, 4> v{
+    [&](int i) { return std::array{1.0f, inf, nan, 2.0f}[i]; }
+  }; // {1, inf, nan, 2}
+
+  simd::vec<float, 4>::mask_type m = simd::isnan(v);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::isnan[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+false false true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isfinite`](isfinite.md)
+- [`std::simd::isinf`](isinf.md)
+- [`std::simd::isunordered`](isunordered.md)
+- [`std::isnan`](/reference/cmath/isnan.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/isnormal.md
+++ b/reference/simd/isnormal.md
@@ -1,0 +1,80 @@
+# isnormal
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isnormal(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素が正規化数（ゼロ・非正規化数・無限大・NaNのいずれでもない）であるかを判定する。各要素に[`std::isnormal`](/reference/cmath/isnormal.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`が正規化数であれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <limits>
+#include <array>
+
+namespace simd = std::simd;
+
+int main()
+{
+  constexpr float inf = std::numeric_limits<float>::infinity();
+  constexpr float denorm = std::numeric_limits<float>::denorm_min();
+  simd::vec<float, 4> v{
+    [&](int i) { return std::array{1.0f, 0.0f, inf, denorm}[i]; }
+  }; // {1, 0, inf, 非正規化数}
+
+  simd::vec<float, 4>::mask_type m = simd::isnormal(v);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::isnormal[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+* denorm_min[link /reference/limits/numeric_limits/denorm_min.md]
+
+### 出力
+```
+true false false false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isfinite`](isfinite.md)
+- [`std::simd::fpclassify`](fpclassify.md)
+- [`std::isnormal`](/reference/cmath/isnormal.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/isunordered.md
+++ b/reference/simd/isunordered.md
@@ -1,0 +1,90 @@
+# isunordered
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isunordered(const V& x, const V& y);                 // (1) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isunordered(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    isunordered(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`と`y[i]`が順序付け不可能（少なくとも一方がNaN）であるかを判定する。各要素に[`std::isunordered`](/reference/cmath/isunordered.md)を適用する。浮動小数点例外を発生させずに比較を行う。
+
+- (1) : 両オペランドが同じ型の場合のオーバーロード。
+- (2), (3) : 一方のオペランドがスカラー値であり、[`basic_vec`](basic_vec.md)へと変換される場合のオーバーロード。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`と`y[i]`の少なくとも一方がNaNであれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <limits>
+#include <array>
+
+namespace simd = std::simd;
+
+int main()
+{
+  constexpr float nan = std::numeric_limits<float>::quiet_NaN();
+  simd::vec<float, 4> x{
+    [&](int i) { return std::array{1.0f, nan, 3.0f, nan}[i]; }
+  }; // {1, nan, 3, nan}
+  simd::vec<float, 4> y = 2.0f; // 全要素が 2
+
+  simd::vec<float, 4>::mask_type m = simd::isunordered(x, y);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::isunordered[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+false true false true 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::isnan`](isnan.md)
+- [`std::simd::islessgreater`](islessgreater.md)
+- [`std::isunordered`](/reference/cmath/isunordered.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/laguerre.md
+++ b/reference/simd/laguerre.md
@@ -1,0 +1,86 @@
+# laguerre
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    laguerre(const rebind_t<unsigned, deduced-vec-t<V>>& n,
+             const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`laguerre`](/reference/cmath/laguerre.md)を適用し、各要素について、次数`n`のラゲール多項式の`x`での値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+`rebind_t<unsigned, deduced-vec-t<V>>`は、[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)と同じ要素数をもつ`unsigned`要素型の[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`n[i]`と`x[i]`に[`<cmath>`](/reference/cmath.md)の[`laguerre`](/reference/cmath/laguerre.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<unsigned, 2> n = 2u; // 次数2
+  simd::vec<double, 2> x([](int i) { return i * 0.5 + 0.5; }); // {0.5, 1}
+
+  // 各要素について次数2のラゲール多項式の値を求める
+  simd::vec<double, 2> r = simd::laguerre(n, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::laguerre[color ff0000]
+
+### 出力例
+```
+0.125 -0.5 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::assoc_laguerre`](assoc_laguerre.md)
+- [`std::simd::hermite`](hermite.md)
+- [`std::simd::legendre`](legendre.md)
+- [`std::laguerre`](/reference/cmath/laguerre.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/ldexp.md
+++ b/reference/simd/ldexp.md
@@ -1,0 +1,83 @@
+# ldexp
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    ldexp(const V& x,
+          const rebind_t<int, deduced-vec-t<V>>& exp); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`を`2`の`exp[i]`乗倍する。各要素に[`std::ldexp`](/reference/cmath/ldexp.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`と`exp[i]`に[`std::ldexp`](/reference/cmath/ldexp.md)を適用した結果（`x[i] × 2`<sup>`exp[i]`</sup>）で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+  simd::rebind_t<int, simd::vec<float, 4>> exp(
+    [](int i) { return i + 1; }); // {1, 2, 3, 4}
+
+  simd::vec<float, 4> r = simd::ldexp(v, exp);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::ldexp[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力
+```
+2 8 24 64 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::frexp`](frexp.md)
+- [`std::simd::scalbn`](scalbn.md)
+- [`std::ldexp`](/reference/cmath/ldexp.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/legendre.md
+++ b/reference/simd/legendre.md
@@ -1,0 +1,86 @@
+# legendre
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    legendre(const rebind_t<unsigned, deduced-vec-t<V>>& l,
+             const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`legendre`](/reference/cmath/legendre.md)を適用し、各要素について、次数`l`のルジャンドル多項式の`x`での値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+`rebind_t<unsigned, deduced-vec-t<V>>`は、[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)と同じ要素数をもつ`unsigned`要素型の[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`l[i]`と`x[i]`に[`<cmath>`](/reference/cmath.md)の[`legendre`](/reference/cmath/legendre.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<unsigned, 2> l = 2u; // 次数2
+  simd::vec<double, 2> x([](int i) { return i * 0.5 + 0.5; }); // {0.5, 1}
+
+  // 各要素について次数2のルジャンドル多項式の値を求める
+  simd::vec<double, 2> r = simd::legendre(l, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::legendre[color ff0000]
+
+### 出力例
+```
+-0.125 1 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::assoc_legendre`](assoc_legendre.md)
+- [`std::simd::sph_legendre`](sph_legendre.md)
+- [`std::simd::laguerre`](laguerre.md)
+- [`std::legendre`](/reference/cmath/legendre.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/lerp.md
+++ b/reference/simd/lerp.md
@@ -1,0 +1,116 @@
+# lerp
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    lerp(const V& a,
+         const V& b,
+         const V& t) noexcept;       // (1) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    lerp(const deduced-vec-t<V>& x,
+         const V& y,
+         const V& z);                // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    lerp(const V& x,
+         const deduced-vec-t<V>& y,
+         const V& z);                // (3) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    lerp(const V& x,
+         const V& y,
+         const deduced-vec-t<V>& z); // (4) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    lerp(const deduced-vec-t<V>& x,
+         const deduced-vec-t<V>& y,
+         const V& z);                // (5) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    lerp(const deduced-vec-t<V>& x,
+         const V& y,
+         const deduced-vec-t<V>& z); // (6) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    lerp(const V& x,
+         const deduced-vec-t<V>& y,
+         const deduced-vec-t<V>& z); // (7) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、`a`と`b`のあいだを媒介変数`t`で線形補間した値（`a + t * (b - a)`）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+- (1) : 3引数が同じ型`V`の場合。
+- (2)-(7) : 一部の引数を[`basic_vec`](basic_vec.md)、残りをスカラー値として、スカラー側を全要素に対して適用する場合。
+
+
+## 戻り値
+各要素`i`について、対応する要素に[`<cmath>`](/reference/cmath.md)の[`lerp`](/reference/cmath/lerp.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> a{[](int i) { return i + 0.0f; }};  // {0, 1, 2, 3}
+  simd::vec<float, 4> b{[](int i) { return i + 10.0f; }}; // {10, 11, 12, 13}
+
+  // 各要素をt=0.5で線形補間する
+  simd::vec<float, 4> r = simd::lerp(a, b, 0.5f);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::lerp[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+5 6 7 8 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::fma`](fma.md)
+- [`std::lerp`](/reference/cmath/lerp.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/lgamma.md
+++ b/reference/simd/lgamma.md
@@ -1,0 +1,78 @@
+# lgamma
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> lgamma(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`lgamma`](/reference/cmath/lgamma.md)を適用し、各要素のガンマ関数の絶対値の自然対数を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`lgamma`](/reference/cmath/lgamma.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 4> v([](int i) { return i + 1.0; }); // {1, 2, 3, 4}
+
+  // 各要素のガンマ関数の絶対値の自然対数を求める
+  simd::vec<double, 4> r = simd::lgamma(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::lgamma[color ff0000]
+
+### 出力例
+```
+0 0 0.6931471805599453 1.791759469228055 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::tgamma`](tgamma.md)
+- [`std::lgamma`](/reference/cmath/lgamma.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/llrint.md
+++ b/reference/simd/llrint.md
@@ -1,0 +1,84 @@
+# llrint
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  rebind_t<long long, deduced-vec-t<V>> llrint(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、現在の丸めモードに従って最も近い整数値に丸め、`long long`を要素型とする[`basic_vec`](basic_vec.md)として返す。[`llround`](llround.md)とは異なり丸めモードに従い、結果が元の値と異なる場合に`FE_INEXACT`浮動小数点例外を送出しうる。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型を表す。戻り値の型は、要素数はそのままに要素型を`long long`とした[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`llrint`](/reference/cmath/llrint.md)を適用した結果で初期化された`rebind_t<long long, deduced-vec-t<V>>`型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {0.5f, 1.5f, 2.5f, 3.5f};
+    return a[i];
+  }};
+
+  // 既定の丸めモード（最近接偶数への丸め）で最も近い整数（long long）に丸める
+  simd::rebind_t<long long, simd::vec<float, 4>> r = simd::llrint(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::llrint[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力
+```
+0 2 2 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::lrint`](lrint.md)
+- [`std::simd::rint`](rint.md)
+- [`std::simd::llround`](llround.md)
+- [`std::llrint`](/reference/cmath/llrint.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/llround.md
+++ b/reference/simd/llround.md
@@ -1,0 +1,83 @@
+# llround
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr rebind_t<long long, deduced-vec-t<V>> llround(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、最も近い整数値に丸め（中間は0から遠いほうへ）、`long long`を要素型とする[`basic_vec`](basic_vec.md)として返す。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型を表す。戻り値の型は、要素数はそのままに要素型を`long long`とした[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`llround`](/reference/cmath/llround.md)を適用した結果で初期化された`rebind_t<long long, deduced-vec-t<V>>`型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {1.4f, 1.6f, -1.6f, 2.5f};
+    return a[i];
+  }};
+
+  // 各要素を最も近い整数（long long）に丸める
+  simd::rebind_t<long long, simd::vec<float, 4>> r = simd::llround(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::llround[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力
+```
+1 2 -2 3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::lround`](lround.md)
+- [`std::simd::round`](round.md)
+- [`std::llround`](/reference/cmath/llround.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/log.md
+++ b/reference/simd/log.md
@@ -1,0 +1,126 @@
+# log
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> log(const V& x); // (1) C++26
+
+  template<simd-complex V>
+  constexpr V log(const V& v);                // (2) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、自然対数（底が`e`の対数）を求める。
+
+- (1) : 浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素に[`<cmath>`](/reference/cmath.md)の[`log`](/reference/cmath/log.md)を要素ごとに適用する。
+- (2) : 要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素に[`<complex>`](/reference/complex/complex.md)の[`log`](/reference/complex/complex/log.md)を要素ごとに適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`v[i]`（`x[i]`）に対応する`log`を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+- (1) : [`<cmath>`](/reference/cmath.md)の[`log`](/reference/cmath/log.md)を適用する。
+- (2) : [`<complex>`](/reference/complex/complex.md)の[`log`](/reference/complex/complex/log.md)を適用する。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+### 基本的な使い方
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return float(i + 1); }); // {1, 2, 3, 4}
+
+  // 各要素の自然対数を求める
+  simd::vec<float, 4> r = simd::log(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::log[color ff0000]
+
+#### 出力例
+```
+0 0.693147 1.09861 1.38629 
+```
+
+### 複素数版 (2)
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i + 1.0f, 0.0f); }
+  };  // {(1, 0), (2, 0)}
+
+  // 各要素の自然対数を求める
+  simd::vec<std::complex<float>, 2> r = simd::log(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::complex<float> c = r[i];
+    std::print("({}, {}) ", c.real(), c.imag());
+  }
+  std::println("");
+}
+```
+* simd::log[color ff0000]
+
+#### 出力例
+```
+(0, 0) (0.693147, 0) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::log10`](log10.md)
+- [`std::simd::log2`](log2.md)
+- [`std::simd::log1p`](log1p.md)
+- [`std::simd::exp`](exp.md)
+- [`std::simd::pow`](pow.md)
+- [`std::simd::sqrt`](sqrt.md)
+- [`std::log`](/reference/cmath/log.md)
+- [`std::complex::log`](/reference/complex/complex/log.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加され、実数版の`log` (1) が追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数版の`log` (2) が追加された

--- a/reference/simd/log10.md
+++ b/reference/simd/log10.md
@@ -1,0 +1,80 @@
+# log10
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> log10(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素の`10`を底とする常用対数を求める。各要素に[`<cmath>`](/reference/cmath.md)の[`log10`](/reference/cmath/log10.md)を要素ごとに適用したものである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`log10`](/reference/cmath/log10.md)を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    float table[] = {1.0f, 10.0f, 100.0f, 1000.0f};
+    return table[i];
+  }};
+
+  // 各要素の常用対数を求める
+  simd::vec<float, 4> r = simd::log10(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::log10[color ff0000]
+
+### 出力例
+```
+0 1 2 3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::log`](log.md)
+- [`std::simd::log2`](log2.md)
+- [`std::log10`](/reference/cmath/log10.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/log1p.md
+++ b/reference/simd/log1p.md
@@ -1,0 +1,77 @@
+# log1p
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> log1p(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素に`1`を足した値の自然対数（<code>log<sub>e</sub>(1 + x)</code>）を求める。各要素に[`<cmath>`](/reference/cmath.md)の[`log1p`](/reference/cmath/log1p.md)を要素ごとに適用したものである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`log1p`](/reference/cmath/log1p.md)を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return float(i); }); // {0, 1, 2, 3}
+
+  // 各要素の log(1 + x) を求める
+  simd::vec<float, 4> r = simd::log1p(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::log1p[color ff0000]
+
+### 出力例
+```
+0 0.693147 1.09861 1.38629 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::log`](log.md)
+- [`std::simd::expm1`](expm1.md)
+- [`std::log1p`](/reference/cmath/log1p.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/log2.md
+++ b/reference/simd/log2.md
@@ -1,0 +1,81 @@
+# log2
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> log2(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素の`2`を底とする対数を求める。各要素に[`<cmath>`](/reference/cmath.md)の[`log2`](/reference/cmath/log2.md)を要素ごとに適用したものである。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`log2`](/reference/cmath/log2.md)を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    float table[] = {1.0f, 2.0f, 4.0f, 8.0f};
+    return table[i];
+  }};
+
+  // 各要素の2を底とする対数を求める
+  simd::vec<float, 4> r = simd::log2(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::log2[color ff0000]
+
+### 出力例
+```
+0 1 2 3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::log`](log.md)
+- [`std::simd::log10`](log10.md)
+- [`std::simd::exp2`](exp2.md)
+- [`std::log2`](/reference/cmath/log2.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/logb.md
+++ b/reference/simd/logb.md
@@ -1,0 +1,80 @@
+# logb
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    logb(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素の指数部を浮動小数点数として取り出す。各要素に[`std::logb`](/reference/cmath/logb.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`に[`std::logb`](/reference/cmath/logb.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{
+    [](int i) { return 1.0f * (1 << i); }
+  }; // {1, 2, 4, 8}
+
+  simd::vec<float, 4> r = simd::logb(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::logb[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0 1 2 3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::ilogb`](ilogb.md)
+- [`std::simd::frexp`](frexp.md)
+- [`std::logb`](/reference/cmath/logb.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/lrint.md
+++ b/reference/simd/lrint.md
@@ -1,0 +1,84 @@
+# lrint
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  rebind_t<long, deduced-vec-t<V>> lrint(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、現在の丸めモードに従って最も近い整数値に丸め、`long`を要素型とする[`basic_vec`](basic_vec.md)として返す。[`lround`](lround.md)とは異なり丸めモードに従い、結果が元の値と異なる場合に`FE_INEXACT`浮動小数点例外を送出しうる。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型を表す。戻り値の型は、要素数はそのままに要素型を`long`とした[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`lrint`](/reference/cmath/lrint.md)を適用した結果で初期化された`rebind_t<long, deduced-vec-t<V>>`型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {0.5f, 1.5f, 2.5f, 3.5f};
+    return a[i];
+  }};
+
+  // 既定の丸めモード（最近接偶数への丸め）で最も近い整数（long）に丸める
+  simd::rebind_t<long, simd::vec<float, 4>> r = simd::lrint(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::lrint[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力
+```
+0 2 2 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::llrint`](llrint.md)
+- [`std::simd::rint`](rint.md)
+- [`std::simd::lround`](lround.md)
+- [`std::lrint`](/reference/cmath/lrint.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/lround.md
+++ b/reference/simd/lround.md
@@ -1,0 +1,83 @@
+# lround
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr rebind_t<long, deduced-vec-t<V>> lround(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、最も近い整数値に丸め（中間は0から遠いほうへ）、`long`を要素型とする[`basic_vec`](basic_vec.md)として返す。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型を表す。戻り値の型は、要素数はそのままに要素型を`long`とした[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`lround`](/reference/cmath/lround.md)を適用した結果で初期化された`rebind_t<long, deduced-vec-t<V>>`型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {1.4f, 1.6f, -1.6f, 2.5f};
+    return a[i];
+  }};
+
+  // 各要素を最も近い整数（long）に丸める
+  simd::rebind_t<long, simd::vec<float, 4>> r = simd::lround(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::lround[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力
+```
+1 2 -2 3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::llround`](llround.md)
+- [`std::simd::round`](round.md)
+- [`std::lround`](/reference/cmath/lround.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/mask-element-size.md
+++ b/reference/simd/mask-element-size.md
@@ -1,0 +1,30 @@
+# mask-element-size
+* [meta exposition-only]
+* simd[meta header]
+* variable[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T>
+  constexpr std::size_t mask-element-size = /*see below*/;
+}
+```
+
+## 概要
+`mask-element-size`は、[`basic_mask`](basic_mask.md)の要素1つが対応するバイトサイズを表す説明専用の変数テンプレートである。
+
+`mask-element-size<basic_mask<Bytes, Abi>>`の値は`Bytes`となる。説明専用コンセプト[`simd-mask-type`](simd-mask-type.md)の定義に使用される。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_mask`](basic_mask.md)
+- [`std::simd::simd-mask-type`](simd-mask-type.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/mask-size-v.md
+++ b/reference/simd/mask-size-v.md
@@ -1,0 +1,32 @@
+# mask-size-v
+* [meta exposition-only]
+* simd[meta header]
+* variable[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<std::size_t Bytes, class Abi>
+  constexpr simd-size-type mask-size-v = /*see below*/;
+}
+```
+* simd-size-type[link simd-size-type.md]
+
+## 概要
+`mask-size-v`は、[`basic_mask`](basic_mask.md)`<Bytes, Abi>`の幅（要素数）を表す説明専用の変数テンプレートである。
+
+`basic_mask<Bytes, Abi>`が有効な特殊化であればその要素数を、そうでなければ`0`を表す。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_mask`](basic_mask.md)
+- [`std::simd::simd-size-v`](simd-size-v.md)
+- [`std::simd::mask-element-size`](mask-element-size.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/math-floating-point.md
+++ b/reference/simd/math-floating-point.md
@@ -1,0 +1,33 @@
+# math-floating-point
+* [meta exposition-only]
+* simd[meta header]
+* concept[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T>
+  concept math-floating-point =
+    simd-floating-point<deduced-vec-t<T>>;
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* simd-floating-point[link simd-floating-point.md]
+
+## 概要
+`math-floating-point`は、型`T`から導出されるデータ並列型（説明専用の`deduced-vec-t<T>`）が、浮動小数点数を要素とする[`basic_vec`](basic_vec.md)（[`simd-floating-point`](simd-floating-point.md)）であることを表す説明専用のコンセプトである。
+
+`deduced-vec-t<T>`は、`T`が[`basic_vec`](basic_vec.md)であればそのまま`T`を、`T`が浮動小数点数のスカラー型であれば対応する要素数1の`basic_vec`を表す。これにより、[`exp`](exp.md)・[`sin`](sin.md)・[`sqrt`](sqrt.md)などの数学関数を、データ並列型とスカラーの両方で共通のインタフェースとして呼び出せる。`std::simd`の数学関数のほとんどは、このコンセプトをテンプレートパラメータ制約として使用する。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::simd-floating-point`](simd-floating-point.md)
+- [`std::simd::simd-vec-type`](simd-vec-type.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/max.md
+++ b/reference/simd/max.md
@@ -1,0 +1,76 @@
+# max
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi>
+  constexpr basic_vec<T, Abi>
+    max(const basic_vec<T, Abi>& a,
+        const basic_vec<T, Abi>& b) noexcept;  // C++26
+}
+```
+
+## 概要
+`max`は、2つの[`basic_vec`](basic_vec.md)を要素ごとに比較し、それぞれ大きいほうの値を持つ`basic_vec`を返す関数である。
+
+## テンプレートパラメータ制約
+- `T`が[`std::totally_ordered`](/reference/concepts/totally_ordered.md)のモデルであること
+
+## 戻り値
+`i`番目の要素が`max(a[i], b[i])`となる`basic_vec`。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a([](int i) { return i; });     // {0, 1, 2, 3}
+  simd::vec<int, 4> b([](int i) { return 3 - i; }); // {3, 2, 1, 0}
+
+  // 要素ごとの最大値
+  auto r = simd::max(a, b);  // {3, 2, 2, 3}
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::max[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+3 2 2 3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::min`](min.md)
+- [`std::simd::minmax`](minmax.md)
+- [`std::simd::clamp`](clamp.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/min.md
+++ b/reference/simd/min.md
@@ -1,0 +1,76 @@
+# min
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi>
+  constexpr basic_vec<T, Abi>
+    min(const basic_vec<T, Abi>& a,
+        const basic_vec<T, Abi>& b) noexcept;  // C++26
+}
+```
+
+## 概要
+`min`は、2つの[`basic_vec`](basic_vec.md)を要素ごとに比較し、それぞれ小さいほうの値を持つ`basic_vec`を返す関数である。
+
+## テンプレートパラメータ制約
+- `T`が[`std::totally_ordered`](/reference/concepts/totally_ordered.md)のモデルであること
+
+## 戻り値
+`i`番目の要素が`min(a[i], b[i])`となる`basic_vec`。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a([](int i) { return i; });     // {0, 1, 2, 3}
+  simd::vec<int, 4> b([](int i) { return 3 - i; }); // {3, 2, 1, 0}
+
+  // 要素ごとの最小値
+  auto r = simd::min(a, b);  // {0, 1, 1, 0}
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::min[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0 1 1 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::max`](max.md)
+- [`std::simd::minmax`](minmax.md)
+- [`std::simd::clamp`](clamp.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/minmax.md
+++ b/reference/simd/minmax.md
@@ -1,0 +1,87 @@
+# minmax
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi>
+  constexpr std::pair<basic_vec<T, Abi>, basic_vec<T, Abi>>
+    minmax(const basic_vec<T, Abi>& a,
+           const basic_vec<T, Abi>& b) noexcept;  // C++26
+}
+```
+
+## 概要
+`minmax`は、2つの[`basic_vec`](basic_vec.md)から、要素ごとの最小値と最大値をまとめて取得する関数である。結果は[`std::pair`](/reference/utility/pair.md)の`first`に最小値、`second`に最大値が格納される。
+
+## 効果
+以下と等価である：
+
+```cpp
+return std::pair{min(a, b), max(a, b)};
+```
+* min[link min.md]
+* max[link max.md]
+
+## 戻り値
+`first`が[`min`](min.md)`(a, b)`、`second`が[`max`](max.md)`(a, b)`である[`std::pair`](/reference/utility/pair.md)。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a([](int i) { return i; });     // {0, 1, 2, 3}
+  simd::vec<int, 4> b([](int i) { return 3 - i; }); // {3, 2, 1, 0}
+
+  // 要素ごとの最小値・最大値をまとめて取得
+  auto [lo, hi] = simd::minmax(a, b);
+
+  for (int i = 0; i < lo.size(); ++i)
+    std::print("{} ", lo[i]);
+  std::println("");
+
+  for (int i = 0; i < hi.size(); ++i)
+    std::print("{} ", hi[i]);
+  std::println("");
+}
+```
+* simd::minmax[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0 1 1 0 
+3 2 2 3 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::min`](min.md)
+- [`std::simd::max`](max.md)
+- [`std::simd::clamp`](clamp.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/modf.md
+++ b/reference/simd/modf.md
@@ -1,0 +1,78 @@
+# modf
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi>
+  constexpr basic_vec<T, Abi>
+    modf(const std::type_identity_t<basic_vec<T, Abi>>& value,
+         basic_vec<T, Abi>* iptr); // C++26
+}
+```
+* basic_vec[link basic_vec.md]
+* std::type_identity_t[link /reference/type_traits/type_identity.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素を整数部と小数部に分解する。各要素に[`std::modf`](/reference/cmath/modf.md)を適用する。
+
+
+## 効果
+各要素`i`（`0`以上`basic_vec<T, Abi>::size()`未満）について、`value[i]`の整数部（元の符号を保持する）を格納した[`basic_vec`](basic_vec.md)を`*iptr`に設定する。
+
+
+## 戻り値
+各要素`i`について、`value[i]`の小数部（元の符号を保持する）で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{
+    [](int i) { return i + 1.5f; }
+  }; // {1.5, 2.5, 3.5, 4.5}
+
+  simd::vec<float, 4> intpart;
+  simd::vec<float, 4> frac = simd::modf(v, &intpart);
+
+  for (std::size_t i = 0; i < v.size(); ++i)
+    std::print("{}+{} ", intpart[i], frac[i]);
+  std::println("");
+}
+```
+* simd::modf[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+1+0.5 2+0.5 3+0.5 4+0.5 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::frexp`](frexp.md)
+- [`std::simd::ldexp`](ldexp.md)
+- [`std::modf`](/reference/cmath/modf.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/native-abi.md
+++ b/reference/simd/native-abi.md
@@ -1,0 +1,32 @@
+# native-abi
+* [meta exposition-only]
+* simd[meta header]
+* type-alias[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T>
+  using native-abi = /*see below*/;
+}
+```
+
+## 概要
+`native-abi`は、要素型`T`に対する既定のABIタグを表す説明専用の型エイリアスである。値は処理系定義であり、`basic_vec<T, native-abi<T>>`は有効な特殊化となる。
+
+対象システムにおいて、要素型`T`のデータ並列実行が最も効率的になるABIタグが選ばれることが意図されている。ISA拡張を持つアーキテクチャでは、コンパイラフラグによって`native-abi<T>`が指す型が変わることがある。
+
+要素数を指定しない場合の[`vec`](basic_vec.md)・[`mask`](basic_mask.md)の既定ABIとして使用される。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::deduce-abi-t`](deduce-abi-t.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/nearbyint.md
+++ b/reference/simd/nearbyint.md
@@ -1,0 +1,81 @@
+# nearbyint
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> nearbyint(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、現在の丸めモードに従って整数値に丸める。[`rint`](rint.md)とは異なり、`FE_INEXACT`浮動小数点例外を送出しない。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`nearbyint`](/reference/cmath/nearbyint.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {0.5f, 1.5f, 2.5f, 3.5f};
+    return a[i];
+  }};
+
+  // 既定の丸めモード（最近接偶数への丸め）で整数に丸める
+  simd::vec<float, 4> r = simd::nearbyint(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::nearbyint[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0 2 2 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::rint`](rint.md)
+- [`std::simd::round`](round.md)
+- [`std::nearbyint`](/reference/cmath/nearbyint.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/nextafter.md
+++ b/reference/simd/nextafter.md
@@ -1,0 +1,89 @@
+# nextafter
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    nextafter(const V& x, const V& y);                 // (1) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    nextafter(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    nextafter(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`から`y[i]`の方向にある次の表現可能な値を求める。各要素に[`std::nextafter`](/reference/cmath/nextafter.md)を適用する。
+
+- (1) : 両オペランドが同じ型の場合のオーバーロード。
+- (2), (3) : 一方のオペランドがスカラー値であり、[`basic_vec`](basic_vec.md)へと変換される場合のオーバーロード。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`と`y[i]`に[`std::nextafter`](/reference/cmath/nextafter.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+
+  // 各要素から正の無限大方向にある次の表現可能な値を求める
+  simd::vec<float, 4> r = simd::nextafter(v, 1e30f);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i] - v[i]);
+  std::println("");
+}
+```
+* simd::nextafter[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力例
+```
+1.19209e-07 2.38419e-07 2.38419e-07 4.76837e-07 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::copysign`](copysign.md)
+- [`std::nextafter`](/reference/cmath/nextafter.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/none_of.md
+++ b/reference/simd/none_of.md
@@ -1,0 +1,75 @@
+# none_of
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<std::size_t Bytes, class Abi>
+  constexpr bool none_of(const basic_mask<Bytes, Abi>& k) noexcept; // (1) C++26
+
+  constexpr bool none_of(std::same_as<bool> auto x) noexcept;       // (2) C++26
+}
+```
+* basic_mask[link basic_mask.md]
+* std::same_as[link /reference/concepts/same_as.md]
+
+## 概要
+マスクの全要素が`false`であるかを判定する。
+
+- (1) : [`basic_mask`](basic_mask.md)`k`の全要素が`false`であるかを判定する。
+- (2) : スカラーの`bool`値`x`の否定を返す（SIMD-genericなコードを書けるようにするためのオーバーロード）。
+
+## 戻り値
+- (1) : [`any_of`](any_of.md)`(k)`の否定、すなわち`!any_of(k)`を返す。
+- (2) : `!x`を返す。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i; }); // {0, 1, 2, 3}
+
+  std::println("{}", simd::none_of(v < 0)); // 0未満の要素は存在しない
+  std::println("{}", simd::none_of(v < 2)); // 2未満の要素が存在する
+}
+```
+* simd::none_of[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+true
+false
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::all_of`](all_of.md)
+- [`std::simd::any_of`](any_of.md)
+- [`std::simd::reduce_count`](reduce_count.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/norm.md
+++ b/reference/simd/norm.md
@@ -1,0 +1,86 @@
+# norm
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-complex V>
+  constexpr rebind_t<simd-complex-value-type<V>, V> norm(const V& v); // C++26
+}
+```
+* simd-complex-value-type[link /reference/simd/simd-complex-value-type.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+* complex[link /reference/complex/complex.md]
+
+## 概要
+要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素のノルム（絶対値の2乗）を求め、実数型`T`を要素とする[`basic_vec`](basic_vec.md)として返す。
+
+制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`simd-complex-value-type<V>`](/reference/simd/simd-complex-value-type.md)は`V`の要素型`std::complex<T>`における`T`（実数型）を表す。戻り値の型は`V`の要素数はそのままに要素型を`T`とした[`basic_vec`](basic_vec.md)となる。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`v[i]`に[`<complex>`](/reference/complex/complex.md)の[`norm`](/reference/complex/complex/norm.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i + 1.0f, i + 2.0f); }
+  };  // {(1, 2), (2, 3)}
+
+  // 各要素のノルム（絶対値の2乗）を求める
+  simd::vec<float, 2> n = simd::norm(v);
+
+  for (std::size_t i = 0; i < n.size(); ++i)
+    std::print("{} ", n[i]);
+  std::println("");
+}
+```
+* simd::norm[color ff0000]
+
+### 出力例
+```
+5 13 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::abs`](abs.md)
+- [`std::simd::arg`](arg.md)
+- [`std::simd::conj`](conj.md)
+- [`std::simd::real`](real.md)
+- [`std::simd::imag`](imag.md)
+- [`std::complex::norm`](/reference/complex/complex/norm.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/partial_gather_from.md
+++ b/reference/simd/partial_gather_from.md
@@ -1,0 +1,114 @@
+# partial_gather_from
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V = /*see below*/, ranges::contiguous_range R,
+           simd-integral I, class... Flags>
+    requires ranges::sized_range<R>
+  constexpr V
+    partial_gather_from(R&& in,
+                        const I& indices,
+                        flags<Flags...> f = {});  // (1) C++26
+
+  template<class V = /*see below*/, ranges::contiguous_range R,
+           simd-integral I, class... Flags>
+    requires ranges::sized_range<R>
+  constexpr V
+    partial_gather_from(R&& in,
+                        const typename I::mask_type& mask,
+                        const I& indices,
+                        flags<Flags...> f = {});  // (2) C++26
+}
+```
+* simd-integral[link /reference/simd/simd-integral.md]
+* ranges::contiguous_range[link /reference/ranges/contiguous_range.md]
+* ranges::sized_range[link /reference/ranges/sized_range.md]
+
+## 概要
+連続したメモリ領域`in`から、インデックスを表すデータ並列型`indices`で指定した飛び飛びの位置の要素を集めて（gather）、[`basic_vec`](basic_vec.md)へ読み込む。結果の`i`番目の要素は、`in`の`indices[i]`番目の要素となる。インデックスが範囲外を指す場合でも安全に読み込め、その位置は値初期化された値（`0`など）となる。
+
+- (1) : 全要素を集める
+- (2) : `mask`の各要素が`true`である位置の要素のみを集め、`false`の位置は値初期化された値とする
+
+- `V` : 結果のデータ並列型。省略した場合は`vec<std::ranges::range_value_t<R>, I::size()>`が使われる
+- `indices` : 各要素が読み込み位置のインデックスを表す、整数要素のデータ並列型
+- `f` : gatherの動作を指定する`flags`オブジェクト。既定値は`flag_default`。要素型が異なるメモリからの変換読み込みを許可する`flag_convert`や、メモリのアライメントを仮定する`flag_aligned`／`flag_overaligned<N>`を指定できる
+
+[`unchecked_gather_from`](unchecked_gather_from.md)との違いは、インデックスが`in`の範囲外を指してもよい点である。範囲外の位置は読み込まれず、値初期化される。
+
+## テンプレートパラメータ制約
+`std::ranges::range_value_t<R>`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であり、`V::value_type`へ明示的に変換可能であること。
+
+## 適格要件
+- `std::ranges::range_value_t<R>`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であること
+- `V`が[`basic_vec`](basic_vec.md)の有効な特殊化であること
+- `V::size() == I::size()`が`true`であること
+- テンプレートパラメータパック`Flags`が`flag_convert`を含まない場合、`std::ranges::range_value_t<R>`から`V::value_type`への変換が値を保存すること
+
+## 事前条件
+- `Flags`が`flag_aligned`を含む場合、`std::ranges::data(in)`が`alignment_v<V, std::ranges::range_value_t<R>>`でアライメントされた領域を指すこと
+- `Flags`が`flag_overaligned<N>`を含む場合、`std::ranges::data(in)`が`N`でアライメントされた領域を指すこと
+
+## 戻り値
+`i`番目の要素が、`0`以上`I::size()`未満の各`i`について以下で初期化された[`basic_vec`](basic_vec.md)オブジェクト。ここで`T`は`V::value_type`である。
+
+```cpp
+mask[i] && indices[i] < ranges::size(in) ? static_cast<T>(ranges::data(in)[indices[i]]) : T()
+```
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::array<int, 4> data = {10, 11, 12, 13};
+
+  // インデックス {0, 2, 4, 6} のうち、範囲外(4, 6)は値初期化(0)となる
+  simd::vec<int, 4> indices([](int i) { return i * 2; });
+
+  auto v = simd::partial_gather_from<simd::vec<int, 4>>(data, indices);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::print("{} ", v[i]);
+  }
+  std::println("");
+}
+```
+* simd::partial_gather_from[color ff0000]
+* simd::vec[link basic_vec.md]
+* v.size()[link basic_vec/size.md]
+
+### 出力
+```
+10 12 0 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::unchecked_gather_from`](unchecked_gather_from.md)
+- [`std::simd::partial_scatter_to`](partial_scatter_to.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリに追加された

--- a/reference/simd/partial_load.md
+++ b/reference/simd/partial_load.md
@@ -1,0 +1,153 @@
+# partial_load
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V = /*see below*/,
+           ranges::contiguous_range R,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr V
+    partial_load(R&& r,
+                 flags<Flags...> f = {});  // (1) C++26
+
+  template<class V = /*see below*/,
+           ranges::contiguous_range R,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr V
+    partial_load(R&& r,
+                 const typename V::mask_type& mask,
+                 flags<Flags...> f = {});  // (2) C++26
+
+  template<class V = /*see below*/,
+           contiguous_iterator I,
+           class... Flags>
+  constexpr V
+    partial_load(I first,
+                 iter_difference_t<I> n,
+                 flags<Flags...> f = {});  // (3) C++26
+
+  template<class V = /*see below*/,
+           contiguous_iterator I,
+           class... Flags>
+  constexpr V
+    partial_load(I first,
+                 iter_difference_t<I> n,
+                 const typename V::mask_type& mask,
+                 flags<Flags...> f = {});  // (4) C++26
+
+  template<class V = /*see below*/,
+           contiguous_iterator I,
+           sized_sentinel_for<I> S,
+           class... Flags>
+  constexpr V
+    partial_load(I first,
+                 S last,
+                 flags<Flags...> f = {});  // (5) C++26
+
+  template<class V = /*see below*/,
+           contiguous_iterator I,
+           sized_sentinel_for<I> S,
+           class... Flags>
+  constexpr V
+    partial_load(I first,
+                 S last,
+                 const typename V::mask_type& mask,
+                 flags<Flags...> f = {});  // (6) C++26
+}
+```
+* ranges::contiguous_range[link /reference/ranges/contiguous_range.md]
+* ranges::sized_range[link /reference/ranges/sized_range.md]
+* contiguous_iterator[link /reference/iterator/contiguous_iterator.md]
+* sized_sentinel_for[link /reference/iterator/sized_sentinel_for.md]
+* iter_difference_t[link /reference/iterator/iter_difference_t.md]
+
+## 概要
+連続したメモリ領域から[`basic_vec`](basic_vec.md)へ、要素をまとめて読み込む。入力範囲の要素数が結果の要素数に満たない場合でも安全に読み込め、範囲を超える位置の要素は値初期化された値（`0`など）となる。
+
+入力範囲の指定方法によって、以下のオーバーロードがある。
+
+- (1), (2) : 連続範囲`r`（[`std::vector`](/reference/vector/vector.md)や[`std::array`](/reference/array/array.md)、[`std::span`](/reference/span/span.md)など）から読み込む
+- (3), (4) : 先頭イテレータ`first`と要素数`n`で指定した範囲から読み込む
+- (5), (6) : 先頭イテレータ`first`と番兵`last`で指定した範囲から読み込む
+
+`mask`を受け取るオーバーロード (2), (4), (6) は、マスクの各要素が`true`である位置の要素のみを読み込み、`false`の位置は値初期化された値とする。
+
+- `V` : 結果のデータ並列型。省略した場合は`basic_vec<std::ranges::range_value_t<R>>`（先頭イテレータ版では`basic_vec<iter_value_t<I>>`）が使われる
+- `f` : 読み込みの動作を指定する`flags`オブジェクト。既定値は`flag_default`。要素型が異なるメモリからの変換読み込みを許可する`flag_convert`や、メモリのアライメントを仮定してより効率的な読み込みをおこなう`flag_aligned`／`flag_overaligned<N>`を指定できる
+
+[`unchecked_load`](unchecked_load.md)との違いは、入力範囲の要素数が結果の要素数より小さくてもよい点である。範囲外の位置は読み込まれず、値初期化される。
+
+## テンプレートパラメータ制約
+- `std::ranges::range_value_t<R>`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であり、`V::value_type`へ明示的に変換可能であること
+- `V`が[`basic_vec`](basic_vec.md)の有効な特殊化であること
+- テンプレートパラメータパック`Flags`が`flag_convert`を含まない場合、`std::ranges::range_value_t<R>`から`V::value_type`への変換が値を保存すること
+
+## 事前条件
+- (3), (4) : 範囲`[first, first + n)`が有効な範囲であること
+- (5), (6) : 範囲`[first, last)`が有効な範囲であること
+- `Flags`が`flag_aligned`を含む場合、`std::ranges::data(r)`が`alignment_v<V, std::ranges::range_value_t<R>>`でアライメントされた領域を指すこと
+- `Flags`が`flag_overaligned<N>`を含む場合、`std::ranges::data(r)`が`N`でアライメントされた領域を指すこと
+
+## 戻り値
+`i`番目の要素が、`0`以上`V::size()`未満の各`i`について以下で初期化された[`basic_vec`](basic_vec.md)オブジェクト。ここで`T`は`V::value_type`である。
+
+```cpp
+mask[i] && i < ranges::size(r) ? static_cast<T>(ranges::data(r)[i]) : T()
+```
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // 要素数が結果の要素数(4)に満たない配列
+  std::array<int, 2> data = {1, 2};
+
+  // 不足分は値初期化(0)となる
+  auto v = simd::partial_load<simd::vec<int, 4>>(data);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::print("{} ", v[i]);
+  }
+  std::println("");
+}
+```
+* simd::partial_load[color ff0000]
+* simd::vec[link basic_vec.md]
+* v.size()[link basic_vec/size.md]
+
+### 出力
+```
+1 2 0 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::unchecked_load`](unchecked_load.md)
+- [`std::simd::partial_store`](partial_store.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリに追加された

--- a/reference/simd/partial_scatter_to.md
+++ b/reference/simd/partial_scatter_to.md
@@ -1,0 +1,125 @@
+# partial_scatter_to
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V,
+           ranges::contiguous_range R,
+           simd-integral I,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr void
+    partial_scatter_to(const V& v,
+                       R&& out,
+                       const I& indices,
+                       flags<Flags...> f = {});  // (1) C++26
+
+  template<simd-vec-type V,
+           ranges::contiguous_range R,
+           simd-integral I,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr void
+    partial_scatter_to(const V& v,
+                       R&& out,
+                       const typename I::mask_type& mask,
+                       const I& indices,
+                       flags<Flags...> f = {});  // (2) C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* simd-integral[link /reference/simd/simd-integral.md]
+* ranges::contiguous_range[link /reference/ranges/contiguous_range.md]
+* ranges::sized_range[link /reference/ranges/sized_range.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素を、インデックスを表すデータ並列型`indices`で指定した連続メモリ領域`out`の飛び飛びの位置へ書き出す（scatter）。`v`の`i`番目の要素は、`out`の`indices[i]`番目の位置へ書き込まれる。インデックスが範囲外を指す場合でも安全に書き出せ、その位置へは書き込まれない。
+
+- (1) : 全要素を書き出す
+- (2) : `mask`の各要素が`true`である位置の要素のみを書き出す
+
+- `v` : scatterするデータ並列型の値
+- `indices` : 各要素が書き込み位置のインデックスを表す、整数要素のデータ並列型
+- `f` : scatterの動作を指定する`flags`オブジェクト。既定値は`flag_default`。要素型が異なるメモリへの変換書き込みを許可する`flag_convert`や、メモリのアライメントを仮定する`flag_aligned`／`flag_overaligned<N>`を指定できる
+
+[`unchecked_scatter_to`](unchecked_scatter_to.md)との違いは、インデックスが`out`の範囲外を指してもよい点である。範囲外の位置へは書き込まれない。
+
+## テンプレートパラメータ制約
+- `V::size() == I::size()`が`true`であること
+- `std::ranges::iterator_t<R>`が`std::indirectly_writable<std::ranges::range_value_t<R>>`のモデルであること
+- `V::value_type`が`std::ranges::range_value_t<R>`へ明示的に変換可能であること
+
+## 適格要件
+- `std::ranges::range_value_t<R>`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であること
+- テンプレートパラメータパック`Flags`が`flag_convert`を含まない場合、`V::value_type`から`std::ranges::range_value_t<R>`への変換が値を保存すること
+
+## 事前条件
+- 選択されたすべてのインデックス`i`について、`indices[i]`の値が一意であること
+- `Flags`が`flag_aligned`を含む場合、`std::ranges::data(out)`が`alignment_v<V, std::ranges::range_value_t<R>>`でアライメントされた領域を指すこと
+- `Flags`が`flag_overaligned<N>`を含む場合、`std::ranges::data(out)`が`N`でアライメントされた領域を指すこと
+
+## 効果
+`0`以上`I::size()`未満の各`i`について、`mask[i] && (indices[i] < std::ranges::size(out))`が`true`であれば、以下を評価する。
+
+```cpp
+ranges::data(out)[indices[i]] = static_cast<ranges::range_value_t<R>>(v[i]);
+```
+
+## 戻り値
+なし。
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return (i + 1) * 10; }); // {10, 20, 30, 40}
+
+  // インデックス {0, 2, 4, 6} のうち、範囲外(4, 6)へは書き込まれない
+  simd::vec<int, 4> indices([](int i) { return i * 2; });
+
+  std::array<int, 4> out{};
+  simd::partial_scatter_to(v, out, indices);
+
+  for (int x : out) {
+    std::print("{} ", x);
+  }
+  std::println("");
+}
+```
+* simd::partial_scatter_to[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+10 0 20 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::unchecked_scatter_to`](unchecked_scatter_to.md)
+- [`std::simd::partial_gather_from`](partial_gather_from.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリに追加された

--- a/reference/simd/partial_store.md
+++ b/reference/simd/partial_store.md
@@ -1,0 +1,170 @@
+# partial_store
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T,
+           class Abi,
+           ranges::contiguous_range R,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr void
+    partial_store(const basic_vec<T, Abi>& v,
+                  R&& r,
+                  flags<Flags...> f = {});  // (1) C++26
+
+  template<class T,
+           class Abi,
+           ranges::contiguous_range R,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr void
+    partial_store(const basic_vec<T, Abi>& v,
+                  R&& r,
+                  const typename basic_vec<T, Abi>::mask_type& mask,
+                  flags<Flags...> f = {});  // (2) C++26
+
+  template<class T,
+           class Abi,
+           contiguous_iterator I,
+           class... Flags>
+  constexpr void
+    partial_store(const basic_vec<T, Abi>& v,
+                  I first,
+                  iter_difference_t<I> n,
+                  flags<Flags...> f = {});  // (3) C++26
+
+  template<class T,
+           class Abi,
+           contiguous_iterator I,
+           class... Flags>
+  constexpr void
+    partial_store(const basic_vec<T, Abi>& v,
+                  I first,
+                  iter_difference_t<I> n,
+                  const typename basic_vec<T, Abi>::mask_type& mask,
+                  flags<Flags...> f = {});  // (4) C++26
+
+  template<class T,
+           class Abi,
+           contiguous_iterator I,
+           sized_sentinel_for<I> S,
+           class... Flags>
+  constexpr void
+    partial_store(const basic_vec<T, Abi>& v,
+                  I first,
+                  S last,
+                  flags<Flags...> f = {});  // (5) C++26
+
+  template<class T,
+           class Abi,
+           contiguous_iterator I,
+           sized_sentinel_for<I> S,
+           class... Flags>
+  constexpr void
+    partial_store(const basic_vec<T, Abi>& v,
+                  I first,
+                  S last,
+                  const typename basic_vec<T, Abi>::mask_type& mask,
+                  flags<Flags...> f = {});  // (6) C++26
+}
+```
+* ranges::contiguous_range[link /reference/ranges/contiguous_range.md]
+* ranges::sized_range[link /reference/ranges/sized_range.md]
+* contiguous_iterator[link /reference/iterator/contiguous_iterator.md]
+* sized_sentinel_for[link /reference/iterator/sized_sentinel_for.md]
+* iter_difference_t[link /reference/iterator/iter_difference_t.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の要素を、連続したメモリ領域へまとめて書き込む。出力範囲の要素数が値の要素数に満たない場合でも安全に書き込め、範囲を超える位置の要素は書き込まれない。
+
+出力範囲の指定方法によって、以下のオーバーロードがある。
+
+- (1), (2) : 連続範囲`r`（[`std::vector`](/reference/vector/vector.md)や[`std::array`](/reference/array/array.md)、[`std::span`](/reference/span/span.md)など）へ書き込む
+- (3), (4) : 先頭イテレータ`first`と要素数`n`で指定した範囲へ書き込む
+- (5), (6) : 先頭イテレータ`first`と番兵`last`で指定した範囲へ書き込む
+
+`mask`を受け取るオーバーロード (2), (4), (6) は、マスクの各要素が`true`である位置の要素のみを書き込む。
+
+- `v` : 書き込むデータ並列型の値
+- `f` : 書き込みの動作を指定する`flags`オブジェクト。既定値は`flag_default`。要素型が異なるメモリへの変換書き込みを許可する`flag_convert`や、メモリのアライメントを仮定してより効率的な書き込みをおこなう`flag_aligned`／`flag_overaligned<N>`を指定できる
+
+[`unchecked_store`](unchecked_store.md)との違いは、出力範囲の要素数が値の要素数より小さくてもよい点である。範囲外の位置へは書き込まれない。
+
+## テンプレートパラメータ制約
+- `std::ranges::iterator_t<R>`が`std::indirectly_writable<std::ranges::range_value_t<R>>`のモデルであること
+- `T`が`std::ranges::range_value_t<R>`へ明示的に変換可能であること
+
+## 適格要件
+- `std::ranges::range_value_t<R>`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であること
+- テンプレートパラメータパック`Flags`が`flag_convert`を含まない場合、`T`から`std::ranges::range_value_t<R>`への変換が値を保存すること
+
+## 事前条件
+- (3), (4) : 範囲`[first, first + n)`が有効な範囲であること
+- (5), (6) : 範囲`[first, last)`が有効な範囲であること
+- `Flags`が`flag_aligned`を含む場合、`std::ranges::data(r)`が`alignment_v<basic_vec<T, Abi>, std::ranges::range_value_t<R>>`でアライメントされた領域を指すこと
+- `Flags`が`flag_overaligned<N>`を含む場合、`std::ranges::data(r)`が`N`でアライメントされた領域を指すこと
+
+## 効果
+`0`以上`basic_vec<T, Abi>::size()`未満の各`i`について、`mask[i] && i < std::ranges::size(r)`が`true`であれば、以下を評価する。
+
+```cpp
+ranges::data(r)[i] = static_cast<ranges::range_value_t<R>>(v[i]);
+```
+
+## 戻り値
+なし。
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return (i + 1) * 10; }); // {10, 20, 30, 40}
+
+  // 出力範囲(2要素)は値の要素数(4)より小さくてもよい
+  std::array<int, 2> data{};
+  simd::partial_store(v, data);
+
+  for (int x : data) {
+    std::print("{} ", x);
+  }
+  std::println("");
+}
+```
+* simd::partial_store[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+10 20 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::unchecked_store`](unchecked_store.md)
+- [`std::simd::partial_load`](partial_load.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリに追加された

--- a/reference/simd/permute.md
+++ b/reference/simd/permute.md
@@ -1,0 +1,118 @@
+# permute
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  // 特殊なインデックス値
+  inline constexpr simd-size-type zero_element   = /*処理系定義*/;  // (1) C++26
+  inline constexpr simd-size-type uninit_element = /*処理系定義*/;  // (2) C++26
+
+  // 静的置換
+  template<simd-size-type N = /*see below*/, simd-vec-type V, class IdxMap>
+  constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);          // (3) C++26
+  template<simd-size-type N = /*see below*/, simd-mask-type V, class IdxMap>
+  constexpr resize_t<N, V> permute(const V& v, IdxMap&& idxmap);          // (4) C++26
+
+  // 動的置換
+  template<simd-vec-type V, simd-integral I>
+  constexpr resize_t<I::size(), V> permute(const V& v, const I& indices); // (5) C++26
+  template<simd-mask-type V, simd-integral I>
+  constexpr resize_t<I::size(), V> permute(const V& v, const I& indices); // (6) C++26
+}
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* simd-mask-type[link /reference/simd/simd-mask-type.md]
+* simd-integral[link /reference/simd/simd-integral.md]
+* zero_element[color ff0000]
+* uninit_element[color ff0000]
+
+## 概要
+`permute`は、[`basic_vec`](basic_vec.md)や[`basic_mask`](basic_mask.md)の要素を、指定したインデックスのマッピングに従って並べ替える（置換する）関数である。結果の各要素は、元のデータ並列オブジェクトのいずれかの要素からコピーされる。
+
+- (3), (4) 静的置換 : インデックスをマッピングする関数`idxmap`を渡す。結果の`i`番目の要素は、元のオブジェクトの`idxmap(i)`番目（または`idxmap(i, V::size())`番目）の要素で初期化される。マッピング関数はコンパイル時に評価される必要がある。テンプレート引数`N`によって結果の要素数を変更でき、既定では元の要素数（`V::size()`）となる
+- (5), (6) 動的置換 : インデックスをまとめたデータ並列型`indices`を渡す。結果の`i`番目の要素は、元のオブジェクトの`indices[i]`番目の要素で初期化される。インデックスは実行時に決定してよい。結果の要素数は`indices`の要素数（`I::size()`）となる
+
+静的置換のマッピング関数`idxmap`は、通常のインデックスのほかに、以下の特殊値を返してよい。
+
+- (1) `zero_element` : その要素を、要素型のゼロ値（`value_type()`）で初期化する
+- (2) `uninit_element` : その要素を、未規定の値のままにする
+
+## テンプレートパラメータ制約
+- (3), (4) : `std::invoke_result_t<IdxMap&, simd-size-type>`と`std::invoke_result_t<IdxMap&, simd-size-type, simd-size-type>`の少なくとも一方が[`std::integral`](/reference/concepts/integral.md)のモデルであること
+
+## 適格要件
+- (3), (4) : すべての`i`（`[0, N)`の範囲）について、`idxmap`を適用した結果が定数式であり、その値が`zero_element`・`uninit_element`・`[0, V::size())`の範囲のいずれかであること
+
+## 事前条件
+- (5), (6) : `indices`のすべての値が`[0, V::size())`の範囲にあること
+
+## 戻り値
+- (3), (4) : `i`番目の要素が、`idxmap`の適用結果に応じて、元のオブジェクトの対応要素・ゼロ値・未規定値のいずれかで初期化されたデータ並列オブジェクト
+- (5), (6) : `i`番目の要素が`v[indices[i]]`で初期化されたデータ並列オブジェクト
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i; });  // {0, 1, 2, 3}
+
+  // 静的置換: 逆順に並べ替える
+  auto r = simd::permute(v, [](int i) { return 3 - i; });  // {3, 2, 1, 0}
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+
+  // 動的置換: 実行時のインデックスで並べ替える
+  simd::vec<int, 4> idx([](int i) { return (i + 1) % 4; });  // {1, 2, 3, 0}
+  auto d = simd::permute(v, idx);                            // {1, 2, 3, 0}
+
+  for (int i = 0; i < d.size(); ++i)
+    std::print("{} ", d[i]);
+  std::println("");
+}
+```
+* simd::permute[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+3 2 1 0 
+1 2 3 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+- [`std::simd::compress`](compress.md)
+- [`std::simd::expand`](expand.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2664R11 Proposal to extend `std::simd` with permutation API](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2664r11.html)
+    - C++26で置換API（`permute`）が追加された

--- a/reference/simd/polar.md
+++ b/reference/simd/polar.md
@@ -1,0 +1,85 @@
+# polar
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-floating-point V>
+  rebind_t<complex<typename V::value_type>, V> polar(const V& x, const V& y = {}); // C++26
+}
+```
+* simd-floating-point[link /reference/simd/simd-floating-point.md]
+* complex[link /reference/complex/complex.md]
+
+## 概要
+実数型を要素とする[`basic_vec`](basic_vec.md)から、極形式で指定した複素数を要素ごとに生成する。`x`が絶対値、`y`が偏角（位相角）を表す。
+
+制約[`simd-floating-point`](/reference/simd/simd-floating-point.md)は、`V`が浮動小数点型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。戻り値の型は`V`の要素数はそのままに、要素型を`std::complex<T>`（`T`は`V`の要素型）とした[`basic_vec`](basic_vec.md)となる。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`x[i]`と`y[i]`に[`<complex>`](/reference/complex/complex.md)の[`polar`](/reference/complex/complex/polar.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <complex>
+#include <numbers>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 2> rho = 1.0f; // {1, 1}
+  simd::vec<float, 2> theta = std::numbers::pi_v<float> / 4.0f; // {π/4, π/4}
+
+  // 極形式から複素数を要素ごとに生成する
+  simd::vec<std::complex<float>, 2> r = simd::polar(rho, theta);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::complex<float> c = r[i];
+    std::print("({}, {}) ", c.real(), c.imag());
+  }
+  std::println("");
+}
+```
+* simd::polar[color ff0000]
+* std::numbers::pi_v[link /reference/numbers/pi.md]
+
+### 出力例
+```
+(0.707107, 0.707107) (0.707107, 0.707107) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::abs`](abs.md)
+- [`std::simd::arg`](arg.md)
+- [`std::complex::polar`](/reference/complex/complex/polar.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/popcount.md
+++ b/reference/simd/popcount.md
@@ -1,0 +1,84 @@
+# popcount
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V>
+  constexpr rebind_t<make_signed_t<typename V::value_type>, V>
+    popcount(const V& v) noexcept; // C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* make_signed_t[link /reference/type_traits/make_signed.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::popcount`](/reference/bit/popcount.md)を要素ごとに適用し、各要素について立っているビットの数を数える。
+
+
+## テンプレートパラメータ制約
+- `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+`i`番目の要素が[`std::popcount`](/reference/bit/popcount.md)`(v[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。要素型は`V::value_type`を符号付き整数型にしたものである。
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0003, 0x0007, 0x000f}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>((1u << (i + 1)) - 1);
+  }};
+
+  auto r = simd::popcount(v);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {}", v[i], r[i]);
+  }
+}
+```
+* simd::popcount[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 1
+0000000000000011 -> 2
+0000000000000111 -> 3
+0000000000001111 -> 4
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::popcount`](/reference/bit/popcount.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/pow.md
+++ b/reference/simd/pow.md
@@ -1,0 +1,131 @@
+# pow
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> pow(const V& x, const V& y);                // (1) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> pow(const deduced-vec-t<V>& x, const V& y); // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> pow(const V& x, const deduced-vec-t<V>& y); // (3) C++26
+
+  template<simd-complex V>
+  constexpr V pow(const V& x, const V& y);                               // (4) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、各要素を底、対応する各要素を指数とする累乗（<code>x<sup>y</sup></code>）を求める。
+
+- (1) : 両引数を`V`（浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)）として受け取り、各要素に[`<cmath>`](/reference/cmath.md)の[`pow`](/reference/cmath/pow.md)を要素ごとに適用する。
+- (2), (3) : 一方の引数をスカラー値（または対応する[`basic_vec`](basic_vec.md)）で受け取れるようにするオーバーロードである。
+- (4) : 要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素に[`<complex>`](/reference/complex/complex.md)の[`pow`](/reference/complex/complex/pow.md)を要素ごとに適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。一方の引数を[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)とするオーバーロードにより、スカラー値を渡して全要素にブロードキャストできる。制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`x[i]`と`y[i]`に対応する`pow`を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+- (1), (2), (3) : [`<cmath>`](/reference/cmath.md)の[`pow`](/reference/cmath/pow.md)を適用する。
+- (4) : [`<complex>`](/reference/complex/complex.md)の[`pow`](/reference/complex/complex/pow.md)を適用する。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+### 基本的な使い方
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x([](int i) { return float(i + 2); }); // {2, 3, 4, 5}
+
+  // 全要素を2乗する（スカラー値2.0fが全要素にブロードキャストされる）
+  simd::vec<float, 4> r = simd::pow(x, 2.0f);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::pow[color ff0000]
+
+#### 出力例
+```
+4 9 16 25 
+```
+
+### 複素数版 (4)
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> x{
+    [](int i) { return std::complex<float>(i + 2.0f, 0.0f); }
+  };  // {(2, 0), (3, 0)}
+  simd::vec<std::complex<float>, 2> y = std::complex<float>(2.0f, 0.0f); // 全要素が (2, 0)
+
+  // 各要素の累乗を求める
+  simd::vec<std::complex<float>, 2> r = simd::pow(x, y);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::complex<float> c = r[i];
+    std::print("({}, {}) ", c.real(), c.imag());
+  }
+  std::println("");
+}
+```
+* simd::pow[color ff0000]
+
+#### 出力例
+```
+(4, 0) (9, 0) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sqrt`](sqrt.md)
+- [`std::simd::cbrt`](cbrt.md)
+- [`std::simd::hypot`](hypot.md)
+- [`std::simd::exp`](exp.md)
+- [`std::simd::log`](log.md)
+- [`std::pow`](/reference/cmath/pow.md)
+- [`std::complex::pow`](/reference/complex/complex/pow.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加され、実数版の`pow` (1), (2), (3) が追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数版の`pow` (4) が追加された

--- a/reference/simd/proj.md
+++ b/reference/simd/proj.md
@@ -1,0 +1,83 @@
+# proj
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-complex V>
+  constexpr V proj(const V& v); // C++26
+}
+```
+* simd-complex[link /reference/simd/simd-complex.md]
+
+## 概要
+要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素をリーマン球面へ射影した複素数を求める。
+
+制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`v[i]`に[`<complex>`](/reference/complex/complex.md)の[`proj`](/reference/complex/complex/proj.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i + 1.0f, i + 2.0f); }
+  };  // {(1, 2), (2, 3)}
+
+  // 各要素をリーマン球面へ射影する
+  simd::vec<std::complex<float>, 2> r = simd::proj(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::complex<float> c = r[i];
+    std::print("({}, {}) ", c.real(), c.imag());
+  }
+  std::println("");
+}
+```
+* simd::proj[color ff0000]
+
+### 出力例
+```
+(1, 2) (2, 3) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::conj`](conj.md)
+- [`std::simd::abs`](abs.md)
+- [`std::complex::proj`](/reference/complex/complex/proj.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/real.md
+++ b/reference/simd/real.md
@@ -1,0 +1,81 @@
+# real
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-complex V>
+  constexpr rebind_t<simd-complex-value-type<V>, V> real(const V& v) noexcept; // C++26
+}
+```
+* simd-complex-value-type[link /reference/simd/simd-complex-value-type.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+* complex[link /reference/complex/complex.md]
+
+## 概要
+要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素の実部を取り出し、実数型`T`を要素とする[`basic_vec`](basic_vec.md)として返す。
+
+制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`simd-complex-value-type<V>`](/reference/simd/simd-complex-value-type.md)は`V`の要素型`std::complex<T>`における`T`（実数型）を表す。`rebind_t`は要素型を置き換えた[`basic_vec`](basic_vec.md)型を得る別名であり、戻り値の型は`V`の要素数はそのままに要素型を`T`とした[`basic_vec`](basic_vec.md)となる。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`v[i]`に[`<complex>`](/reference/complex/complex.md)の[`real`](/reference/complex/complex/real_free.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // 各要素が複素数のデータ並列型
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i + 1.0f, i + 0.5f); }
+  };  // {(1, 0.5), (2, 1.5)}
+
+  // 各要素の実部を取り出す
+  simd::vec<float, 2> re = simd::real(v);
+
+  for (std::size_t i = 0; i < re.size(); ++i)
+    std::print("{} ", re[i]);
+  std::println("");
+}
+```
+* simd::real[color ff0000]
+
+### 出力例
+```
+1 2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::imag`](imag.md)
+- [`std::simd::abs`](abs.md)
+- [`std::simd::arg`](arg.md)
+- [`std::simd::norm`](norm.md)
+- [`std::simd::conj`](conj.md)
+- [`std::complex::real`](/reference/complex/complex/real_free.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/rebind.md
+++ b/reference/simd/rebind.md
@@ -1,0 +1,70 @@
+# rebind
+* simd[meta header]
+* std::simd[meta namespace]
+* class template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class V>
+  struct rebind { using type = /*see below*/; };
+
+  template<class T, class V>
+  using rebind_t = rebind<T, V>::type;
+}
+```
+
+## 概要
+`rebind`は、データ並列型`V`（[`basic_vec`](basic_vec.md)または[`basic_mask`](basic_mask.md)）の要素数（「width」）を維持したまま、要素型を`T`に変更した型を取得する型特性である。
+
+メンバ`type`は、`V`がデータ並列型であり、要素型を`T`とし`V`と同じ要素数を持つデータ並列型が存在する場合にのみ存在する。存在するとき`type`は次を表す。
+
+- `V`が[`basic_vec`](basic_vec.md)の特殊化のとき: 要素型`T`・`V`と同じ要素数の`basic_vec`
+- `V`が[`basic_mask`](basic_mask.md)の特殊化のとき: 対応する`basic_mask`
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <type_traits>
+
+namespace simd = std::simd;
+
+int main()
+{
+  using Vi = simd::vec<int, 4>;
+
+  // 要素数4を維持したまま要素型をfloatに変更
+  using Vf = simd::rebind_t<float, Vi>;
+
+  std::println("{}", std::is_same_v<Vf, simd::vec<float, 4>>);
+}
+```
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[color ff0000]
+
+### 出力
+```
+true
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::resize`](resize.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/reduce.md
+++ b/reference/simd/reduce.md
@@ -1,0 +1,131 @@
+# reduce
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi, class BinaryOperation = std::plus<>>
+  constexpr T
+    reduce(const basic_vec<T, Abi>& x,
+           BinaryOperation binary_op = {});                           // (1) C++26
+
+  template<class T, class Abi, class BinaryOperation = std::plus<>>
+  constexpr T
+    reduce(const basic_vec<T, Abi>& x,
+           const typename basic_vec<T, Abi>::mask_type& mask,
+           BinaryOperation binary_op = {},
+           std::type_identity_t<T> identity_element = /*see below*/); // (2) C++26
+
+  template<class T, class BinaryOperation = std::plus<>>
+  constexpr T
+    reduce(const T& x,
+           BinaryOperation binary_op = {}); // (3) C++26
+
+  template<class T, class BinaryOperation = std::plus<>>
+  constexpr T
+    reduce(const T& x,
+           std::same_as<bool> auto mask,
+           BinaryOperation binary_op = {},
+           std::type_identity_t<T> identity_element = /*see below*/); // (4) C++26
+}
+```
+* basic_vec[link basic_vec.md]
+* std::plus[link /reference/functional/plus.md]
+* std::type_identity_t[link /reference/type_traits/type_identity.md]
+* std::same_as[link /reference/concepts/same_as.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の全要素を二項演算`binary_op`で集計し、単一の値を求める。
+
+- (1) : `x`の全要素を`binary_op`で集計する。
+- (2) : `mask`で選択された要素のみを`binary_op`で集計する。ひとつも選択されていない場合は`identity_element`（単位元）を返す。
+- (3) : スカラー値`x`をそのまま返す（SIMD-genericなコードを書けるようにするためのオーバーロード）。
+- (4) : `mask`が`true`なら`x`を、`false`なら`identity_element`を返す。
+
+`binary_op`は結合的かつ可換な二項演算でなければならず、要素の集計順は規定されない。
+
+## テンプレートパラメータ制約
+- (1), (2) : `BinaryOperation`が説明専用コンセプト[`reduction-binary-operation`](/reference/simd/reduction-binary-operation.md)`<T>`のモデルであること
+- (3), (4) : `T`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であり、かつ`BinaryOperation`が[`reduction-binary-operation`](/reference/simd/reduction-binary-operation.md)`<T>`のモデルであること
+- (2), (4) : `BinaryOperation`が[`std::plus<>`](/reference/functional/plus.md)・[`std::multiplies<>`](/reference/functional/multiplies.md)・[`std::bit_and<>`](/reference/functional/bit_and.md)・[`std::bit_or<>`](/reference/functional/bit_or.md)・[`std::bit_xor<>`](/reference/functional/bit_xor.md)のいずれでもない場合、`identity_element`の実引数を指定しなければならない
+
+## 事前条件
+- (1), (2) : `binary_op`が`x`を書き換えないこと
+- (2), (4) : `T`で表現可能な任意の有限値`y`について、`identity_element`を`binary_op`の単位元として作用させた結果が`y`と等しくなること
+
+## 戻り値
+- (1) : `x`の全要素`x[0], …, x[x.size() - 1]`を`binary_op`で集計した結果を返す。
+- (2) : [`none_of`](none_of.md)`(mask)`が`true`なら`identity_element`を返す。そうでなければ`mask`で選択された要素を`binary_op`で集計した結果を返す。
+- (3) : `x`を返す。
+- (4) : `mask`が`false`なら`identity_element`を、そうでなければ`x`を返す。
+
+## 例外
+- (1), (2) : `binary_op`が送出する例外を送出する
+- (3), (4) : 投げない
+
+## 備考
+- (2), (4) : `identity_element`の既定引数は、`BinaryOperation`に応じて以下の値となる。
+    - [`std::plus<>`](/reference/functional/plus.md) : `T()`
+    - [`std::multiplies<>`](/reference/functional/multiplies.md) : `T(1)`
+    - [`std::bit_and<>`](/reference/functional/bit_and.md) : `T(~T())`
+    - [`std::bit_or<>`](/reference/functional/bit_or.md) : `T()`
+    - [`std::bit_xor<>`](/reference/functional/bit_xor.md) : `T()`
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <functional>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i + 1; }); // {1, 2, 3, 4}
+
+  // 全要素の総和（既定の二項演算はstd::plus<>）
+  std::println("{}", simd::reduce(v));
+
+  // 全要素の積
+  std::println("{}", simd::reduce(v, std::multiplies<>{}));
+
+  // 偶数要素だけの総和
+  auto mask = (v % 2 == 0);
+  std::println("{}", simd::reduce(v, mask));
+}
+```
+* simd::reduce[color ff0000]
+* simd::vec[link basic_vec.md]
+* std::multiplies[link /reference/functional/multiplies.md]
+
+### 出力
+```
+10
+24
+6
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::reduce_min`](reduce_min.md)
+- [`std::simd::reduce_max`](reduce_max.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+- [P3690R1 Consistency fix: Make simd reductions SIMD-generic](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3690r1.pdf)
+    - スカラー[「vectorizable type」](/reference/simd.md#vectorizable-type)を受け取るオーバーロード (3), (4) が追加され、SIMD-genericなコードを書けるようになった

--- a/reference/simd/reduce_count.md
+++ b/reference/simd/reduce_count.md
@@ -1,0 +1,79 @@
+# reduce_count
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<std::size_t Bytes, class Abi>
+  constexpr simd-size-type
+    reduce_count(const basic_mask<Bytes, Abi>& k) noexcept; // (1) C++26
+
+  constexpr simd-size-type
+    reduce_count(std::same_as<bool> auto x) noexcept;       // (2) C++26
+}
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* basic_mask[link basic_mask.md]
+* std::same_as[link /reference/concepts/same_as.md]
+
+## 概要
+マスクのうち、`true`である要素の数を数える。
+
+- (1) : [`basic_mask`](basic_mask.md)`k`のうち、`true`である要素の数を返す。
+- (2) : スカラーの`bool`値`x`をそのまま数として返す（SIMD-genericなコードを書けるようにするためのオーバーロード。`true`なら`1`、`false`なら`0`）。
+
+戻り値の型[`simd-size-type`](/reference/simd/simd-size-type.md)は、要素数を表す説明専用の符号付き整数型である。
+
+## 戻り値
+- (1) : `k`のうち`true`である要素の数を返す。
+- (2) : `x`を返す。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i; }); // {0, 1, 2, 3}
+
+  // 2未満の要素の数
+  std::println("{}", simd::reduce_count(v < 2));
+}
+```
+* simd::reduce_count[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+2
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::all_of`](all_of.md)
+- [`std::simd::any_of`](any_of.md)
+- [`std::simd::none_of`](none_of.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/reduce_max.md
+++ b/reference/simd/reduce_max.md
@@ -1,0 +1,100 @@
+# reduce_max
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi>
+  constexpr T
+    reduce_max(const basic_vec<T, Abi>& x) noexcept; // (1) C++26
+
+  template<class T, class Abi>
+  constexpr T
+    reduce_max(const basic_vec<T, Abi>& x,
+               const typename basic_vec<T, Abi>::mask_type& mask) noexcept; // (2) C++26
+
+  template<class T>
+  constexpr T
+    reduce_max(const T& x) noexcept; // (3) C++26
+
+  template<class T>
+  constexpr T
+    reduce_max(const T& x,
+               std::same_as<bool> auto mask) noexcept; // (4) C++26
+}
+```
+* basic_vec[link basic_vec.md]
+* std::same_as[link /reference/concepts/same_as.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の要素のうち、最大の値を取得する。
+
+- (1) : `x`の全要素の最大値を返す。
+- (2) : `mask`で選択された要素の最大値を返す。ひとつも選択されていない場合は`T`の最小値を返す。
+- (3) : スカラー値`x`をそのまま返す（SIMD-genericなコードを書けるようにするためのオーバーロード）。
+- (4) : `mask`が`true`なら`x`を、`false`なら`T`の最小値を返す。
+
+## テンプレートパラメータ制約
+- (1), (2) : `T`が[`std::totally_ordered`](/reference/concepts/totally_ordered.md)のモデルであること
+- (3), (4) : `T`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であり、かつ[`std::totally_ordered`](/reference/concepts/totally_ordered.md)のモデルであること
+
+## 戻り値
+- (1) : すべての`i`（`0`以上`x.size()`未満）について`x[j] < x[i]`が`false`となるような要素`x[j]`の値を返す。
+- (2) : [`none_of`](none_of.md)`(mask)`が`true`なら[`std::numeric_limits`](/reference/limits/numeric_limits.md)`<T>::lowest()`を返す。そうでなければ、`mask`で選択されたすべてのインデックス`i`について`x[j] < x[i]`が`false`となるような選択要素`x[j]`の値を返す。
+- (3) : `x`を返す。
+- (4) : `mask`が`false`なら[`std::numeric_limits`](/reference/limits/numeric_limits.md)`<T>::lowest()`を、そうでなければ`x`を返す。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i; }); // {0, 1, 2, 3}
+
+  // 全要素の最大値
+  std::println("{}", simd::reduce_max(v));
+
+  // 選択された要素（値が2未満）の最大値
+  std::println("{}", simd::reduce_max(v, v < 2));
+}
+```
+* simd::reduce_max[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+3
+1
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::reduce_min`](reduce_min.md)
+- [`std::simd::reduce`](reduce.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+- [P3690R1 Consistency fix: Make simd reductions SIMD-generic](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3690r1.pdf)
+    - スカラー[「vectorizable type」](/reference/simd.md#vectorizable-type)を受け取るオーバーロード (3), (4) が追加され、SIMD-genericなコードを書けるようになった

--- a/reference/simd/reduce_max_index.md
+++ b/reference/simd/reduce_max_index.md
@@ -1,0 +1,79 @@
+# reduce_max_index
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<std::size_t Bytes, class Abi>
+  constexpr simd-size-type
+    reduce_max_index(const basic_mask<Bytes, Abi>& k); // (1) C++26
+
+  constexpr simd-size-type
+    reduce_max_index(std::same_as<bool> auto x);       // (2) C++26
+}
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* basic_mask[link basic_mask.md]
+* std::same_as[link /reference/concepts/same_as.md]
+
+## 概要
+マスクのうち、`true`である要素の最大のインデックス（最後に`true`となる要素の位置）を取得する。
+
+- (1) : [`basic_mask`](basic_mask.md)`k`のうち、`true`である要素の最大のインデックスを返す。
+- (2) : スカラーの`bool`値`x`に対するオーバーロード（SIMD-genericなコードを書けるようにするためのもの）。
+
+戻り値の型[`simd-size-type`](/reference/simd/simd-size-type.md)は、要素数を表す説明専用の符号付き整数型である。
+
+## 事前条件
+- (1) : [`any_of`](any_of.md)`(k)`が`true`であること
+- (2) : `x`が`true`であること
+
+## 戻り値
+- (1) : `k[i]`が`true`となる最大のインデックス`i`を返す。
+- (2) : `0`を返す。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i; }); // {0, 1, 2, 3}
+
+  // 値が1より小さい最後の要素のインデックス
+  std::println("{}", simd::reduce_max_index(v < 2));
+}
+```
+* simd::reduce_max_index[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+1
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::reduce_min_index`](reduce_min_index.md)
+- [`std::simd::reduce_count`](reduce_count.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/reduce_min.md
+++ b/reference/simd/reduce_min.md
@@ -1,0 +1,100 @@
+# reduce_min
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi>
+  constexpr T
+    reduce_min(const basic_vec<T, Abi>& x) noexcept; // (1) C++26
+
+  template<class T, class Abi>
+  constexpr T
+    reduce_min(const basic_vec<T, Abi>& x,
+               const typename basic_vec<T, Abi>::mask_type& mask) noexcept; // (2) C++26
+
+  template<class T>
+  constexpr T
+    reduce_min(const T& x) noexcept; // (3) C++26
+
+  template<class T>
+  constexpr T
+    reduce_min(const T& x,
+               std::same_as<bool> auto mask) noexcept; // (4) C++26
+}
+```
+* basic_vec[link basic_vec.md]
+* std::same_as[link /reference/concepts/same_as.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の要素のうち、最小の値を取得する。
+
+- (1) : `x`の全要素の最小値を返す。
+- (2) : `mask`で選択された要素の最小値を返す。ひとつも選択されていない場合は`T`の最大値を返す。
+- (3) : スカラー値`x`をそのまま返す（SIMD-genericなコードを書けるようにするためのオーバーロード）。
+- (4) : `mask`が`true`なら`x`を、`false`なら`T`の最大値を返す。
+
+## テンプレートパラメータ制約
+- (1), (2) : `T`が[`std::totally_ordered`](/reference/concepts/totally_ordered.md)のモデルであること
+- (3), (4) : `T`が[「vectorizable type」](/reference/simd.md#vectorizable-type)であり、かつ[`std::totally_ordered`](/reference/concepts/totally_ordered.md)のモデルであること
+
+## 戻り値
+- (1) : すべての`i`（`0`以上`x.size()`未満）について`x[i] < x[j]`が`false`となるような要素`x[j]`の値を返す。
+- (2) : [`none_of`](none_of.md)`(mask)`が`true`なら[`std::numeric_limits`](/reference/limits/numeric_limits.md)`<T>::max()`を返す。そうでなければ、`mask`で選択されたすべてのインデックス`i`について`x[i] < x[j]`が`false`となるような選択要素`x[j]`の値を返す。
+- (3) : `x`を返す。
+- (4) : `mask`が`false`なら[`std::numeric_limits`](/reference/limits/numeric_limits.md)`<T>::max()`を、そうでなければ`x`を返す。
+
+## 例外
+投げない
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return 3 - i; }); // {3, 2, 1, 0}
+
+  // 全要素の最小値
+  std::println("{}", simd::reduce_min(v));
+
+  // 選択された要素（値が2以上）の最小値
+  std::println("{}", simd::reduce_min(v, v >= 2));
+}
+```
+* simd::reduce_min[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0
+2
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::reduce_max`](reduce_max.md)
+- [`std::simd::reduce`](reduce.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+- [P3690R1 Consistency fix: Make simd reductions SIMD-generic](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3690r1.pdf)
+    - スカラー[「vectorizable type」](/reference/simd.md#vectorizable-type)を受け取るオーバーロード (3), (4) が追加され、SIMD-genericなコードを書けるようになった

--- a/reference/simd/reduce_min_index.md
+++ b/reference/simd/reduce_min_index.md
@@ -1,0 +1,79 @@
+# reduce_min_index
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<std::size_t Bytes, class Abi>
+  constexpr simd-size-type
+    reduce_min_index(const basic_mask<Bytes, Abi>& k); // (1) C++26
+
+  constexpr simd-size-type
+    reduce_min_index(std::same_as<bool> auto x);       // (2) C++26
+}
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+* basic_mask[link basic_mask.md]
+* std::same_as[link /reference/concepts/same_as.md]
+
+## 概要
+マスクのうち、`true`である要素の最小のインデックス（最初に`true`となる要素の位置）を取得する。
+
+- (1) : [`basic_mask`](basic_mask.md)`k`のうち、`true`である要素の最小のインデックスを返す。
+- (2) : スカラーの`bool`値`x`に対するオーバーロード（SIMD-genericなコードを書けるようにするためのもの）。
+
+戻り値の型[`simd-size-type`](/reference/simd/simd-size-type.md)は、要素数を表す説明専用の符号付き整数型である。
+
+## 事前条件
+- (1) : [`any_of`](any_of.md)`(k)`が`true`であること
+- (2) : `x`が`true`であること
+
+## 戻り値
+- (1) : `k[i]`が`true`となる最小のインデックス`i`を返す。
+- (2) : `0`を返す。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return i; }); // {0, 1, 2, 3}
+
+  // 値が1より大きい最初の要素のインデックス
+  std::println("{}", simd::reduce_min_index(v > 1));
+}
+```
+* simd::reduce_min_index[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+2
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::reduce_max_index`](reduce_max_index.md)
+- [`std::simd::reduce_count`](reduce_count.md)
+- [`std::simd::basic_mask`](basic_mask.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/reduction-binary-operation.md
+++ b/reference/simd/reduction-binary-operation.md
@@ -1,0 +1,39 @@
+# reduction-binary-operation
+* [meta exposition-only]
+* simd[meta header]
+* concept[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class BinaryOperation, class T>
+  concept reduction-binary-operation =
+    requires (const BinaryOperation binary_op, const vec<T, 1> v) {
+      { binary_op(v, v) } -> same_as<vec<T, 1>>;
+    };
+}
+```
+* vec[link basic_vec.md]
+
+## 概要
+`reduction-binary-operation`は、型`BinaryOperation`が、要素型`T`のデータ並列型に対する[`reduce`](reduce.md)の二項演算として使用できることを表す説明専用のコンセプトである。
+
+`vec<T, 1>`の2つの値で呼び出せて、結果が同じ`vec<T, 1>`型になる場合に、構文的な要件を満たす。
+
+## モデル
+`BinaryOperation`と`T`が`reduction-binary-operation<BinaryOperation, T>`のモデルとなるのは、上記の構文的要件に加えて、次を満たす場合に限る。
+
+- `BinaryOperation`が要素ごとの二項演算であり、かつ可換であること
+- `BinaryOperation`のオブジェクトを、未規定のABIタグ`Abi`をもつ`basic_vec<T, Abi>`型の2引数で呼び出せて、`basic_vec<T, Abi>`を返すこと
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::reduce`](reduce.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/remainder.md
+++ b/reference/simd/remainder.md
@@ -1,0 +1,85 @@
+# remainder
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> remainder(const V& x, const V& y);                 // (1) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> remainder(const deduced-vec-t<V>& x, const V& y);  // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> remainder(const V& x, const deduced-vec-t<V>& y);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、IEEE 754で定義される剰余（`x - n * y`、`n`は`x / y`を最も近い整数に丸めた値）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+- (1) : 両引数が同じ型`V`の場合。
+- (2), (3) : 一方の引数を[`basic_vec`](basic_vec.md)、他方をスカラー値として、スカラー側を全要素に対して適用する場合。
+
+
+## 戻り値
+各要素`i`について、`x`・`y`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`remainder`](/reference/cmath/remainder.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x{[](int i) { return i + 5.0f; }}; // {5, 6, 7, 8}
+
+  // 各要素の3.0に対するIEEE剰余（スカラーとの演算）
+  simd::vec<float, 4> r = simd::remainder(x, 3.0f);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::remainder[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+-1 0 1 -1 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::fmod`](fmod.md)
+- [`std::simd::remquo`](remquo.md)
+- [`std::remainder`](/reference/cmath/remainder.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/remquo.md
+++ b/reference/simd/remquo.md
@@ -1,0 +1,99 @@
+# remquo
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    remquo(const V& x, const V& y,
+           rebind_t<int, deduced-vec-t<V>>* quo);  // (1) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    remquo(const deduced-vec-t<V>& x, const V& y,
+           rebind_t<int, deduced-vec-t<V>>* quo);  // (2) C++26
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    remquo(const V& x, const deduced-vec-t<V>& y,
+           rebind_t<int, deduced-vec-t<V>>* quo);  // (3) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、[`remainder`](remainder.md)と同じIEEE剰余を求めると同時に、商`x / y`の下位ビット（符号付き）を`*quo`に格納する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+- (1) : 両引数が同じ型`V`の場合。
+- (2), (3) : 一方の引数を[`basic_vec`](basic_vec.md)、他方をスカラー値として、スカラー側を全要素に対して適用する場合。
+
+
+## 効果
+各要素`i`について、`x`・`y`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`remquo`](/reference/cmath/remquo.md)を適用したときの商側の結果で初期化された`rebind_t<int, deduced-vec-t<V>>`型のオブジェクトを`*quo`に格納する。
+
+
+## 戻り値
+各要素`i`について、`x`・`y`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`remquo`](/reference/cmath/remquo.md)を適用したときの剰余で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> x{[](int i) { constexpr float a[] = {5, 7, 9, 11}; return a[i]; }};
+
+  simd::rebind_t<int, simd::vec<float, 4>> quo;
+
+  // 各要素の3.0に対するIEEE剰余と、商の下位ビットを求める
+  simd::vec<float, 4> r = simd::remquo(x, 3.0f, &quo);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{}(quo={}) ", r[i], quo[i]);
+  std::println("");
+}
+```
+* simd::remquo[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力
+```
+-1(quo=2) 1(quo=2) 0(quo=3) -1(quo=4) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::fmod`](fmod.md)
+- [`std::simd::remainder`](remainder.md)
+- [`std::remquo`](/reference/cmath/remquo.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/resize.md
+++ b/reference/simd/resize.md
@@ -1,0 +1,70 @@
+# resize
+* simd[meta header]
+* std::simd[meta namespace]
+* class template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-size-type N, class V>
+  struct resize { using type = /*see below*/; };
+
+  template<simd-size-type N, class V>
+  using resize_t = resize<N, V>::type;
+}
+```
+* simd-size-type[link /reference/simd/simd-size-type.md]
+
+## 概要
+`resize`は、データ並列型`V`（[`basic_vec`](basic_vec.md)または[`basic_mask`](basic_mask.md)）の要素型を維持したまま、要素数（「width」）を`N`に変更した型を取得する型特性である。
+
+メンバ`type`は、`V`がデータ並列型であり、要素数`N`を表現できるデータ並列型が存在する場合にのみ存在する。存在するとき`type`は、`V`と同じ要素型で要素数`N`のデータ並列型を表す。
+
+[`permute`](permute.md)や[`chunk`](chunk.md)・[`cat`](cat.md)など、要素数が変化する操作の戻り値型に用いられる。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <type_traits>
+
+namespace simd = std::simd;
+
+int main()
+{
+  using V4 = simd::vec<int, 4>;
+
+  // 要素型intを維持したまま要素数を8に変更
+  using V8 = simd::resize_t<8, V4>;
+
+  std::println("{}", std::is_same_v<V8, simd::vec<int, 8>>);
+}
+```
+* simd::vec[link basic_vec.md]
+* simd::resize_t[color ff0000]
+
+### 出力
+```
+true
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::rebind`](rebind.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/riemann_zeta.md
+++ b/reference/simd/riemann_zeta.md
@@ -1,0 +1,77 @@
+# riemann_zeta
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> riemann_zeta(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`riemann_zeta`](/reference/cmath/riemann_zeta.md)を適用し、各要素のリーマンゼータ関数（Riemann zeta function）の値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`riemann_zeta`](/reference/cmath/riemann_zeta.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 2> v{[](int i) { return i * 2.0 + 2.0; }}; // {2, 4}
+
+  // 各要素のリーマンゼータ関数を求める
+  simd::vec<double, 2> r = simd::riemann_zeta(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::riemann_zeta[color ff0000]
+
+### 出力例
+```
+1.6449340668482264 1.0823232337111382 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::riemann_zeta`](/reference/cmath/riemann_zeta.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/rint.md
+++ b/reference/simd/rint.md
@@ -1,0 +1,81 @@
+# rint
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> rint(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、現在の丸めモードに従って整数値に丸める。[`nearbyint`](nearbyint.md)とは異なり、結果が元の値と異なる場合に`FE_INEXACT`浮動小数点例外を送出しうる。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`rint`](/reference/cmath/rint.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {0.5f, 1.5f, 2.5f, 3.5f};
+    return a[i];
+  }};
+
+  // 既定の丸めモード（最近接偶数への丸め）で整数に丸める
+  simd::vec<float, 4> r = simd::rint(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::rint[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+0 2 2 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::nearbyint`](nearbyint.md)
+- [`std::simd::round`](round.md)
+- [`std::rint`](/reference/cmath/rint.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/rotl.md
+++ b/reference/simd/rotl.md
@@ -1,0 +1,97 @@
+# rotl
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V0, simd-vec-type V1>
+  constexpr V0 rotl(const V0& v0, const V1& v1) noexcept; // (1) C++26
+
+  template<simd-vec-type V>
+  constexpr V rotl(const V& v, int s) noexcept;           // (2) C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::rotl`](/reference/bit/rotl.md)を要素ごとに適用し、各要素のビットを左に循環シフトする。
+
+- (1) : 各要素をシフト量`v1[i]`だけ左に循環シフトする
+- (2) : 各要素を同一のシフト量`s`だけ左に循環シフトする
+
+
+## テンプレートパラメータ制約
+- (1) :
+    - `V0::value_type`が符号なし整数型であること
+    - `V1::value_type`が整数型であること
+    - `V0::size() == V1::size()`が`true`であること
+    - `sizeof(typename V0::value_type) == sizeof(typename V1::value_type)`が`true`であること
+- (2) :
+    - `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+- (1) : `i`番目の要素が[`std::rotl`](/reference/bit/rotl.md)`(v0[i], static_cast<int>(v1[i]))`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+- (2) : `i`番目の要素が[`std::rotl`](/reference/bit/rotl.md)`(v[i], s)`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0010, 0x0100, 0x1000}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(1u << (i * 4));
+  }};
+
+  // 各要素を4ビットだけ左に循環シフトする
+  simd::vec<std::uint16_t, 4> r = simd::rotl(v, 4);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::rotl[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 0000000000010000
+0000000000010000 -> 0000000100000000
+0000000100000000 -> 0001000000000000
+0001000000000000 -> 0000000000000001
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::rotl`](/reference/bit/rotl.md)
+- [`std::simd::rotr`](rotr.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/rotr.md
+++ b/reference/simd/rotr.md
@@ -1,0 +1,97 @@
+# rotr
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V0, simd-vec-type V1>
+  constexpr V0 rotr(const V0& v0, const V1& v1) noexcept; // (1) C++26
+
+  template<simd-vec-type V>
+  constexpr V rotr(const V& v, int s) noexcept;           // (2) C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+
+## 概要
+符号なし整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、[`std::rotr`](/reference/bit/rotr.md)を要素ごとに適用し、各要素のビットを右に循環シフトする。
+
+- (1) : 各要素をシフト量`v1[i]`だけ右に循環シフトする
+- (2) : 各要素を同一のシフト量`s`だけ右に循環シフトする
+
+
+## テンプレートパラメータ制約
+- (1) :
+    - `V0::value_type`が符号なし整数型であること
+    - `V1::value_type`が整数型であること
+    - `V0::size() == V1::size()`が`true`であること
+    - `sizeof(typename V0::value_type) == sizeof(typename V1::value_type)`が`true`であること
+- (2) :
+    - `V::value_type`が符号なし整数型であること
+
+
+## 戻り値
+- (1) : `i`番目の要素が[`std::rotr`](/reference/bit/rotr.md)`(v0[i], static_cast<int>(v1[i]))`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+- (2) : `i`番目の要素が[`std::rotr`](/reference/bit/rotr.md)`(v[i], s)`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0010, 0x0100, 0x1000}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(1u << (i * 4));
+  }};
+
+  // 各要素を4ビットだけ右に循環シフトする
+  simd::vec<std::uint16_t, 4> r = simd::rotr(v, 4);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::rotr[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 0001000000000000
+0000000000010000 -> 0000000000000001
+0000000100000000 -> 0000000000010000
+0001000000000000 -> 0000000100000000
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::rotr`](/reference/bit/rotr.md)
+- [`std::simd::rotl`](rotl.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2933R4 Extend `<bit>` header function with overloads for `std::simd`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2933r4.html)
+    - C++26で`<bit>`ヘッダの関数に`std::simd`向けのオーバーロードが追加された

--- a/reference/simd/round.md
+++ b/reference/simd/round.md
@@ -1,0 +1,82 @@
+# round
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> round(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、最も近い整数値に丸める。ちょうど中間（.5）の場合は0から遠いほうへ丸める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`round`](/reference/cmath/round.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {1.4f, 1.5f, 2.5f, -1.5f};
+    return a[i];
+  }};
+
+  // 各要素を最も近い整数に丸める（中間は0から遠いほうへ）
+  simd::vec<float, 4> r = simd::round(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::round[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+1 2 3 -2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::nearbyint`](nearbyint.md)
+- [`std::simd::rint`](rint.md)
+- [`std::simd::lround`](lround.md)
+- [`std::round`](/reference/cmath/round.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/scalbln.md
+++ b/reference/simd/scalbln.md
@@ -1,0 +1,85 @@
+# scalbln
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    scalbln(const V& x,
+            const rebind_t<long, deduced-vec-t<V>>& n); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`を浮動小数点数の基数`FLT_RADIX`の`n[i]`乗倍する。各要素に[`std::scalbln`](/reference/cmath/scalbln.md)を適用する。
+
+[`scalbn`](scalbn.md)と同じ計算を行うが、指数`n`の要素型が`long`である点が異なる。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`と`n[i]`に[`std::scalbln`](/reference/cmath/scalbln.md)を適用した結果（`x[i] × FLT_RADIX`<sup>`n[i]`</sup>）で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+  simd::rebind_t<long, simd::vec<float, 4>> n(
+    [](int i) { return i + 1; }); // {1, 2, 3, 4}
+
+  simd::vec<float, 4> r = simd::scalbln(v, n);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::scalbln[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力例
+```
+2 8 24 64 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::scalbn`](scalbn.md)
+- [`std::simd::ldexp`](ldexp.md)
+- [`std::scalbln`](/reference/cmath/scalbln.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/scalbn.md
+++ b/reference/simd/scalbn.md
@@ -1,0 +1,83 @@
+# scalbn
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V>
+    scalbn(const V& x,
+           const rebind_t<int, deduced-vec-t<V>>& n); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素`x[i]`を浮動小数点数の基数`FLT_RADIX`の`n[i]`乗倍する。各要素に[`std::scalbn`](/reference/cmath/scalbn.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`と`n[i]`に[`std::scalbn`](/reference/cmath/scalbn.md)を適用した結果（`x[i] × FLT_RADIX`<sup>`n[i]`</sup>）で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i + 1.0f; }); // {1, 2, 3, 4}
+  simd::rebind_t<int, simd::vec<float, 4>> n(
+    [](int i) { return i + 1; }); // {1, 2, 3, 4}
+
+  simd::vec<float, 4> r = simd::scalbn(v, n);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::scalbn[color ff0000]
+* simd::vec[link basic_vec.md]
+* simd::rebind_t[link rebind.md]
+
+### 出力例
+```
+2 8 24 64 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::scalbln`](scalbln.md)
+- [`std::simd::ldexp`](ldexp.md)
+- [`std::scalbn`](/reference/cmath/scalbn.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/select.md
+++ b/reference/simd/select.md
@@ -1,0 +1,93 @@
+# select
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class U>
+  constexpr auto
+    select(bool c,
+           const T& a,
+           const U& b)
+    -> remove_cvref_t<decltype(c ? a : b)>;              // (1) C++26
+
+  template<std::size_t Bytes, class Abi, class T, class U>
+  constexpr auto
+    select(const basic_mask<Bytes, Abi>& c,
+           const T& a,
+           const U& b)
+    noexcept -> decltype(/*simd-select-impl*/(c, a, b)); // (2) C++26
+}
+```
+* basic_mask[link basic_mask.md]
+* remove_cvref_t[link /reference/type_traits/remove_cvref.md]
+
+## 概要
+条件に応じて2つの値のうちいずれかを選択する。条件演算子`c ? a : b`のデータ並列版である。
+
+- (1) : スカラー版。条件`c`が`true`なら`a`を、`false`なら`b`を返す
+- (2) : データ並列版。マスク`c`の各要素に応じて、`true`の位置では`a`の対応する要素を、`false`の位置では`b`の対応する要素を選択した結果を返す
+
+- `c` : 選択条件。(2) では[`basic_mask`](basic_mask.md)（比較演算子の結果など）
+- `a` : 条件が`true`のときに選択される値
+- `b` : 条件が`false`のときに選択される値
+
+## 効果
+- (1) : `return c ? a : b;`と等価である
+- (2) : 実引数依存の名前探索（ADL）によって見つかる説明専用の`simd-select-impl(c, a, b)`を返すことと等価である
+
+## 戻り値
+選択結果。(2) では`a`と`b`の各要素をマスクに応じて選択したデータ並列型。
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> a([](int i) { return i + 1; });        // {1, 2, 3, 4}
+  simd::vec<int, 4> b([](int i) { return (i + 1) * 10; }); // {10, 20, 30, 40}
+
+  // マスクの各要素に応じてa/bの要素を選択する
+  auto mask = (a < 3);                // {true, true, false, false}
+  auto r = simd::select(mask, a, b);  // {1, 2, 30, 40}
+
+  for (int i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::select[color ff0000]
+* simd::vec[link basic_vec.md]
+* r.size()[link basic_vec/size.md]
+
+### 出力
+```
+1 2 30 40 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::basic_mask`](basic_mask.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリに追加された

--- a/reference/simd/shl.md
+++ b/reference/simd/shl.md
@@ -1,0 +1,95 @@
+# shl
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-integral VX, simd-integral VS>
+  constexpr VX shl(const VX& x, const VS& s) noexcept; // (1) C++29
+
+  template<simd-integral V, class S>
+  constexpr V shl(const V& x, S s) noexcept;           // (2) C++29
+}
+```
+* simd-integral[link /reference/simd/simd-integral.md]
+
+## 概要
+整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、`<bit>`ヘッダの[`std::shl`](/reference/bit/shl.md)を要素ごとに適用し、各要素を論理左シフトする。下位には0が入る。
+
+組み込みの左シフト演算子`<<`とは異なり、シフト量が要素のビット幅以上である場合や負である場合でも未定義動作とならず、定義された結果を返す。
+
+- (1) : 各要素をシフト量`s[i]`だけ左シフトする
+- (2) : すべての要素を同一のシフト量`s`だけ左シフトする
+
+
+## テンプレートパラメータ制約
+- (1) :
+    - `VX::value_type`と`VS::value_type`がそれぞれ符号付きまたは符号なし整数型であること
+    - `VX::size() == VS::size()`が`true`であること
+    - `sizeof(typename VX::value_type) == sizeof(typename VS::value_type)`が`true`であること
+- (2) :
+    - `V::value_type`と`S`がそれぞれ符号付きまたは符号なし整数型であること
+
+
+## 戻り値
+- (1) : `i`番目の要素が`std::shl(x[i], s[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+- (2) : `i`番目の要素が`std::shl(x[i], s)`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0010, 0x0100, 0x1000}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(1u << (i * 4));
+  }};
+
+  // 各要素を4ビットだけ論理左シフトする
+  simd::vec<std::uint16_t, 4> r = simd::shl(v, 4);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::shl[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 0000000000010000
+0000000000010000 -> 0000000100000000
+0000000100000000 -> 0001000000000000
+0001000000000000 -> 0000000000000000
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::shr`](shr.md)
+
+
+## 参照
+- [P3793R1 Better shifting](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3793r1.html)
+    - C++29で`<bit>`ヘッダにスカラー版、`<simd>`ヘッダに`std::simd`版の`shl`が追加された

--- a/reference/simd/shr.md
+++ b/reference/simd/shr.md
@@ -1,0 +1,95 @@
+# shr
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp29[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-integral VX, simd-integral VS>
+  constexpr VX shr(const VX& x, const VS& s) noexcept; // (1) C++29
+
+  template<simd-integral V, class S>
+  constexpr V shr(const V& x, S s) noexcept;           // (2) C++29
+}
+```
+* simd-integral[link /reference/simd/simd-integral.md]
+
+## 概要
+整数要素をもつ[`basic_vec`](basic_vec.md)の各要素に対して、`<bit>`ヘッダの[`std::shr`](/reference/bit/shr.md)を要素ごとに適用し、各要素を論理右シフトする。符号によらず上位には0が入る。
+
+組み込みの右シフト演算子`>>`とは異なり、シフト量が要素のビット幅以上である場合や負である場合でも未定義動作とならず、定義された結果を返す。
+
+- (1) : 各要素をシフト量`s[i]`だけ右シフトする
+- (2) : すべての要素を同一のシフト量`s`だけ右シフトする
+
+
+## テンプレートパラメータ制約
+- (1) :
+    - `VX::value_type`と`VS::value_type`がそれぞれ符号付きまたは符号なし整数型であること
+    - `VX::size() == VS::size()`が`true`であること
+    - `sizeof(typename VX::value_type) == sizeof(typename VS::value_type)`が`true`であること
+- (2) :
+    - `V::value_type`と`S`がそれぞれ符号付きまたは符号なし整数型であること
+
+
+## 戻り値
+- (1) : `i`番目の要素が`std::shr(x[i], s[i])`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+- (2) : `i`番目の要素が`std::shr(x[i], s)`で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す
+
+
+## 例外
+投げない
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+#include <cstdint>
+
+namespace simd = std::simd;
+
+int main()
+{
+  // {0x0001, 0x0010, 0x0100, 0x1000}
+  simd::vec<std::uint16_t, 4> v {[](int i) {
+    return static_cast<std::uint16_t>(1u << (i * 4));
+  }};
+
+  // 各要素を4ビットだけ論理右シフトする
+  simd::vec<std::uint16_t, 4> r = simd::shr(v, 4);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::println("{:016b} -> {:016b}", v[i], r[i]);
+  }
+}
+```
+* simd::shr[color ff0000]
+
+### 出力
+```
+0000000000000001 -> 0000000000000000
+0000000000010000 -> 0000000000000001
+0000000100000000 -> 0000000000010000
+0001000000000000 -> 0000000100000000
+```
+
+
+## バージョン
+### 言語
+- C++29
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::shl`](shl.md)
+
+
+## 参照
+- [P3793R1 Better shifting](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3793r1.html)
+    - C++29で`<bit>`ヘッダにスカラー版、`<simd>`ヘッダに`std::simd`版の`shr`が追加された

--- a/reference/simd/signbit.md
+++ b/reference/simd/signbit.md
@@ -1,0 +1,75 @@
+# signbit
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr typename deduced-vec-t<V>::mask_type
+    signbit(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)について、各要素の符号ビットが設定されている（値が負である）かを判定する。各要素に[`std::signbit`](/reference/cmath/signbit.md)を適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはそれと組み合わせて[`basic_vec`](basic_vec.md)を導出できる型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、引数から導出される[`basic_vec`](basic_vec.md)型である。戻り値の型`deduced-vec-t<V>::mask_type`は、要素ごとの判定結果を保持する[`basic_mask`](basic_mask.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`の符号ビットが設定されていれば`true`、そうでなければ`false`となる[`basic_mask`](basic_mask.md)オブジェクトを返す。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{
+    [](int i) { return i % 2 == 0 ? -(i + 1.0f) : (i + 1.0f); }
+  }; // {-1, 2, -3, 4}
+
+  simd::vec<float, 4>::mask_type m = simd::signbit(v);
+
+  for (std::size_t i = 0; i < m.size(); ++i)
+    std::print("{} ", m[i]);
+  std::println("");
+}
+```
+* simd::signbit[color ff0000]
+* simd::vec[link basic_vec.md]
+* m.size()[link basic_mask/size.md]
+
+### 出力
+```
+true false true false 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::copysign`](copysign.md)
+- [`std::simd::fpclassify`](fpclassify.md)
+- [`std::signbit`](/reference/cmath/signbit.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/simd-complex-value-type.md
+++ b/reference/simd/simd-complex-value-type.md
@@ -1,0 +1,31 @@
+# simd-complex-value-type
+* [meta exposition-only]
+* simd[meta header]
+* type-alias[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V>
+  using simd-complex-value-type = typename V::value_type::value_type;
+}
+```
+
+## 概要
+`simd-complex-value-type`は、複素数を要素とする[`basic_vec`](basic_vec.md)の、実数部・虚数部の型を表す説明専用の型エイリアスである。
+
+要素型が`std::complex<U>`のとき、`simd-complex-value-type<V>`は`U`（`V::value_type::value_type`）となる。[`real`](real.md)・[`imag`](imag.md)・[`norm`](norm.md)・[`arg`](arg.md)などの戻り値型（実数型の[`basic_vec`](basic_vec.md)）を表すために使用され、説明専用コンセプト[`simd-complex`](simd-complex.md)の定義にも用いられる。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::simd-complex`](simd-complex.md)
+- [`std::simd::real`](real.md)
+- [`std::simd::imag`](imag.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/simd-complex.md
+++ b/reference/simd/simd-complex.md
@@ -1,0 +1,36 @@
+# simd-complex
+* [meta exposition-only]
+* simd[meta header]
+* concept[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V>
+  concept simd-complex =
+    simd-vec-type<V> &&
+    same_as<typename V::value_type, complex<simd-complex-value-type<V>>>;
+}
+```
+* simd-complex-value-type[link /reference/simd/simd-complex-value-type.md]
+* simd-vec-type[link simd-vec-type.md]
+* complex[link /reference/complex/complex.md]
+
+## 概要
+`simd-complex`は、型`V`が[`basic_vec`](basic_vec.md)の特殊化（[`simd-vec-type`](simd-vec-type.md)）であり、かつその要素型が[`std::complex`](/reference/complex/complex.md)の特殊化であることを表す説明専用のコンセプトである。
+
+要素の実数部・虚数部の型は、説明専用の`simd-complex-value-type<V>`（`V::value_type::value_type`）で表される。このコンセプトは、[`real`](real.md)・[`imag`](imag.md)・[`arg`](arg.md)・[`conj`](conj.md)などの複素数用の関数のテンプレートパラメータ制約として使用される。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::simd-vec-type`](simd-vec-type.md)
+- [`std::simd::real`](real.md)
+- [`std::simd::imag`](imag.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/simd-floating-point.md
+++ b/reference/simd/simd-floating-point.md
@@ -1,0 +1,32 @@
+# simd-floating-point
+* [meta exposition-only]
+* simd[meta header]
+* concept[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V>
+  concept simd-floating-point =
+    simd-vec-type<V> && floating_point<typename V::value_type>;
+}
+```
+* simd-vec-type[link simd-vec-type.md]
+* floating_point[link /reference/concepts/floating_point.md]
+
+## 概要
+`simd-floating-point`は、型`V`が[`basic_vec`](basic_vec.md)の特殊化（[`simd-vec-type`](simd-vec-type.md)）であり、かつその要素型が浮動小数点数型（[`std::floating_point`](/reference/concepts/floating_point.md)のモデル）であることを表す説明専用のコンセプトである。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::simd-vec-type`](simd-vec-type.md)
+- [`std::simd::simd-integral`](simd-integral.md)
+- [`std::simd::math-floating-point`](math-floating-point.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/simd-integral.md
+++ b/reference/simd/simd-integral.md
@@ -1,0 +1,33 @@
+# simd-integral
+* [meta exposition-only]
+* simd[meta header]
+* concept[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V>
+  concept simd-integral =
+    simd-vec-type<V> && integral<typename V::value_type>;
+}
+```
+* simd-vec-type[link simd-vec-type.md]
+* integral[link /reference/concepts/integral.md]
+
+## 概要
+`simd-integral`は、型`V`が[`basic_vec`](basic_vec.md)の特殊化（[`simd-vec-type`](simd-vec-type.md)）であり、かつその要素型が整数型（[`std::integral`](/reference/concepts/integral.md)のモデル）であることを表す説明専用のコンセプトである。
+
+このコンセプトは、gather／scatterのインデックスや、bit操作系の関数のテンプレートパラメータ制約として使用される。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::simd-vec-type`](simd-vec-type.md)
+- [`std::simd::simd-floating-point`](simd-floating-point.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/simd-mask-type.md
+++ b/reference/simd/simd-mask-type.md
@@ -1,0 +1,35 @@
+# simd-mask-type
+* [meta exposition-only]
+* simd[meta header]
+* concept[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V>
+  concept simd-mask-type =
+    same_as<V, basic_mask<mask-element-size<V>, typename V::abi_type>> &&
+    is_default_constructible_v<V>;
+}
+```
+* mask-element-size[link /reference/simd/mask-element-size.md]
+* basic_mask[link basic_mask.md]
+* is_default_constructible_v[link /reference/type_traits/is_default_constructible.md]
+
+## 概要
+`simd-mask-type`は、型`V`が[`basic_mask`](basic_mask.md)の特殊化であることを表す説明専用のコンセプトである。
+
+`V`が、対応する要素サイズ（説明専用の`mask-element-size<V>`）と自身の`abi_type`から構築される`basic_mask`と同じ型であり、かつデフォルト構築可能である場合にモデルとなる。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_mask`](basic_mask.md)
+- [`std::simd::simd-vec-type`](simd-vec-type.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/simd-size-type.md
+++ b/reference/simd/simd-size-type.md
@@ -1,0 +1,29 @@
+# simd-size-type
+* [meta exposition-only]
+* simd[meta header]
+* type-alias[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  using simd-size-type = /*see below*/;
+}
+```
+
+## 概要
+`simd-size-type`は、データ並列型の要素数（幅）や、要素のインデックスを表すために使用される、符号付き整数型のエイリアスである（説明専用）。
+
+[`basic_vec`](basic_vec.md)・[`basic_mask`](basic_mask.md)の`size()`の戻り値型や、[`permute`](permute.md)のインデックス写像、[`reduce_count`](reduce_count.md)などの戻り値型として使用される。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::simd-size-v`](simd-size-v.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/simd-size-v.md
+++ b/reference/simd/simd-size-v.md
@@ -1,0 +1,33 @@
+# simd-size-v
+* [meta exposition-only]
+* simd[meta header]
+* variable[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T, class Abi>
+  constexpr simd-size-type simd-size-v = /*see below*/;
+}
+```
+* simd-size-type[link simd-size-type.md]
+
+## 概要
+`simd-size-v`は、[`basic_vec`](basic_vec.md)`<T, Abi>`の幅（要素数）を表す説明専用の変数テンプレートである。
+
+`basic_vec<T, Abi>`が有効な特殊化であればその要素数を、そうでなければ`0`を表す。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::simd-size-type`](simd-size-type.md)
+- [`std::simd::mask-size-v`](mask-size-v.md)
+- [`std::simd::deduce-abi-t`](deduce-abi-t.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/simd-vec-type.md
+++ b/reference/simd/simd-vec-type.md
@@ -1,0 +1,37 @@
+# simd-vec-type
+* [meta exposition-only]
+* simd[meta header]
+* concept[meta id-type]
+* std::simd[meta namespace]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V>
+  concept simd-vec-type =
+    same_as<V, basic_vec<typename V::value_type, typename V::abi_type>> &&
+    is_default_constructible_v<V>;
+}
+```
+* basic_vec[link basic_vec.md]
+* is_default_constructible_v[link /reference/type_traits/is_default_constructible.md]
+
+## 概要
+`simd-vec-type`は、型`V`が[`basic_vec`](basic_vec.md)の特殊化であることを表す説明専用のコンセプトである。
+
+`V`が、自身の`value_type`と`abi_type`から構築される`basic_vec<value_type, abi_type>`と同じ型であり、かつデフォルト構築可能である場合にモデルとなる。`std::simd`の多くの関数は、このコンセプト（およびこれを土台とする[`simd-floating-point`](simd-floating-point.md)・[`simd-integral`](simd-integral.md)・[`simd-complex`](simd-complex.md)）をテンプレートパラメータ制約として使用する。
+
+## バージョン
+### 言語
+- C++26
+
+## 関連項目
+- [`std::simd::basic_vec`](basic_vec.md)
+- [`std::simd::simd-mask-type`](simd-mask-type.md)
+- [`std::simd::simd-floating-point`](simd-floating-point.md)
+- [`std::simd::simd-integral`](simd-integral.md)
+- [`std::simd::simd-complex`](simd-complex.md)
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/sin.md
+++ b/reference/simd/sin.md
@@ -1,0 +1,125 @@
+# sin
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> sin(const V& x);  // (1) C++26
+
+  template<simd-complex V>
+  constexpr V sin(const V& v);                 // (2) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、正弦（サイン）を求める。
+
+- (1) : 要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の正弦を求める。
+- (2) : 要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素の正弦を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。
+
+
+## 戻り値
+- (1) : 各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`sin`](/reference/cmath/sin.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+- (2) : 各要素`i`（`0`以上`V::size()`未満）について、`v[i]`に[`<complex>`](/reference/complex/complex.md)の[`sin`](/reference/complex/complex/sin.md)を適用した結果で初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+### 基本的な使い方
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i * 0.5f; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の正弦を求める
+  simd::vec<float, 4> r = simd::sin(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::sin[color ff0000]
+
+#### 出力例
+```
+0 0.479426 0.841471 0.997495 
+```
+
+### 複素数版
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i * 1.0f, 0.0f); }
+  };  // {(0, 0), (1, 0)}
+
+  // 各要素の正弦を求める
+  simd::vec<std::complex<float>, 2> r = simd::sin(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::complex<float> c = r[i];
+    std::print("({}, {}) ", c.real(), c.imag());
+  }
+  std::println("");
+}
+```
+* simd::sin[color ff0000]
+
+#### 出力例
+```
+(0, 0) (0.841471, 0) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::cos`](cos.md)
+- [`std::simd::tan`](tan.md)
+- [`std::simd::asin`](asin.md)
+- [`std::simd::sinh`](sinh.md)
+- [`sin`](/reference/cmath/sin.md)
+- [`std::complex::sin`](/reference/complex/complex/sin.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数関連の関数が追加された

--- a/reference/simd/sinh.md
+++ b/reference/simd/sinh.md
@@ -1,0 +1,80 @@
+# sinh
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> sinh(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の双曲線正弦（ハイパボリックサイン）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`sinh`](/reference/cmath/sinh.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i * 0.5f; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の双曲線正弦を求める
+  simd::vec<float, 4> r = simd::sinh(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::sinh[color ff0000]
+
+### 出力例
+```
+0 0.521095 1.1752 2.12928 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::cosh`](cosh.md)
+- [`std::simd::tanh`](tanh.md)
+- [`std::simd::asinh`](asinh.md)
+- [`std::simd::sin`](sin.md)
+- [`sinh`](/reference/cmath/sinh.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/sph_bessel.md
+++ b/reference/simd/sph_bessel.md
@@ -1,0 +1,83 @@
+# sph_bessel
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V> sph_bessel(const rebind_t<unsigned, deduced-vec-t<V>>& n, const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`sph_bessel`](/reference/cmath/sph_bessel.md)を適用し、各要素について、次数`n`の第一種球ベッセル関数の`x`での値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+`rebind_t<unsigned, deduced-vec-t<V>>`は、[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)と同じ要素数をもつ`unsigned`要素型の[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`n[i]`と`x[i]`に[`<cmath>`](/reference/cmath.md)の[`sph_bessel`](/reference/cmath/sph_bessel.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<unsigned, 2> n = 0u;                          // 次数0
+  simd::vec<double, 2> x([](int i) { return i + 1.0; });  // {1, 2}
+
+  // 各要素について次数0の第一種球ベッセル関数の値を求める
+  simd::vec<double, 2> r = simd::sph_bessel(n, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::sph_bessel[color ff0000]
+
+### 出力例
+```
+0.8414709848078965 0.45464871341284085 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sph_neumann`](sph_neumann.md)
+- [`std::simd::cyl_bessel_j`](cyl_bessel_j.md)
+- [`std::sph_bessel`](/reference/cmath/sph_bessel.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/sph_legendre.md
+++ b/reference/simd/sph_legendre.md
@@ -1,0 +1,87 @@
+# sph_legendre
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    sph_legendre(const rebind_t<unsigned, deduced-vec-t<V>>& l,
+                 const rebind_t<unsigned, deduced-vec-t<V>>& m,
+                 const V& theta); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`sph_legendre`](/reference/cmath/sph_legendre.md)を適用し、各要素について、次数`l`・位数`m`の球面調和関数に対応するルジャンドル陪関数の`theta`での値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+`rebind_t<unsigned, deduced-vec-t<V>>`は、[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)と同じ要素数をもつ`unsigned`要素型の[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`l[i]`・`m[i]`・`theta[i]`に[`<cmath>`](/reference/cmath.md)の[`sph_legendre`](/reference/cmath/sph_legendre.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<unsigned, 2> l = 0u; // 次数0
+  simd::vec<unsigned, 2> m = 0u; // 位数0
+  simd::vec<double, 2> theta([](int i) { return i * 0.5 + 0.5; }); // {0.5, 1}
+
+  // 各要素について次数0・位数0の球面調和関数のルジャンドル陪関数の値を求める
+  simd::vec<double, 2> r = simd::sph_legendre(l, m, theta);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::sph_legendre[color ff0000]
+
+### 出力例
+```
+0.28209479177387814 0.28209479177387814 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::assoc_legendre`](assoc_legendre.md)
+- [`std::simd::legendre`](legendre.md)
+- [`std::sph_legendre`](/reference/cmath/sph_legendre.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/sph_neumann.md
+++ b/reference/simd/sph_neumann.md
@@ -1,0 +1,85 @@
+# sph_neumann
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  deduced-vec-t<V>
+    sph_neumann(const rebind_t<unsigned, deduced-vec-t<V>>& n,
+                const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* rebind_t[link rebind.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`sph_neumann`](/reference/cmath/sph_neumann.md)を適用し、各要素について、次数`n`の第二種球ベッセル関数（球ノイマン関数）の`x`での値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+`rebind_t<unsigned, deduced-vec-t<V>>`は、[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)と同じ要素数をもつ`unsigned`要素型の[`basic_vec`](basic_vec.md)である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`n[i]`と`x[i]`に[`<cmath>`](/reference/cmath.md)の[`sph_neumann`](/reference/cmath/sph_neumann.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<unsigned, 2> n = 0u;                          // 次数0
+  simd::vec<double, 2> x([](int i) { return i + 1.0; });  // {1, 2}
+
+  // 各要素について次数0の第二種球ベッセル関数の値を求める
+  simd::vec<double, 2> r = simd::sph_neumann(n, x);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::sph_neumann[color ff0000]
+
+### 出力例
+```
+-0.5403023058681398 0.20807341827357127 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sph_bessel`](sph_bessel.md)
+- [`std::simd::cyl_neumann`](cyl_neumann.md)
+- [`std::sph_neumann`](/reference/cmath/sph_neumann.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/sqrt.md
+++ b/reference/simd/sqrt.md
@@ -1,0 +1,128 @@
+# sqrt
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> sqrt(const V& x); // (1) C++26
+
+  template<simd-complex V>
+  constexpr V sqrt(const V& v);                // (2) C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+* simd-complex[link /reference/simd/simd-complex.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、平方根を求める。
+
+- (1) : 浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)について、各要素に[`<cmath>`](/reference/cmath.md)の[`sqrt`](/reference/cmath/sqrt.md)を要素ごとに適用する。
+- (2) : 要素型が`std::complex<T>`の[`basic_vec`](basic_vec.md)について、各要素に[`<complex>`](/reference/complex/complex.md)の[`sqrt`](/reference/complex/complex/sqrt.md)を要素ごとに適用する。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数型を要素とする[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は`V`から導出される[`basic_vec`](basic_vec.md)型（通常は`V`自身）を表す。制約[`simd-complex`](/reference/simd/simd-complex.md)は、`V`が要素型`std::complex<T>`の[`basic_vec`](basic_vec.md)であることを表す説明専用のコンセプトである。
+
+
+## 戻り値
+各要素`i`（`0`以上`V::size()`未満）について、`v[i]`（`x[i]`）に対応する`sqrt`を適用した結果に要素ごとに等しい[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+- (1) : [`<cmath>`](/reference/cmath.md)の[`sqrt`](/reference/cmath/sqrt.md)を適用する。
+- (2) : [`<complex>`](/reference/complex/complex.md)の[`sqrt`](/reference/complex/complex/sqrt.md)を適用する。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+### 基本的な使い方
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    float table[] = {1.0f, 4.0f, 9.0f, 16.0f};
+    return table[i];
+  }};
+
+  // 各要素の平方根を求める
+  simd::vec<float, 4> r = simd::sqrt(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::sqrt[color ff0000]
+
+#### 出力例
+```
+1 2 3 4 
+```
+
+### 複素数版 (2)
+```cpp example
+#include <simd>
+#include <complex>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<std::complex<float>, 2> v{
+    [](int i) { return std::complex<float>(i + 1.0f, 0.0f); }
+  };  // {(1, 0), (2, 0)}
+
+  // 各要素の平方根を求める
+  simd::vec<std::complex<float>, 2> r = simd::sqrt(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::complex<float> c = r[i];
+    std::print("({}, {}) ", c.real(), c.imag());
+  }
+  std::println("");
+}
+```
+* simd::sqrt[color ff0000]
+
+#### 出力例
+```
+(1, 0) (1.41421, 0) 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::cbrt`](cbrt.md)
+- [`std::simd::hypot`](hypot.md)
+- [`std::simd::pow`](pow.md)
+- [`std::simd::exp`](exp.md)
+- [`std::simd::log`](log.md)
+- [`std::sqrt`](/reference/cmath/sqrt.md)
+- [`std::complex::sqrt`](/reference/complex/complex/sqrt.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加され、実数版の`sqrt` (1) が追加された
+- [P2663R7 Interleaved complex values support in std::simd](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2663r7.html)
+    - 要素型が複素数の`basic_vec`に対する複素数版の`sqrt` (2) が追加された

--- a/reference/simd/tan.md
+++ b/reference/simd/tan.md
@@ -1,0 +1,80 @@
+# tan
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> tan(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の正接（タンジェント）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`tan`](/reference/cmath/tan.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i * 0.5f; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の正接を求める
+  simd::vec<float, 4> r = simd::tan(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::tan[color ff0000]
+
+### 出力例
+```
+0 0.546302 1.55741 14.1014 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sin`](sin.md)
+- [`std::simd::cos`](cos.md)
+- [`std::simd::atan`](atan.md)
+- [`std::simd::tanh`](tanh.md)
+- [`tan`](/reference/cmath/tan.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/tanh.md
+++ b/reference/simd/tanh.md
@@ -1,0 +1,80 @@
+# tanh
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> tanh(const V& x);  // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+要素型が浮動小数点数の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数`x`について、各要素の双曲線正接（ハイパボリックタンジェント）を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点数の[「vectorizable type」](/reference/simd.md#vectorizable-type)を要素とする[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点数であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`decltype(x + x)`）である。
+
+
+## 戻り値
+各要素`i`について、`x`の各要素に[`<cmath>`](/reference/cmath.md)の[`tanh`](/reference/cmath/tanh.md)を適用した結果を要素とする[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v([](int i) { return i * 0.5f; }); // {0, 0.5, 1, 1.5}
+
+  // 各要素の双曲線正接を求める
+  simd::vec<float, 4> r = simd::tanh(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::tanh[color ff0000]
+
+### 出力例
+```
+0 0.462117 0.761594 0.905148 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::sinh`](sinh.md)
+- [`std::simd::cosh`](cosh.md)
+- [`std::simd::atanh`](atanh.md)
+- [`std::simd::tan`](tan.md)
+- [`tanh`](/reference/cmath/tanh.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリが追加された

--- a/reference/simd/tgamma.md
+++ b/reference/simd/tgamma.md
@@ -1,0 +1,78 @@
+# tgamma
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> tgamma(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+浮動小数点要素型の[`basic_vec`](basic_vec.md)（またはスカラーの浮動小数点数）について、各要素に[`<cmath>`](/reference/cmath.md)の[`tgamma`](/reference/cmath/tgamma.md)を適用し、各要素のガンマ関数の値を求める。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素型の[`basic_vec`](basic_vec.md)、またはスカラーの浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応するデータ並列型（`V`がスカラーの場合は既定のABIをもつ[`basic_vec`](basic_vec.md)）である。
+
+
+## 戻り値
+各要素`i`（`0`以上`deduced-vec-t<V>::size()`未満）について、`x[i]`に[`<cmath>`](/reference/cmath.md)の[`tgamma`](/reference/cmath/tgamma.md)を適用した結果で要素ごとに初期化された[`basic_vec`](basic_vec.md)オブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<double, 4> v([](int i) { return i + 1.0; }); // {1, 2, 3, 4}
+
+  // 各要素のガンマ関数を求める
+  simd::vec<double, 4> r = simd::tgamma(v);
+
+  for (std::size_t i = 0; i < r.size(); ++i) {
+    std::print("{} ", r[i]);
+  }
+  std::println("");
+}
+```
+* simd::tgamma[color ff0000]
+
+### 出力例
+```
+1 1 2 6 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::lgamma`](lgamma.md)
+- [`std::tgamma`](/reference/cmath/tgamma.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された
+

--- a/reference/simd/trunc.md
+++ b/reference/simd/trunc.md
@@ -1,0 +1,82 @@
+# trunc
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<math-floating-point V>
+  constexpr deduced-vec-t<V> trunc(const V& x); // C++26
+}
+```
+* deduced-vec-t[link /reference/simd/deduced-vec-t.md]
+* math-floating-point[link /reference/simd/math-floating-point.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素について、小数点以下を切り捨てて絶対値が元の値を超えない最も近い整数値を求める（0方向への丸め）。
+
+制約[`math-floating-point`](/reference/simd/math-floating-point.md)は、`V`が浮動小数点要素の[`basic_vec`](basic_vec.md)、またはそこから[`basic_vec`](basic_vec.md)を導出可能なスカラー浮動小数点型であることを表す説明専用のコンセプトである。[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)は、`V`に対応する[`basic_vec`](basic_vec.md)型（`V`がスカラー型のときはそれを要素型とする[`basic_vec`](basic_vec.md)）を表す。
+
+
+## 戻り値
+各要素`i`について、`x`の対応する要素に[`<cmath>`](/reference/cmath.md)の[`trunc`](/reference/cmath/trunc.md)を適用した結果で初期化された[`deduced-vec-t<V>`](/reference/simd/deduced-vec-t.md)型のオブジェクトを返す。
+
+ある要素`i`について定義域エラー・極エラー・値域エラーが発生する場合、その要素の値は未規定である。
+
+
+## 備考
+[`errno`](/reference/cerrno/errno.md)にアクセスするか否かは未規定である。
+
+
+## 例
+```cpp example
+#include <simd>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<float, 4> v{[](int i) {
+    constexpr float a[] = {1.2f, 2.7f, -1.2f, -2.7f};
+    return a[i];
+  }};
+
+  // 各要素を0方向へ丸める
+  simd::vec<float, 4> r = simd::trunc(v);
+
+  for (int i = 0; i < r.size(); ++i)
+    std::print("{} ", r[i]);
+  std::println("");
+}
+```
+* simd::trunc[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+1 2 -1 -2 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::ceil`](ceil.md)
+- [`std::simd::floor`](floor.md)
+- [`std::simd::round`](round.md)
+- [`std::trunc`](/reference/cmath/trunc.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で追加された

--- a/reference/simd/unchecked_gather_from.md
+++ b/reference/simd/unchecked_gather_from.md
@@ -1,0 +1,105 @@
+# unchecked_gather_from
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V = /*see below*/,
+           ranges::contiguous_range R,
+           simd-integral I,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr V
+    unchecked_gather_from(R&& in,
+                          const I& indices,
+                          flags<Flags...> f = {}); // (1) C++26
+
+  template<class V = /*see below*/,
+           ranges::contiguous_range R,
+           simd-integral I,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr V
+    unchecked_gather_from(R&& in,
+                          const typename I::mask_type& mask,
+                          const I& indices,
+                          flags<Flags...> f = {}); // (2) C++26
+}
+```
+* simd-integral[link /reference/simd/simd-integral.md]
+* ranges::contiguous_range[link /reference/ranges/contiguous_range.md]
+* ranges::sized_range[link /reference/ranges/sized_range.md]
+
+## 概要
+連続したメモリ領域`in`から、インデックスを表すデータ並列型`indices`で指定した飛び飛びの位置の要素を集めて（gather）、[`basic_vec`](basic_vec.md)へ読み込む。結果の`i`番目の要素は、`in`の`indices[i]`番目の要素となる。境界チェックをおこなわない高速なgatherである。
+
+- (1) : 全要素を集める
+- (2) : `mask`の各要素が`true`である位置の要素のみを集め、`false`の位置は値初期化された値（`0`など）とする
+
+- `V` : 結果のデータ並列型。省略した場合は`vec<std::ranges::range_value_t<R>, I::size()>`が使われる
+- `indices` : 各要素が読み込み位置のインデックスを表す、整数要素のデータ並列型
+- `f` : gatherの動作を指定する`flags`オブジェクト。既定値は`flag_default`。要素型が異なるメモリからの変換読み込みを許可する`flag_convert`や、メモリのアライメントを仮定する`flag_aligned`／`flag_overaligned<N>`を指定できる
+
+## 事前条件
+`select(mask, indices, typename I::value_type())`のすべての値が、範囲`[0, std::ranges::size(in))`に含まれること。
+
+## 効果
+[`partial_gather_from`](partial_gather_from.md)`<V>(in, mask, indices, f)`を返すことと等価である。ただし (1) では`mask`は`typename I::mask_type(true)`（すべて`true`）とみなす。
+
+## 戻り値
+集めた結果の[`basic_vec`](basic_vec.md)オブジェクト。
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::array<int, 8> data = {10, 11, 12, 13, 14, 15, 16, 17};
+
+  // インデックス {0, 2, 4, 6} の位置の要素を集める
+  simd::vec<int, 4> indices([](int i) { return i * 2; });
+
+  auto v = simd::unchecked_gather_from<simd::vec<int, 4>>(data, indices);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::print("{} ", v[i]);
+  }
+  std::println("");
+}
+```
+* simd::unchecked_gather_from[color ff0000]
+* simd::vec[link basic_vec.md]
+* v.size()[link basic_vec/size.md]
+
+### 出力
+```
+10 12 14 16 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::partial_gather_from`](partial_gather_from.md)
+- [`std::simd::unchecked_scatter_to`](unchecked_scatter_to.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリに追加された

--- a/reference/simd/unchecked_load.md
+++ b/reference/simd/unchecked_load.md
@@ -1,0 +1,146 @@
+# unchecked_load
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class V = /*see below*/,
+           ranges::contiguous_range R,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr V
+    unchecked_load(R&& r,
+                   flags<Flags...> f = {}); // (1) C++26
+
+  template<class V = /*see below*/,
+           ranges::contiguous_range R,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr V
+    unchecked_load(R&& r,
+                   const typename V::mask_type& mask,
+                   flags<Flags...> f = {}); // (2) C++26
+
+  template<class V = /*see below*/,
+           contiguous_iterator I,
+           class... Flags>
+  constexpr V
+    unchecked_load(I first,
+                   iter_difference_t<I> n,
+                   flags<Flags...> f = {}); // (3) C++26
+
+  template<class V = /*see below*/,
+           contiguous_iterator I,
+           class... Flags>
+  constexpr V
+    unchecked_load(I first,
+                   iter_difference_t<I> n,
+                   const typename V::mask_type& mask,
+                   flags<Flags...> f = {}); // (4) C++26
+
+  template<class V = /*see below*/,
+           contiguous_iterator I,
+           sized_sentinel_for<I> S,
+           class... Flags>
+  constexpr V
+    unchecked_load(I first,
+                   S last,
+                   flags<Flags...> f = {}); // (5) C++26
+
+  template<class V = /*see below*/,
+           contiguous_iterator I,
+           sized_sentinel_for<I> S,
+           class... Flags>
+  constexpr V
+    unchecked_load(I first,
+                   S last,
+                   const typename V::mask_type& mask,
+                   flags<Flags...> f = {}); // (6) C++26
+}
+```
+* ranges::contiguous_range[link /reference/ranges/contiguous_range.md]
+* ranges::sized_range[link /reference/ranges/sized_range.md]
+* contiguous_iterator[link /reference/iterator/contiguous_iterator.md]
+* sized_sentinel_for[link /reference/iterator/sized_sentinel_for.md]
+* iter_difference_t[link /reference/iterator/iter_difference_t.md]
+
+## 概要
+連続したメモリ領域から[`basic_vec`](basic_vec.md)へ、要素をまとめて読み込む。境界チェックをおこなわない高速な読み込みである。
+
+入力範囲の指定方法によって、以下のオーバーロードがある。
+
+- (1), (2) : 連続範囲`r`（[`std::vector`](/reference/vector/vector.md)や[`std::array`](/reference/array/array.md)、[`std::span`](/reference/span/span.md)など）から読み込む
+- (3), (4) : 先頭イテレータ`first`と要素数`n`で指定した範囲から読み込む
+- (5), (6) : 先頭イテレータ`first`と番兵`last`で指定した範囲から読み込む
+
+`mask`を受け取るオーバーロード (2), (4), (6) は、マスクの各要素が`true`である位置の要素のみを読み込み、`false`の位置は値初期化された値（`0`など）とする。
+
+- `V` : 結果のデータ並列型。省略した場合は`basic_vec<std::ranges::range_value_t<R>>`（先頭イテレータ版では`basic_vec<iter_value_t<I>>`）が使われる
+- `f` : 読み込みの動作を指定する`flags`オブジェクト。既定値は`flag_default`。要素型が異なるメモリからの変換読み込みを許可する`flag_convert`や、メモリのアライメントを仮定してより効率的な読み込みをおこなう`flag_aligned`／`flag_overaligned<N>`を指定できる
+
+## 適格要件
+`std::ranges::size(r)`が定数式である場合、`std::ranges::size(r) >= V::size()`であること。
+
+## 事前条件
+- (3), (4) : 範囲`[first, first + n)`が有効な範囲であること
+- (5), (6) : 範囲`[first, last)`が有効な範囲であること
+- すべてのオーバーロードにおいて、`std::ranges::size(r) >= V::size()`であること。すなわち、入力範囲の要素数が結果の要素数以上であること
+
+## 効果
+[`partial_load`](partial_load.md)`<V>(r, mask, f)`を返すことと等価である。ただし`mask`を受け取らないオーバーロードでは`mask`は`V::mask_type(true)`（すべて`true`）とみなす。
+
+## 戻り値
+読み込んだ結果の[`basic_vec`](basic_vec.md)オブジェクト。
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  std::array<int, 4> data = {1, 2, 3, 4};
+
+  // 配列からデータ並列型へ読み込む
+  auto v = simd::unchecked_load<simd::vec<int, 4>>(data);
+
+  for (int i = 0; i < v.size(); ++i) {
+    std::print("{} ", v[i]);
+  }
+  std::println("");
+}
+```
+* simd::unchecked_load[color ff0000]
+* simd::vec[link basic_vec.md]
+* v.size()[link basic_vec/size.md]
+
+### 出力
+```
+1 2 3 4 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::partial_load`](partial_load.md)
+- [`std::simd::unchecked_store`](unchecked_store.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリに追加された

--- a/reference/simd/unchecked_scatter_to.md
+++ b/reference/simd/unchecked_scatter_to.md
@@ -1,0 +1,108 @@
+# unchecked_scatter_to
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<simd-vec-type V,
+           ranges::contiguous_range R,
+           simd-integral I,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr void
+    unchecked_scatter_to(const V& v,
+                         R&& out,
+                         const I& indices,
+                         flags<Flags...> f = {}); // (1) C++26
+
+  template<simd-vec-type V,
+           ranges::contiguous_range R,
+           simd-integral I,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr void
+    unchecked_scatter_to(const V& v,
+                         R&& out,
+                         const typename I::mask_type& mask,
+                         const I& indices,
+                         flags<Flags...> f = {}); // (2) C++26
+}
+```
+* simd-vec-type[link /reference/simd/simd-vec-type.md]
+* simd-integral[link /reference/simd/simd-integral.md]
+* ranges::contiguous_range[link /reference/ranges/contiguous_range.md]
+* ranges::sized_range[link /reference/ranges/sized_range.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の各要素を、インデックスを表すデータ並列型`indices`で指定した連続メモリ領域`out`の飛び飛びの位置へ書き出す（scatter）。`v`の`i`番目の要素は、`out`の`indices[i]`番目の位置へ書き込まれる。境界チェックをおこなわない高速なscatterである。
+
+- (1) : 全要素を書き出す
+- (2) : `mask`の各要素が`true`である位置の要素のみを書き出す
+
+- `v` : scatterするデータ並列型の値
+- `indices` : 各要素が書き込み位置のインデックスを表す、整数要素のデータ並列型
+- `f` : scatterの動作を指定する`flags`オブジェクト。既定値は`flag_default`。要素型が異なるメモリへの変換書き込みを許可する`flag_convert`や、メモリのアライメントを仮定する`flag_aligned`／`flag_overaligned<N>`を指定できる
+
+## 事前条件
+`select(mask, indices, typename I::value_type())`のすべての値が、範囲`[0, std::ranges::size(out))`に含まれること。
+
+## 効果
+[`partial_scatter_to`](partial_scatter_to.md)`(v, out, mask, indices, f)`と等価である。ただし (1) では`mask`は`typename I::mask_type(true)`（すべて`true`）とみなす。
+
+## 戻り値
+なし。
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return (i + 1) * 10; }); // {10, 20, 30, 40}
+
+  // インデックス {0, 2, 4, 6} の位置へ書き出す
+  simd::vec<int, 4> indices([](int i) { return i * 2; });
+
+  std::array<int, 8> out{};
+  simd::unchecked_scatter_to(v, out, indices);
+
+  for (int x : out) {
+    std::print("{} ", x);
+  }
+  std::println("");
+}
+```
+* simd::unchecked_scatter_to[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+10 0 20 0 30 0 40 0 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::partial_scatter_to`](partial_scatter_to.md)
+- [`std::simd::unchecked_gather_from`](unchecked_gather_from.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリに追加された

--- a/reference/simd/unchecked_store.md
+++ b/reference/simd/unchecked_store.md
@@ -1,0 +1,158 @@
+# unchecked_store
+* simd[meta header]
+* std::simd[meta namespace]
+* function template[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+namespace std::simd {
+  template<class T,
+           class Abi,
+           ranges::contiguous_range R,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr void
+    unchecked_store(const basic_vec<T, Abi>& v,
+                    R&& r,
+                    flags<Flags...> f = {}); // (1) C++26
+
+  template<class T,
+           class Abi,
+           ranges::contiguous_range R,
+           class... Flags>
+    requires ranges::sized_range<R>
+  constexpr void
+    unchecked_store(const basic_vec<T, Abi>& v,
+                    R&& r,
+                    const typename basic_vec<T, Abi>::mask_type& mask,
+                    flags<Flags...> f = {}); // (2) C++26
+
+  template<class T,
+           class Abi,
+           contiguous_iterator I,
+           class... Flags>
+  constexpr void
+    unchecked_store(const basic_vec<T, Abi>& v,
+                    I first,
+                    iter_difference_t<I> n,
+                    flags<Flags...> f = {}); // (3) C++26
+
+  template<class T,
+           class Abi,
+           contiguous_iterator I,
+           class... Flags>
+  constexpr void
+    unchecked_store(const basic_vec<T, Abi>& v,
+                    I first,
+                    iter_difference_t<I> n,
+                    const typename basic_vec<T, Abi>::mask_type& mask,
+                    flags<Flags...> f = {}); // (4) C++26
+
+  template<class T,
+           class Abi,
+           contiguous_iterator I,
+           sized_sentinel_for<I> S,
+           class... Flags>
+  constexpr void
+    unchecked_store(const basic_vec<T, Abi>& v,
+                    I first,
+                    S last,
+                    flags<Flags...> f = {}); // (5) C++26
+
+  template<class T,
+           class Abi,
+           contiguous_iterator I,
+           sized_sentinel_for<I> S,
+           class... Flags>
+  constexpr void
+    unchecked_store(const basic_vec<T, Abi>& v,
+                    I first,
+                    S last,
+                    const typename basic_vec<T, Abi>::mask_type& mask,
+                    flags<Flags...> f = {}); // (6) C++26
+}
+```
+* ranges::contiguous_range[link /reference/ranges/contiguous_range.md]
+* ranges::sized_range[link /reference/ranges/sized_range.md]
+* contiguous_iterator[link /reference/iterator/contiguous_iterator.md]
+* sized_sentinel_for[link /reference/iterator/sized_sentinel_for.md]
+* iter_difference_t[link /reference/iterator/iter_difference_t.md]
+
+## 概要
+[`basic_vec`](basic_vec.md)の全要素を、連続したメモリ領域へまとめて書き込む。境界チェックをおこなわない高速な書き込みである。
+
+出力範囲の指定方法によって、以下のオーバーロードがある。
+
+- (1), (2) : 連続範囲`r`（[`std::vector`](/reference/vector/vector.md)や[`std::array`](/reference/array/array.md)、[`std::span`](/reference/span/span.md)など）へ書き込む
+- (3), (4) : 先頭イテレータ`first`と要素数`n`で指定した範囲へ書き込む
+- (5), (6) : 先頭イテレータ`first`と番兵`last`で指定した範囲へ書き込む
+
+`mask`を受け取るオーバーロード (2), (4), (6) は、マスクの各要素が`true`である位置の要素のみを書き込む。
+
+- `v` : 書き込むデータ並列型の値
+- `f` : 書き込みの動作を指定する`flags`オブジェクト。既定値は`flag_default`。要素型が異なるメモリへの変換書き込みを許可する`flag_convert`や、メモリのアライメントを仮定してより効率的な書き込みをおこなう`flag_aligned`／`flag_overaligned<N>`を指定できる
+
+## 適格要件
+`std::ranges::size(r)`が定数式である場合、`std::ranges::size(r) >= simd-size-v<T, Abi>`であること。
+
+## 事前条件
+- (3), (4) : 範囲`[first, first + n)`が有効な範囲であること
+- (5), (6) : 範囲`[first, last)`が有効な範囲であること
+- すべてのオーバーロードにおいて、`std::ranges::size(r) >= simd-size-v<T, Abi>`であること。すなわち、出力範囲の要素数が書き込む値の要素数以上であること
+
+## 効果
+[`partial_store`](partial_store.md)`(v, r, mask, f)`と等価である。ただし`mask`を受け取らないオーバーロードでは`mask`は`basic_vec<T, Abi>::mask_type(true)`（すべて`true`）とみなす。
+
+## 戻り値
+なし。
+
+## 例
+```cpp example
+#include <simd>
+#include <array>
+#include <print>
+
+namespace simd = std::simd;
+
+int main()
+{
+  simd::vec<int, 4> v([](int i) { return (i + 1) * 10; }); // {10, 20, 30, 40}
+
+  // データ並列型を配列へ書き込む
+  std::array<int, 4> data{};
+  simd::unchecked_store(v, data);
+
+  for (int x : data) {
+    std::print("{} ", x);
+  }
+  std::println("");
+}
+```
+* simd::unchecked_store[color ff0000]
+* simd::vec[link basic_vec.md]
+
+### 出力
+```
+10 20 30 40 
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`std::simd::partial_store`](partial_store.md)
+- [`std::simd::unchecked_load`](unchecked_load.md)
+- [`std::simd::basic_vec`](basic_vec.md)
+
+
+## 参照
+- [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
+    - C++26で`std::simd`ライブラリに追加された


### PR DESCRIPTION
- https://github.com/cpprefjp/site/issues/1393

C++29にも対応した。
`<bit>`に追加される関数 (`bit_compress`とか) もついでに対応した。

一度一通り確認はしましたが、まだ何度か確認します。
レビューはしていただいて大丈夫です。