### PR TITLE
C++26 LWG Issueへの対応第1弾

### DIFF
--- a/lang/cpp26/feature_test_macros.md
+++ b/lang/cpp26/feature_test_macros.md
@@ -150,6 +150,8 @@
 |`__cpp_lib_smart_ptr_owner_equality`|`202306L`|[`<memory>`](/reference/memory.md)に[`std::owner_hash`](/reference/memory/owner_hash.md)と[`std::owner_equal`](/reference/memory/owner_equal.md)を追加|[`<memory>`](/reference/memory.md)|
 |`__cpp_lib_span`|`202311L`|[`std::mdspan`](/reference/mdspan/mdspan.md)に[`at()`](/reference/mdspan/mdspan/at.md)メンバ関数を追加|[`<span>`](/reference/span.md)|
 |`__cpp_lib_span_initializer_list`|`202311L`|[`std::span`](/reference/span/span.md)に[`std::initializer_list`](/reference/initializer_list/initializer_list.md)をとるコンストラクタを追加|[`<span>`](/reference/span.md)|
+|`__cpp_lib_stdbit_h`|`202603L`|[`<stdbit.h>`](/reference/stdbit.h.md)ヘッダがC++から使用可能であることを示す|[`<stdbit.h>`](/reference/stdbit.h.md)|
+|`__cpp_lib_stdckdint_h`|`202603L`|[`<stdckdint.h>`](/reference/stdckdint.h.md)ヘッダがC++から使用可能であることを示す|[`<stdckdint.h>`](/reference/stdckdint.h.md)|
 |`__cpp_lib_sstream_from_string_view`|`202306L`|[`std::basic_stringstream`](/reference/sstream/basic_stringstream.md)などが[`std::basic_string_view`](/reference/string_view/basic_string_view.md)から構築可能に|[`<sstream>`](/reference/sstream.md)|
 |`__cpp_lib_string_subview`|`202506L`|[`std::basic_string`](/reference/string/basic_string.md)と[`std::basic_string_view`](/reference/string_view/basic_string_view.md)に`subview()`を追加|[`<string>`](/reference/string.md), [`<string_view>`](/reference/string_view.md)|
 |`__cpp_lib_string_view`|`202403L`|[`std::basic_string`](/reference/string/basic_string.md)と[`std::basic_string_view`](/reference/string_view/basic_string_view.md)を連結させる`operator+`を追加|[`<string>`](/reference/string.md), [`<string_view>`](/reference/string_view.md)|
@@ -191,3 +193,5 @@
 ## 参照
 
 - [SD-FeatureTest: Feature-Test Macros and Policies - isocpp](https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations)
+- [LWG Issue 4550. Need new feature test macros for `<stdckdint.h>` and `<stdbit.h>`](https://cplusplus.github.io/LWG/issue4550)
+    - C++26で、`__cpp_lib_stdbit_h`と`__cpp_lib_stdckdint_h`が追加された

--- a/lang/cpp26/feature_test_macros.md
+++ b/lang/cpp26/feature_test_macros.md
@@ -195,3 +195,7 @@
 - [SD-FeatureTest: Feature-Test Macros and Policies - isocpp](https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations)
 - [LWG Issue 4550. Need new feature test macros for `<stdckdint.h>` and `<stdbit.h>`](https://cplusplus.github.io/LWG/issue4550)
     - C++26で、`__cpp_lib_stdbit_h`と`__cpp_lib_stdckdint_h`が追加された
+- [P3371R5 Fix C++26 BLAS rank updates consistency](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3371r5.html)
+    - C++26で`__cpp_lib_linalg`が`202511L`に更新された
+- [P4012R1 Value-preserving consteval broadcast to `simd::vec`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4012r1.pdf)
+    - C++26のsimd整合修正により`__cpp_lib_simd`が`202603L`に更新された

--- a/lang/cpp29/feature_test_macros.md
+++ b/lang/cpp29/feature_test_macros.md
@@ -25,3 +25,11 @@
 ## 参照
 
 - [SD-FeatureTest: Feature-Test Macros and Policies - isocpp](https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations)
+- [P3428R4 Hazard Pointer Batches](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3428r4.pdf)
+    - C++29で`__cpp_lib_hazard_pointer`が`202606L`に更新された
+- [P3319R6 Add an iota object for simd (and more)](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3319r6.pdf)
+    - C++29で`__cpp_lib_simd`が`202606L`に更新された
+- [P3772R2 std::simd overloads for bit permutations](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3772r2.html)
+    - C++29で`__cpp_lib_simd_bitops`が追加された
+- [P3793R2 Better shifting](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3793r2.html)
+    - C++29で`__cpp_lib_simd_bitops`が追加された

--- a/reference/algorithm/ranges_set_difference.md
+++ b/reference/algorithm/ranges_set_difference.md
@@ -51,7 +51,7 @@ namespace std::ranges {
             class Proj1 = identity,
             class Proj2 = identity>
     requires mergeable<I1, I2, O, Comp, Proj1, Proj2>
-  set_difference_result<I1, O>
+  set_difference_truncated_result<I1, I2, O>
     set_difference(Ep&& exec,
                    I1 first1,
                    S1 last1,
@@ -71,7 +71,7 @@ namespace std::ranges {
             class Proj1 = identity,
             class Proj2 = identity>
     requires mergeable<iterator_t<R1>, iterator_t<R2>, iterator_t<OutR>, Comp, Proj1, Proj2>
-  set_difference_result<borrowed_iterator_t<R1>, borrowed_iterator_t<OutR>>
+  set_difference_truncated_result<borrowed_iterator_t<R1>, borrowed_iterator_t<R2>, borrowed_iterator_t<OutR>>
     set_difference(Ep&& exec,
                    R1&& r1,
                    R2&& r2,
@@ -82,6 +82,7 @@ namespace std::ranges {
 }
 ```
 * set_difference_result[link ranges_in_out_result.md]
+* set_difference_truncated_result[link ranges_in_in_out_result.md]
 * weakly_incrementable[link /reference/iterator/weakly_incrementable.md]
 * ranges::less[link /reference/functional/ranges_less.md]
 * mergeable[link /reference/iterator/mergeable.md]
@@ -109,15 +110,21 @@ namespace std::ranges {
 
 
 ## 戻り値
-```cpp
-set_difference_result {
-  .in  = last1,
-  .out = result_last,
-}
-```
-* set_difference_result[link ranges_in_out_result.md]
+- (1), (2) :
 
-ただし、`result_last` は構築された範囲の終端。 
+    ```cpp
+    set_difference_result {
+      .in  = last1,
+      .out = result_last,
+    }
+    ```
+    * set_difference_result[link ranges_in_out_result.md]
+
+    ただし、`result_last` は構築された範囲の終端。
+
+- (3), (4) : [`set_difference_truncated_result`](ranges_in_in_out_result.md)を返す。`[first1, last1)`／`[first2, last2)`のうちコピーまたはスキップされた要素数をそれぞれ`A`／`B`、`result`へ書き込んだ要素数を`N`、出力範囲の要素数（`result`から`result_last`までの距離）を`M`とする。
+    - `N == M`のとき（出力バッファを使い切ったとき）：`{.in1 = last1, .in2 = first2 + B, .out = result + N}`
+    - そうでなければ：`{.in1 = first1 + A, .in2 = first2 + B, .out = result_last}`
 
 
 ## 計算量
@@ -209,3 +216,5 @@ int main()
 ## 参照
 - [N4861 25 Algorithms library](https://timsong-cpp.github.io/cppwp/n4861/algorithms)
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 4544. Parallel overload of `ranges::set_difference` should return `in_in_out_result`](https://cplusplus.github.io/LWG/issue4544)
+    - C++26で、並列版(3), (4)の戻り値型が`set_difference_result`(`in_out_result`)から`set_difference_truncated_result`(`in_in_out_result`)に変更され、両入力範囲がどこまで処理されたかを返すようになった

--- a/reference/algorithm/ranges_set_intersection.md
+++ b/reference/algorithm/ranges_set_intersection.md
@@ -119,16 +119,20 @@ namespace std::ranges {
 ## 戻り値
 次のメンバをもつtuple-likeオブジェクト。
 
-```cpp
-set_intersection_result {
-  .in1 = last1,
-  .in2 = last2,
-  .out = result_last,
-}
-```
-* set_intersection_result[link ranges_in_in_out_result.md]
+- (1), (2) :
 
-ただし、`result_last` は構築された範囲の終端。 
+    ```cpp
+    set_intersection_result {
+      .in1 = last1,
+      .in2 = last2,
+      .out = result_last,
+    }
+    ```
+    * set_intersection_result[link ranges_in_in_out_result.md]
+
+    ただし、`result_last` は構築された範囲の終端。
+
+- (3), (4) : `[first1, last1)`／`[first2, last2)`のうちコピーまたはスキップされた要素数をそれぞれ`A`／`B`、`result`へ書き込んだ要素数を`N`とするとき、`{.in1 = first1 + A, .in2 = first2 + B, .out = result + N}`。並列版では一方の入力範囲を消費し終えた時点で早期終了できるため、入力範囲の末尾まで進めるとは限らない。
 
 ## 計算量
 最大で `2 * ((last1 - first1) + (last2 - first2)) - 1` 回の比較を行う
@@ -218,3 +222,5 @@ int main()
 ## 参照
 - [N4861 25 Algorithms library](https://timsong-cpp.github.io/cppwp/n4861/algorithms)
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 4548. Parallel `ranges::set_intersection` should not do unnecessary work](https://cplusplus.github.io/LWG/issue4548)
+    - C++26で、並列版(3), (4)の戻り値が、一方の入力を消費し終えた時点での位置`{first1 + A, first2 + B, result + N}`となり、不要な反復を避けて早期終了できるようになった

--- a/reference/execution/execution/task.md
+++ b/reference/execution/execution/task.md
@@ -36,6 +36,8 @@ namespace std::execution {
 
 `error_types`が[`completion_signatures`](completion_signatures.md)`<ErrorSigs...>`の特殊化ではない、もしくは`ErrorSigs`が[`set_error_t`](set_error.md)`(E)`が適格でない要素型`E`を含むとき、プログラムは不適格となる。
 
+`allocator_type`はCpp17Allocator要件を満たし、`start_scheduler_type`は[`scheduler`](scheduler.md)のモデルであり、`stop_source_type`は[`stoppable-source`](/reference/stop_token/stoppable-source.md)のモデルであること。
+
 `task`クラステンプレートは、下記の静的メンバ関数テンプレートを定義する。
 
 ```cpp
@@ -131,5 +133,7 @@ int main()
 - [P3552R3 Add a Coroutine Task Type](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3552r3.html)
 - [LWG4343. Missing default template arguments for `task`](https://cplusplus.github.io/LWG/issue4343)
 - [LWG4528. `task` needs `get_completion_signatures()`](https://cplusplus.github.io/LWG/issue4528)
+- [LWG4485. Move specification for `task::stop_token_type`](https://cplusplus.github.io/LWG/issue4485)
+    - C++26で、`allocator_type`・`start_scheduler_type`・`stop_source_type`に対する要件が明記された
 - [P3941R4 Scheduler Affinity](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3941r4.html)
 - C++now 2025, [Getting The Lazy Task Done](https://schedule.cppnow.org/wp-content/uploads/2025/03/Getting_The_Lazy_Task_Done.pdf)

--- a/reference/expected/expected.void/op_assign.md
+++ b/reference/expected/expected.void/op_assign.md
@@ -71,6 +71,13 @@ has_val = false;`
     [`is_nothrow_move_constructible_v`](/reference/type_traits/is_nothrow_move_constructible.md)`<E> &&` [`is_nothrow_move_assignable_v`](/reference/type_traits/is_nothrow_move_assignable.md)`<E>`
 
 
+## トリビアルに定義される条件
+C++26から、下記の条件を満たす場合、代入演算子はトリビアルに定義される。
+
+- (1) : [`is_trivially_copy_constructible_v`](/reference/type_traits/is_trivially_copy_constructible.md)`<E>`、[`is_trivially_copy_assignable_v`](/reference/type_traits/is_trivially_copy_assignable.md)`<E>`、[`is_trivially_destructible_v`](/reference/type_traits/is_trivially_destructible.md)`<E>`が全て`true`のとき、コピー代入演算子はトリビアルである。
+- (2) : [`is_trivially_move_constructible_v`](/reference/type_traits/is_trivially_move_constructible.md)`<E>`、[`is_trivially_move_assignable_v`](/reference/type_traits/is_trivially_move_assignable.md)`<E>`、[`is_trivially_destructible_v`](/reference/type_traits/is_trivially_destructible.md)`<E>`が全て`true`のとき、ムーブ代入演算子はトリビアルである。
+
+
 ## delete定義される条件
 - (1) : 下記いずれか1つでも満たされないとき、コピー代入演算子はdelete定義される。
     - [`is_copy_assignable_v`](/reference/type_traits/is_copy_assignable.md)`<E> == true`
@@ -168,3 +175,5 @@ int main()
 
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
+- [LWG Issue 4026. Assignment operators of `std::expected` should propagate triviality](https://cplusplus.github.io/LWG/issue4026)
+    - C++26で、`E`が対応する操作をトリビアルに持つ場合に、コピー代入演算子(1)とムーブ代入演算子(2)もトリビアルに定義されるようになった

--- a/reference/expected/expected/op_assign.md
+++ b/reference/expected/expected/op_assign.md
@@ -122,6 +122,25 @@ has_val = false;`
     - [`is_nothrow_move_assignable_v`](/reference/type_traits/is_nothrow_move_assignable.md)`<T> &&` [`is_nothrow_move_constructible_v`](/reference/type_traits/is_nothrow_move_constructible.md)`<T> &&` [`is_nothrow_move_assignable_v`](/reference/type_traits/is_nothrow_move_assignable.md)`<E> &&` [`is_nothrow_move_constructible_v`](/reference/type_traits/is_nothrow_move_constructible.md)`<E>`
 
 
+## トリビアルに定義される条件
+C++26から、下記の条件を満たす場合、代入演算子はトリビアルに定義される。
+
+- (1) : 以下の全てを満たすとき、コピー代入演算子はトリビアルである。
+    - [`is_trivially_copy_constructible_v`](/reference/type_traits/is_trivially_copy_constructible.md)`<T> == true`
+    - [`is_trivially_copy_assignable_v`](/reference/type_traits/is_trivially_copy_assignable.md)`<T> == true`
+    - [`is_trivially_destructible_v`](/reference/type_traits/is_trivially_destructible.md)`<T> == true`
+    - [`is_trivially_copy_constructible_v`](/reference/type_traits/is_trivially_copy_constructible.md)`<E> == true`
+    - [`is_trivially_copy_assignable_v`](/reference/type_traits/is_trivially_copy_assignable.md)`<E> == true`
+    - [`is_trivially_destructible_v`](/reference/type_traits/is_trivially_destructible.md)`<E> == true`
+- (2) : 以下の全てを満たすとき、ムーブ代入演算子はトリビアルである。
+    - [`is_trivially_move_constructible_v`](/reference/type_traits/is_trivially_move_constructible.md)`<T> == true`
+    - [`is_trivially_move_assignable_v`](/reference/type_traits/is_trivially_move_assignable.md)`<T> == true`
+    - [`is_trivially_destructible_v`](/reference/type_traits/is_trivially_destructible.md)`<T> == true`
+    - [`is_trivially_move_constructible_v`](/reference/type_traits/is_trivially_move_constructible.md)`<E> == true`
+    - [`is_trivially_move_assignable_v`](/reference/type_traits/is_trivially_move_assignable.md)`<E> == true`
+    - [`is_trivially_destructible_v`](/reference/type_traits/is_trivially_destructible.md)`<E> == true`
+
+
 ## delete定義される条件
 - (1) : 下記いずれか1つでも満たされないとき、コピー代入演算子はdelete定義される。
     - [`is_copy_assignable_v`](/reference/type_traits/is_copy_assignable.md)`<T> == true`
@@ -242,3 +261,5 @@ int main()
 
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
+- [LWG Issue 4026. Assignment operators of `std::expected` should propagate triviality](https://cplusplus.github.io/LWG/issue4026)
+    - C++26で、`T`と`E`が対応する操作をトリビアルに持つ場合に、コピー代入演算子(1)とムーブ代入演算子(2)もトリビアルに定義されるようになった

--- a/reference/expected/expected/swap.md
+++ b/reference/expected/expected/swap.md
@@ -48,7 +48,7 @@ constexpr void swap(expected& rhs) noexcept(see below);
         throw;
       }
     } else {
-      T tmp(std::move(val));
+      remove_cv_t<T> tmp(std::move(val));
       destroy_at(addressof(val));
       try {
         construct_at(addressof(unex), std::move(rhs.unex));
@@ -66,6 +66,7 @@ constexpr void swap(expected& rhs) noexcept(see below);
     * destroy_at[link /reference/memory/destroy_at.md]
     * std::move[link /reference/utility/move.md]
     * is_nothrow_move_constructible_v[link /reference/type_traits/is_nothrow_move_constructible.md]
+    * remove_cv_t[link /reference/type_traits/remove_cv.md]
 
 
 ## 戻り値
@@ -119,3 +120,5 @@ int main()
 
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
+- [LWG Issue 3891. LWG 3870 breaks `std::expected<cv T, E>`](https://cplusplus.github.io/LWG/issue3891)
+    - C++26で、`expected<const T, E>`のようなCV修飾された正常値型を扱えるよう、内部で値を`remove_cv_t<T>`として格納するようになり、交換時の一時変数の型も`remove_cv_t<T>`に修正された

--- a/reference/functional/bind_back.md
+++ b/reference/functional/bind_back.md
@@ -153,3 +153,5 @@ int main() {
 - [rangesのパイプにアダプトするには](https://onihusube.hatenablog.com/entry/2022/04/24/010041)
 - [P2714R1 Bind front and back to NTTP callables](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2714r1.html)
     - C++26でオーバーロード(2)を追加
+- [LWG Issue 4533. `not_fn<f>` is unimplementable](https://cplusplus.github.io/LWG/issue4533)
+    - C++26で、NTTP版の呼び出しラッパーを実装可能にするため、`cw<f>`のコピーを対象オブジェクトとして持つよう仕様が明確化された

--- a/reference/functional/bind_front.md
+++ b/reference/functional/bind_front.md
@@ -145,3 +145,5 @@ int main() {
 - [P1651R0 `bind_front` should not unwrap `reference_wrapper`](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1651r0.html)
 - [P2714R1 Bind front and back to NTTP callables](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2714r1.html)
     - C++26でオーバーロード(2)を追加
+- [LWG Issue 4533. `not_fn<f>` is unimplementable](https://cplusplus.github.io/LWG/issue4533)
+    - C++26で、NTTP版の呼び出しラッパーを実装可能にするため、`cw<f>`のコピーを対象オブジェクトとして持つよう仕様が明確化された

--- a/reference/functional/not_fn.md
+++ b/reference/functional/not_fn.md
@@ -139,3 +139,5 @@ true
 - [P1065R2 constexpr INVOKE](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1065r2.html)
 - [P2714R1 Bind front and back to NTTP callables](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2714r1.html)
     - C++26でオーバーロード(2)を追加
+- [LWG Issue 4533. `not_fn<f>` is unimplementable](https://cplusplus.github.io/LWG/issue4533)
+    - C++26で、NTTP版の呼び出しラッパーを実装可能にするため、`cw<f>`のコピーを対象オブジェクトとして持つよう仕様が明確化された

--- a/reference/hive/hive/is_within_hard_limits.md
+++ b/reference/hive/hive/is_within_hard_limits.md
@@ -77,3 +77,5 @@ true
 ## 参照
 - [P0447R28 Introduction of `std::hive` to the standard library](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0447r28.html)
     - C++26で追加された
+- [LWG Issue 4554. Remove undefined behaviour from `hive` for invalid limits](https://cplusplus.github.io/LWG/issue4554)
+    - C++26で、不正な容量制限に対する動作が未定義動作からエラー性動作（効果は処理系定義）に変更され、事前検証用の静的メンバ関数`is_within_hard_limits`が追加された

--- a/reference/hive/hive/op_constructor.md
+++ b/reference/hive/hive/op_constructor.md
@@ -178,3 +178,5 @@ h5.size() = 3
 ## 参照
 - [P0447R28 Introduction of `std::hive` to the standard library](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0447r28.html)
     - C++26で追加された
+- [LWG Issue 4554. Remove undefined behaviour from `hive` for invalid limits](https://cplusplus.github.io/LWG/issue4554)
+    - C++26で、不正な容量制限に対する動作が未定義動作からエラー性動作（効果は処理系定義）に変更され、事前検証用の静的メンバ関数`is_within_hard_limits`が追加された

--- a/reference/hive/hive/reserve.md
+++ b/reference/hive/hive/reserve.md
@@ -90,3 +90,5 @@ capacity >= 100 : true
 ## 参照
 - [P0447R28 Introduction of `std::hive` to the standard library](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0447r28.html)
     - C++26で`hive`が追加された
+- [LWG Issue 4379. `hive::reserve()` needs *Throws:* element adjusted to match block min/max considerations](https://cplusplus.github.io/LWG/issue4379)
+    - C++26で、`capacity()`が`max_size()`を超える場合に`length_error`を送出するよう例外指定が明確化された

--- a/reference/inplace_vector/inplace_vector/op_compare_3way.md
+++ b/reference/inplace_vector/inplace_vector/op_compare_3way.md
@@ -9,7 +9,8 @@ namespace std {
   template <class T, size_t N>
   constexpr synth-three-way-result<T>
     operator<=>(const inplace_vector<T, N>& x,
-                const inplace_vector<T, N>& y); // (1) C++26
+                const inplace_vector<T, N>& y)
+      requires requires (const T t) { synth-three-way(t, t); }; // (1) C++26
 }
 ```
 
@@ -43,6 +44,7 @@ return std::lexicographical_compare_three_way(
     - `operator<=`
     - `operator>`
     - `operator>=`
+- 要素型`T`が三方比較 (`synth-three-way`) を行えない場合、この演算子はオーバーロード解決の候補から除外される（ハードエラーにはならない）。
 
 
 ## 例
@@ -88,3 +90,5 @@ true
 
 ## 参照
 - [P0843R14 `inplace_vector`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0843r14.html)
+- [LWG Issue 4122. Ill-formed `operator<=>` can cause hard error instantiating `std::inplace_vector`](https://cplusplus.github.io/LWG/issue4122)
+    - C++26で、要素型`T`が三方比較できない場合にハードエラーとならないよう、この演算子に`requires`節による制約が追加された

--- a/reference/inplace_vector/inplace_vector/swap.md
+++ b/reference/inplace_vector/inplace_vector/swap.md
@@ -15,6 +15,11 @@ constexpr void swap(inplace_vector& x)
 他の`inplace_vector`オブジェクトとデータを入れ替える。
 
 
+## 事前条件
+- 型`T`がCpp17MoveConstructible要件を満たすこと。
+- `M`を`min(`[`size()`](size.md)`, x.`[`size()`](size.md)`)`とする。`0`以上`M`未満の各整数`n`について、`(*this)[n]`と`x[n]`がswap可能であること。
+
+
 ## 効果
 `*this`と`x`の要素を入れ替える。
 
@@ -73,3 +78,5 @@ v2: 1 2 3
 
 ## 参照
 - [P0843R14 `inplace_vector`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0843r14.html)
+- [LWG Issue 4151. Precondition of `inplace_vector::swap`](https://cplusplus.github.io/LWG/issue4151)
+    - C++26で、要素型`T`のCpp17MoveConstructible要件と、対応する要素がswap可能であることの事前条件が明記された

--- a/reference/iterator/sentinel_for.md
+++ b/reference/iterator/sentinel_for.md
@@ -30,6 +30,7 @@ namespace std {
 - `i == s`が適格である（未定義動作にならない）
 - `bool(i != s) == true`の（`i`が範囲終端に到達していない）時、`i`は間接参照可能であり`[++i, s)`も範囲を示す
 - `I&, S`が[`assignable_from`](/reference/concepts/assignable_from.md)`<I&, S>`のモデルとならないなら、構文的にも`assignable_from`コンセプトを満たさない
+- （C++26）`I`と`S`が同じ型である場合、`i == i`は`true`である
 
 ここでの`==`の[定義域](/reference/concepts.md)は静的ではなく、実行時に変化しうる。`[i, s)`が範囲を示している時に`i == oi`となるような別のイテレータ`oi`をインクリメント（`++oi`）した後で、範囲`[i, s)`が有効であり続ける必要はない。
 
@@ -108,3 +109,5 @@ int* is not sentinel for double*
 
 - [P0896R4 The One Ranges Proposal (was Merging the Ranges TS)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0896r4.pdf)
 - [LWG Issue 3453. Generic code cannot call `ranges::advance(i, s)`](https://cplusplus.github.io/LWG/issue3453)
+- [LWG Issue 3777. Common `cartesian_product_view` produces invalid range if first range is input and one range is empty](https://cplusplus.github.io/LWG/issue3777)
+    - C++26で、`I`と`S`が同じ型のとき`i == i`が`true`であるという意味論要件がモデルに追加された

--- a/reference/map/map/op_deduction_guide.md
+++ b/reference/map/map/op_deduction_guide.md
@@ -8,16 +8,15 @@
 namespace std {
   // 説明用の型
   template <class InputIterator>
-  using iter_key_t = remove_const_t<typename iterator_traits<InputIterator>::value_type::first_type>;
+  using iter_key_t = remove_cvref_t<tuple_element_t<0, typename iterator_traits<InputIterator>::value_type>>;
   template <class InputIterator>
-  using iter_val_t = typename iterator_traits<InputIterator>::value_type::second_type;
+  using iter_val_t = remove_cvref_t<tuple_element_t<1, typename iterator_traits<InputIterator>::value_type>>;
   template <class InputIterator>
-  using iter_to_alloc_t = pair<add_const_t<typename iterator_traits<InputIterator>::value_type::first_type>,
-                               typename iterator_traits<InputIterator>::value_type::second_type>;
+  using iter_to_alloc_t = pair<const iter_key_t<InputIterator>, iter_val_t<InputIterator>>;
   template <ranges::input_range Range>
-  using range_key_t = remove_const_t<typename ranges::range_value_t<Range>::first_type>;
+  using range_key_t = remove_cvref_t<tuple_element_t<0, ranges::range_value_t<Range>>>;
   template <ranges::input_range Range>
-  using range_val_t = typename ranges::range_value_t<Range>::second_type;
+  using range_val_t = remove_cvref_t<tuple_element_t<1, ranges::range_value_t<Range>>>;
 
   template <class InputIterator,
             class Compare = less<iter_key_t<InputIterator>>,
@@ -46,8 +45,8 @@ namespace std {
     -> map<range_key_t<R>, range_val_t<R>, less<range_key_t<R>>, Allocator>;          // (5) C++23から
 }
 ```
-* remove_const_t[link /reference/type_traits/remove_const.md]
-* add_const_t[link /reference/type_traits/add_const.md]
+* remove_cvref_t[link /reference/type_traits/remove_cvref.md]
+* tuple_element_t[link /reference/tuple/tuple_element.md]
 * less[link /reference/functional/less.md]
 * allocator[link /reference/memory/allocator.md]
 * initializer_list[link /reference/initializer_list/initializer_list.md]
@@ -71,6 +70,7 @@ namespace std {
     map m = {{"foo", 2}, {"bar", 3}, {"baz", 4}}; // コンパイルエラー！ 初期化子リストからconst Keyを導出できない
     map m2 = initializer_list<pair<char const *, int>>({{"foo", 2}, {"bar", 3}, {"baz", 4}}); // OK
     ```
+- C++26 (LWG 4223) では、上記の説明用エイリアスが[`tuple_element_t`](/reference/tuple/tuple_element.md)を用いて定義し直され、`pair`以外のtuple-likeな要素型からも推論できるようになり、要素型からCV修飾・参照が取り除かれるようになった。
 
 
 ## バージョン
@@ -90,3 +90,5 @@ namespace std {
 ## 参照
 - [P0433R2 Toward a resolution of US7 and US14: Integrating template deduction for class templates into the standard library](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0433r2.html)
 - [LWG Issue 3025. Map-like container deduction guides should use `pair<Key, T>`, not `pair<const Key, T>`](https://wg21.cmeerw.net/lwg/issue3025)
+- [LWG Issue 4223. Deduction guides for maps mishandling tuples and references](https://cplusplus.github.io/LWG/issue4223)
+    - C++26で、推論補助の説明用エイリアスが`tuple_element_t`ベースに変更され、tuple-likeな要素型への対応とCV修飾・参照の除去が行われた

--- a/reference/map/multimap/op_deduction_guide.md
+++ b/reference/map/multimap/op_deduction_guide.md
@@ -8,16 +8,15 @@
 namespace std {
   // 説明用の型
   template <class InputIterator>
-  using iter_key_t = remove_const_t<typename iterator_traits<InputIterator>::value_type::first_type>;
+  using iter_key_t = remove_cvref_t<tuple_element_t<0, typename iterator_traits<InputIterator>::value_type>>;
   template <class InputIterator>
-  using iter_val_t = typename iterator_traits<InputIterator>::value_type::second_type;
+  using iter_val_t = remove_cvref_t<tuple_element_t<1, typename iterator_traits<InputIterator>::value_type>>;
   template <class InputIterator>
-  using iter_to_alloc_t = pair<add_const_t<typename iterator_traits<InputIterator>::value_type::first_type>,
-                               typename iterator_traits<InputIterator>::value_type::second_type>;
+  using iter_to_alloc_t = pair<const iter_key_t<InputIterator>, iter_val_t<InputIterator>>;
   template <ranges::input_range Range>
-  using range_key_t = remove_const_t<typename ranges::range_value_t<Range>::first_type>;
+  using range_key_t = remove_cvref_t<tuple_element_t<0, ranges::range_value_t<Range>>>;
   template <ranges::input_range Range>
-  using range_val_t = typename ranges::range_value_t<Range>::second_type;
+  using range_val_t = remove_cvref_t<tuple_element_t<1, ranges::range_value_t<Range>>>;
 
   template <class InputIterator,
             class Compare = less<iter_key_t<InputIterator>>,
@@ -46,8 +45,8 @@ namespace std {
     -> multimap<range_key_t<R>, range_val_t<R>, less<range_key_t<R>>, Allocator>;          // (5) C++23から
 }
 ```
-* remove_const_t[link /reference/type_traits/remove_const.md]
-* add_const_t[link /reference/type_traits/add_const.md]
+* remove_cvref_t[link /reference/type_traits/remove_cvref.md]
+* tuple_element_t[link /reference/tuple/tuple_element.md]
 * less[link /reference/functional/less.md]
 * allocator[link /reference/memory/allocator.md]
 * initializer_list[link /reference/initializer_list/initializer_list.md]
@@ -71,6 +70,7 @@ namespace std {
     multimap m = {{"foo", 2}, {"bar", 3}, {"baz", 4}}; // コンパイルエラー！ 初期化子リストからconst Keyを導出できない
     multimap m2 = initializer_list<pair<char const *, int>>({{"foo", 2}, {"bar", 3}, {"baz", 4}}); // OK
     ```
+- C++26 (LWG 4223) では、上記の説明用エイリアスが[`tuple_element_t`](/reference/tuple/tuple_element.md)を用いて定義し直され、`pair`以外のtuple-likeな要素型からも推論できるようになり、要素型からCV修飾・参照が取り除かれるようになった。
 
 
 ## バージョン
@@ -90,3 +90,5 @@ namespace std {
 ## 参照
 - [P0433R2 Toward a resolution of US7 and US14: Integrating template deduction for class templates into the standard library](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0433r2.html)
 - [LWG Issue 3025. Map-like container deduction guides should use `pair<Key, T>`, not `pair<const Key, T>`](https://wg21.cmeerw.net/lwg/issue3025)
+- [LWG Issue 4223. Deduction guides for maps mishandling tuples and references](https://cplusplus.github.io/LWG/issue4223)
+    - C++26で、推論補助の説明用エイリアスが`tuple_element_t`ベースに変更され、tuple-likeな要素型への対応とCV修飾・参照の除去が行われた

--- a/reference/mdspan/layout_left/mapping/op_call.md
+++ b/reference/mdspan/layout_left/mapping/op_call.md
@@ -28,9 +28,10 @@ constexpr index_type operator()(Indices... i) const noexcept;
 説明用のパラメータパック`P`において、[`is_same_v`](/reference/type_traits/is_same.md)`<`[`index_sequence_for`](/reference/utility/index_sequence_for.md)`<Indices...>,` [`index_sequence`](/reference/utility/index_sequence.md)`<P...>>`が`true`となるとき、以下と等価。
 
 ```cpp
-return ((static_cast<index_type>(Indices...) * stride(P)) + ... + 0);
+return ((static_cast<index_type>(std::move(i)) * stride(P)) + ... + 0);
 ```
 * stride[link stride.md]
+* std::move[link /reference/utility/move.md]
 
 
 ## 例外
@@ -73,3 +74,5 @@ int main()
 
 ## 参照
 - [P0009R18 MDSPAN](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r18.html)
+- [LWG Issue 4314. Missing move in mdspan layout mapping::operator()](https://cplusplus.github.io/LWG/issue4314)
+    - C++26で、rvalueでのみ`index_type`へ変換できる型に対応するため、`operator()`の返し式でインデックス値を`std::move`するようになった

--- a/reference/mdspan/layout_left_padded/mapping/op_call.md
+++ b/reference/mdspan/layout_left_padded/mapping/op_call.md
@@ -26,9 +26,10 @@ constexpr size_t operator()(Indices... idxs) const noexcept;
 
 ## 戻り値
 ```cpp
-return ((static_cast<index_type>(idxs) * stride(P_rank)) + ... + 0);
+return ((static_cast<index_type>(std::move(idxs)) * stride(P_rank)) + ... + 0);
 ```
 * stride[link stride.md]
+* std::move[link /reference/utility/move.md]
 
 
 ## 例外
@@ -48,3 +49,5 @@ return ((static_cast<index_type>(idxs) * stride(P_rank)) + ... + 0);
 
 ## 参照
 - [P2642R6 Padded mdspan layouts](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2642r6.pdf)
+- [LWG Issue 4314. Missing move in mdspan layout mapping::operator()](https://cplusplus.github.io/LWG/issue4314)
+    - C++26で、rvalueでのみ`index_type`へ変換できる型に対応するため、`operator()`の返し式でインデックス値を`std::move`するようになった

--- a/reference/mdspan/layout_right/mapping/op_call.md
+++ b/reference/mdspan/layout_right/mapping/op_call.md
@@ -28,9 +28,10 @@ constexpr index_type operator()(Indices... i) const noexcept;
 説明用のパラメータパック`P`において、[`is_same_v`](/reference/type_traits/is_same.md)`<`[`index_sequence_for`](/reference/utility/index_sequence_for.md)`<Indices...>,` [`index_sequence`](/reference/utility/index_sequence.md)`<P...>>`が`true`となるとき、以下と等価。
 
 ```cpp
-return ((static_cast<index_type>(Indices...) * stride(P)) + ... + 0);
+return ((static_cast<index_type>(std::move(i)) * stride(P)) + ... + 0);
 ```
 * stride[link stride.md]
+* std::move[link /reference/utility/move.md]
 
 
 ## 例外
@@ -73,3 +74,5 @@ int main()
 
 ## 参照
 - [P0009R18 MDSPAN](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r18.html)
+- [LWG Issue 4314. Missing move in mdspan layout mapping::operator()](https://cplusplus.github.io/LWG/issue4314)
+    - C++26で、rvalueでのみ`index_type`へ変換できる型に対応するため、`operator()`の返し式でインデックス値を`std::move`するようになった

--- a/reference/mdspan/layout_right_padded/mapping/op_call.md
+++ b/reference/mdspan/layout_right_padded/mapping/op_call.md
@@ -26,9 +26,10 @@ constexpr size_t operator()(Indices... idxs) const noexcept;
 
 ## 戻り値
 ```cpp
-return ((static_cast<index_type>(idxs) * stride(P_rank)) + ... + 0);
+return ((static_cast<index_type>(std::move(idxs)) * stride(P_rank)) + ... + 0);
 ```
 * stride[link stride.md]
+* std::move[link /reference/utility/move.md]
 
 
 ## 例外
@@ -48,3 +49,5 @@ return ((static_cast<index_type>(idxs) * stride(P_rank)) + ... + 0);
 
 ## 参照
 - [P2642R6 Padded mdspan layouts](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2642r6.pdf)
+- [LWG Issue 4314. Missing move in mdspan layout mapping::operator()](https://cplusplus.github.io/LWG/issue4314)
+    - C++26で、rvalueでのみ`index_type`へ変換できる型に対応するため、`operator()`の返し式でインデックス値を`std::move`するようになった

--- a/reference/mdspan/layout_stride/mapping/op_call.md
+++ b/reference/mdspan/layout_stride/mapping/op_call.md
@@ -28,9 +28,10 @@ constexpr index_type operator()(Indices... i) const noexcept;
 説明用のパラメータパック`P`において、[`is_same_v`](/reference/type_traits/is_same.md)`<`[`index_sequence_for`](/reference/utility/index_sequence_for.md)`<Indices...>,` [`index_sequence`](/reference/utility/index_sequence.md)`<P...>>`が`true`となるとき、以下と等価。
 
 ```cpp
-return ((static_cast<index_type>(Indices...) * stride(P)) + ... + 0);
+return ((static_cast<index_type>(std::move(i)) * stride(P)) + ... + 0);
 ```
 * stride[link stride.md]
+* std::move[link /reference/utility/move.md]
 
 
 ## 例外
@@ -83,3 +84,5 @@ int main()
 
 ## 参照
 - [P0009R18 MDSPAN](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r18.html)
+- [LWG Issue 4314. Missing move in mdspan layout mapping::operator()](https://cplusplus.github.io/LWG/issue4314)
+    - C++26で、rvalueでのみ`index_type`へ変換できる型に対応するため、`operator()`の返し式でインデックス値を`std::move`するようになった

--- a/reference/memory/indirect/op_equal.md
+++ b/reference/memory/indirect/op_equal.md
@@ -32,6 +32,13 @@ friend constexpr bool operator==(
 - (2) : `lhs`が無効値状態であれば`false`、そうでなければ`*lhs == rhs`。
 
 
+## 例外
+`noexcept`指定は下記の式に従う。
+
+- (1) : `noexcept(bool(*lhs == *rhs))`
+- (2) : `noexcept(bool(*lhs == rhs))`
+
+
 ## 備考
 この演算子により、`operator!=`が使用可能になる。
 
@@ -73,3 +80,5 @@ int main()
 
 ## 参照
 - [P3019R14 `indirect` and `polymorphic`: Vocabulary Types for Composite Class Design](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3019r14.pdf)
+- [LWG Issue 4325. `std::indirect`'s `operator==` still doesn't support incomplete types](https://cplusplus.github.io/LWG/issue4325)
+    - C++26で、`noexcept`指定を`bool`への変換を含む式`bool(*lhs == *rhs)`にもとづくよう修正した

--- a/reference/memory/owner_less/op_call.md
+++ b/reference/memory/owner_less/op_call.md
@@ -9,59 +9,35 @@
 // shared_ptr特殊化版
 bool operator()(const shared_ptr<T>& a, const shared_ptr<T>& b) const;          // (1) C++11
 bool operator()(const shared_ptr<T>& a, const shared_ptr<T>& b) const noexcept; // (1) C++17
-constexpr bool
-  operator()(const shared_ptr<T>& a, const shared_ptr<T>& b) const noexcept;    // (1) C++26
 
 bool operator()(const shared_ptr<T>& a, const weak_ptr<T>& b) const;            // (2) C++11
 bool operator()(const shared_ptr<T>& a, const weak_ptr<T>& b) const noexcept;   // (2) C++17
-constexpr bool
-  operator()(const shared_ptr<T>& a, const weak_ptr<T>& b) const noexcept;      // (2) C++26
 
 bool operator()(const weak_ptr<T>& a, const shared_ptr<T>& b) const;            // (3) C++11
 bool operator()(const weak_ptr<T>& a, const shared_ptr<T>& b) const noexcept;   // (3) C++17
-constexpr bool
-  operator()(const weak_ptr<T>& a, const shared_ptr<T>& b) const noexcept;      // (3) C++26
 
 // weak_ptr特殊化版
 bool operator()(const weak_ptr<T>& a, const weak_ptr<T>& b) const;              // (4) C++11
 bool operator()(const weak_ptr<T>& a, const weak_ptr<T>& b) const noexcept;     // (4) C++17
-constexpr bool
-  operator()(const weak_ptr<T>& a, const weak_ptr<T>& b) const noexcept;        // (4) C++26
 
 bool operator()(const shared_ptr<T>& a, const weak_ptr<T>& b) const;            // (5) C++11
 bool operator()(const shared_ptr<T>& a, const weak_ptr<T>& b) const noexcept;   // (5) C++17
-constexpr bool
-  operator()(const shared_ptr<T>& a, const weak_ptr<T>& b) const noexcept;      // (5) C++26
 
 bool operator()(const weak_ptr<T>& a, const shared_ptr<T>& b) const;            // (6) C++11
 bool operator()(const weak_ptr<T>& a, const shared_ptr<T>& b) const noexcept;   // (6) C++17
-constexpr bool
-  operator()(const weak_ptr<T>& a, const shared_ptr<T>& b) const noexcept;      // (6) C++26
 
 // void特殊化版
 template<class T, class U>
 bool operator()(const shared_ptr<T>&, const shared_ptr<U>&) const noexcept;     // (7) C++17
-template<class T, class U>
-constexpr bool
-  operator()(const shared_ptr<T>&, const shared_ptr<U>&) const noexcept;        // (7) C++26
 
 template<class T, class U>
 bool operator()(const shared_ptr<T>&, const weak_ptr<U>&) const noexcept;       // (8) C++17
-template<class T, class U>
-constexpr bool
-  operator()(const shared_ptr<T>&, const weak_ptr<U>&) const noexcept;          // (8) C++26
 
 template<class T, class U>
 bool operator()(const weak_ptr<T>&, const shared_ptr<U>&) const noexcept;       // (9) C++17
-template<class T, class U>
-constexpr bool
-  operator()(const weak_ptr<T>&, const shared_ptr<U>&) const noexcept;          // (9) C++26
 
 template<class T, class U>
 bool operator()(const weak_ptr<T>&, const weak_ptr<U>&) const noexcept;         // (10) C++17
-template<class T, class U>
-constexpr bool
-  operator()(const weak_ptr<T>&, const weak_ptr<U>&) const noexcept;            // (10) C++26
 ```
 * shared_ptr[link /reference/memory/shared_ptr.md]
 * weak_ptr[link /reference/memory/weak_ptr.md]
@@ -90,3 +66,5 @@ a.owner_before(b)
 - [LWG Issue 2873. Add `noexcept` to several `shared_ptr` related functions](https://wg21.cmeerw.net/lwg/issue2873)
 - [P0074R0 Making `std::owner_less` more flexible](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0074r0.html)
 - [P3037R6 `constexpr std::shared_ptr` and friends](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3037r6.pdf)
+- [LWG Issue 4557. Remove `constexpr` from `owner_less` and `owner_before`](https://cplusplus.github.io/LWG/issue4557)
+    - C++26で、P3037R6により一旦付与された`constexpr`指定が取り消され、`owner_before`と`owner_less`の`operator()`は`constexpr`ではなくなった

--- a/reference/memory/polymorphic/op_assign.md
+++ b/reference/memory/polymorphic/op_assign.md
@@ -92,3 +92,5 @@ int main()
 
 ## 参照
 - [P3019R14 `indirect` and `polymorphic`: Vocabulary Types for Composite Class Design](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3019r14.pdf)
+- [LWG Issue 4532. Imprecise `std::polymorphic` wording seems to imply slicing](https://cplusplus.github.io/LWG/issue4532)
+    - C++26で、コピー/ムーブや破棄の際に、所有オブジェクトの動的型`U`を保持する（基底型へスライスしない）ことがワーディング上明確化された

--- a/reference/memory/polymorphic/op_constructor.md
+++ b/reference/memory/polymorphic/op_constructor.md
@@ -156,3 +156,5 @@ int main()
 
 ## 参照
 - [P3019R14 `indirect` and `polymorphic`: Vocabulary Types for Composite Class Design](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3019r14.pdf)
+- [LWG Issue 4532. Imprecise `std::polymorphic` wording seems to imply slicing](https://cplusplus.github.io/LWG/issue4532)
+    - C++26で、コピー/ムーブや破棄の際に、所有オブジェクトの動的型`U`を保持する（基底型へスライスしない）ことがワーディング上明確化された

--- a/reference/memory/polymorphic/op_destructor.md
+++ b/reference/memory/polymorphic/op_destructor.md
@@ -37,3 +37,5 @@ constexpr ~polymorphic();
 
 ## 参照
 - [P3019R14 `indirect` and `polymorphic`: Vocabulary Types for Composite Class Design](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3019r14.pdf)
+- [LWG Issue 4532. Imprecise `std::polymorphic` wording seems to imply slicing](https://cplusplus.github.io/LWG/issue4532)
+    - C++26で、コピー/ムーブや破棄の際に、所有オブジェクトの動的型`U`を保持する（基底型へスライスしない）ことがワーディング上明確化された

--- a/reference/memory/shared_ptr/owner_before.md
+++ b/reference/memory/shared_ptr/owner_before.md
@@ -12,9 +12,6 @@ bool
 template <class U>
 bool
   owner_before(const shared_ptr<U>& b) const noexcept; // (1) C++17
-template <class U>
-constexpr bool
-  owner_before(const shared_ptr<U>& b) const noexcept; // (1) C++26
 
 template <class U>
 bool
@@ -22,9 +19,6 @@ bool
 template <class U>
 bool
   owner_before(const weak_ptr<U>& b) const noexcept;   // (2) C++17
-template <class U>
-constexpr bool
-  owner_before(const weak_ptr<U>& b) const noexcept;   // (2) C++26
 ```
 * weak_ptr[link /reference/memory/weak_ptr.md]
 
@@ -115,3 +109,5 @@ false
 - [LWG Issue 1406. Support hashing smart-pointers based on owner](http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-active.html#1406)
 - [LWG Issue 2873. Add `noexcept` to several `shared_ptr` related functions](https://wg21.cmeerw.net/lwg/issue2873)
 - [P3037R6 `constexpr std::shared_ptr` and friends](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3037r6.pdf)
+- [LWG Issue 4557. Remove `constexpr` from `owner_less` and `owner_before`](https://cplusplus.github.io/LWG/issue4557)
+    - C++26で、P3037R6により一旦付与された`constexpr`指定が取り消され、`owner_before`と`owner_less`の`operator()`は`constexpr`ではなくなった

--- a/reference/memory/weak_ptr/owner_before.md
+++ b/reference/memory/weak_ptr/owner_before.md
@@ -12,9 +12,6 @@ bool
 template <class U>
 bool
   owner_before(const shared_ptr<U>& b) const noexcept; // (1) C++17
-template <class U>
-constexpr bool
-  owner_before(const shared_ptr<U>& b) const noexcept; // (1) C++17
 
 template <class U>
 bool
@@ -22,9 +19,6 @@ bool
 template <class U>
 bool
   owner_before(const weak_ptr<U>& b) const noexcept;   // (2) C++17
-template <class U>
-constexpr bool
-  owner_before(const weak_ptr<U>& b) const noexcept;   // (2) C++26
 ```
 * shared_ptr[link /reference/memory/shared_ptr.md]
 
@@ -91,3 +85,5 @@ false
 - [LWG Issue 1406. Support hashing smart-pointers based on owner](http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-active.html#1406)
 - [LWG Issue 2873. Add `noexcept` to several `shared_ptr` related functions](https://wg21.cmeerw.net/lwg/issue2873)
 - [P3037R6 `constexpr std::shared_ptr` and friends](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3037r6.pdf)
+- [LWG Issue 4557. Remove `constexpr` from `owner_less` and `owner_before`](https://cplusplus.github.io/LWG/issue4557)
+    - C++26で、P3037R6により一旦付与された`constexpr`指定が取り消され、`owner_before`と`owner_less`の`operator()`は`constexpr`ではなくなった

--- a/reference/meta/display_string_of.md
+++ b/reference/meta/display_string_of.md
@@ -21,6 +21,10 @@ namespace std::meta {
 `r`の人間可読な表示文字列を返す。結果は実装定義である。
 
 
+## 備考
+`std::meta`名前空間の関数のうち、戻り値の型が`string_view`または`u8string_view`であるものは、NULL終端された静的記憶域上の文字列を返す、というルールがある。本関数もそれに該当する。
+
+
 ## 例
 ```cpp example
 #include <meta>
@@ -52,3 +56,5 @@ template<class _Tp, class _Alloc> class std::vector
 
 ## 参照
 - [P2996R13 Reflection for C++26](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2996r13.html)
+- [LWG Issue 4556. Unclear properties of reflection strings](https://cplusplus.github.io/LWG/issue4556)
+    - C++26で、`string_view`／`u8string_view`を返す`std::meta`の関数がNULL終端された静的記憶域上の文字列を返すことが明確化された

--- a/reference/meta/has_identifier.md
+++ b/reference/meta/has_identifier.md
@@ -52,3 +52,5 @@ int main() {
 ## 参照
 - [P2996R13 Reflection for C++26](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2996r13.html)
 - [P3096R12 Function Parameter Reflection in Reflection for C++26](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3096r12.pdf)
+- [LWG Issue 4478. `meta::has_identifier` is not specified for annotations](https://cplusplus.github.io/LWG/issue4478)
+    - C++26で、データメンバ記述などの未規定だったケースについての戻り値が明確化された

--- a/reference/meta/identifier_of.md
+++ b/reference/meta/identifier_of.md
@@ -25,6 +25,10 @@ namespace std::meta {
 [`has_identifier`](has_identifier.md)`(r)`が`false`の場合、または返される識別子が文字エンコーディングで表現できない場合、[`std::meta::exception`](exception.md)例外を送出する。
 
 
+## 備考
+`std::meta`名前空間の関数のうち、戻り値の型が`string_view`または`u8string_view`であるものは、NULL終端された静的記憶域上の文字列を返す、というルールがある。本関数もそれに該当する。
+
+
 ## 例
 ```cpp example
 #include <meta>
@@ -67,3 +71,5 @@ y
 ## 参照
 - [P2996R13 Reflection for C++26](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2996r13.html)
 - [P3096R12 Function Parameter Reflection in Reflection for C++26](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3096r12.pdf)
+- [LWG Issue 4556. Unclear properties of reflection strings](https://cplusplus.github.io/LWG/issue4556)
+    - C++26で、`string_view`／`u8string_view`を返す`std::meta`の関数がNULL終端された静的記憶域上の文字列を返すことが明確化された

--- a/reference/meta/symbol_of.md
+++ b/reference/meta/symbol_of.md
@@ -21,6 +21,10 @@ namespace std::meta {
 演算子`op`に対応する記号文字列を返す。
 
 
+## 備考
+`std::meta`名前空間の関数のうち、戻り値の型が`string_view`または`u8string_view`であるものは、NULL終端された静的記憶域上の文字列を返す、というルールがある。本関数もそれに該当する。
+
+
 ## 例
 ```cpp example
 #include <meta>
@@ -65,3 +69,5 @@ int main() {
 
 ## 参照
 - [P2996R13 Reflection for C++26](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2996r13.html)
+- [LWG Issue 4556. Unclear properties of reflection strings](https://cplusplus.github.io/LWG/issue4556)
+    - C++26で、`string_view`／`u8string_view`を返す`std::meta`の関数がNULL終端された静的記憶域上の文字列を返すことが明確化された

--- a/reference/optional/nullopt_t.md
+++ b/reference/optional/nullopt_t.md
@@ -20,6 +20,10 @@ namespace std {
 `nullopt_t`クラスは、デフォルトコンストラクタおよび初期化子リストコンストラクタを持たない。これは、`nullopt`変数を`nullopt_t`型の唯一の値とするためである。また、`nullopt_t`は[集成体](/reference/type_traits/is_aggregate.md)ではない。これは`optional<T> opt = {};`を曖昧にしないためである。
 
 
+## 備考
+C++26では、`nullopt_t`は比較可能となり、[`copyable`](/reference/concepts/copyable.md)および[`three_way_comparable`](/reference/compare/three_way_comparable.md)`<`[`strong_ordering`](/reference/compare/strong_ordering.md)`>`のモデルとなった。`nullopt_t`の値はすべて等しく、`vector<optional<T>>`に対して`nullopt`を検索する、といった使い方ができるようになった。
+
+
 ## 例
 ```cpp example
 #include <cassert>
@@ -60,3 +64,5 @@ int main()
 
 ## 参照
 - [LWG Issue 2736. `nullopt_t` insufficiently constrained](https://wg21.cmeerw.net/lwg/issue2736)
+- [LWG Issue 4497. `std::nullopt_t` should be comparable](https://cplusplus.github.io/LWG/issue4497)
+    - C++26で、`nullopt_t`が`copyable`と`three_way_comparable<strong_ordering>`のモデルとなり、比較可能になった

--- a/reference/print/vprint_nonunicode_buffered.md
+++ b/reference/print/vprint_nonunicode_buffered.md
@@ -23,7 +23,7 @@ namespace std {
 - (1) : 以下と等価：
     ```cpp
     string out = vformat(fmt, args);
-    vprint_nonunicode("{}", make_format_args(out));
+    vprint_nonunicode(stream, "{}", make_format_args(out));
     ```
     * string[link /reference/string/basic_string.md]
     * vformat[link /reference/format/vformat.md]
@@ -50,3 +50,5 @@ namespace std {
 ## 参照
 - [P3107R5 Permit an efficient implementation of `std::print`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3107r5.html)
 - [P3235R3 `std::print` more types faster with less memory](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3235r3.html)
+- [LWG Issue 4549. `vprint_nonunicode_buffered` ignores its `stream` parameter](https://cplusplus.github.io/LWG/issue4549)
+    - C++26で、`stream`引数を`vprint_nonunicode`に渡すよう効果が修正された（従来は無視され`stdout`に出力されていた）

--- a/reference/ranges/concat_view.md
+++ b/reference/ranges/concat_view.md
@@ -112,6 +112,7 @@ namespace std::ranges {
 | [`begin`](concat_view/begin.md)                   | 先頭を指すイテレータを取得する   | C++26          |
 | [`end`](concat_view/end.md)                       | 番兵を取得する                   | C++26          |
 | [`size`](concat_view/size.md)                     | 要素数を取得する                 | C++26          |
+| [`reserve_hint`](concat_view/reserve_hint.md)     | 要素数の近似値を取得する         | C++26          |
 
 ## 継承しているメンバ関数
 

--- a/reference/ranges/concat_view/reserve_hint.md
+++ b/reference/ranges/concat_view/reserve_hint.md
@@ -1,0 +1,56 @@
+# reserve_hint
+* ranges[meta header]
+* std::ranges[meta namespace]
+* concat_view[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr auto reserve_hint()
+  requires (approximately_sized_range<Views> && ...);       // (1) C++26
+constexpr auto reserve_hint() const
+  requires (approximately_sized_range<const Views> && ...); // (2) C++26
+```
+* approximately_sized_range[link /reference/ranges/approximately_sized_range.md]
+
+## 概要
+要素数の近似値を取得する。
+
+`concat_view`は連結するすべてのRangeの要素を並べるため、近似値は各Rangeの`reserve_hint`の総和となる。連結するすべてのViewが[`approximately_sized_range`](/reference/ranges/approximately_sized_range.md)であるときのみ提供される。
+
+
+## 効果
+以下と等価：
+
+```cpp
+return apply(
+  [](auto... sizes) {
+    using CT = make-unsigned-like-t<common_type_t<decltype(sizes)...>>;
+    return (CT(sizes) + ...);
+  },
+  tuple-transform(ranges::reserve_hint, views_));
+```
+* apply[link /reference/tuple/apply.md]
+* common_type_t[link /reference/type_traits/common_type.md]
+* ranges::reserve_hint[link /reference/ranges/reserve_hint.md]
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): ??
+- [GCC](/implementation.md#gcc): ??
+- [Visual C++](/implementation.md#visual_cpp): ??
+
+
+## 関連項目
+- [`std::ranges::concat_view`](../concat_view.md)
+- [`std::ranges::reserve_hint`](../reserve_hint.md)
+
+
+## 参照
+- [P2846R6 `reserve_hint`: Eagerly reserving memory for not-quite-sized lazy ranges](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2846r6.pdf)
+- [LWG Issue 4553. Wording for FR-025-246 25.7.18.2 Add a `reserve_hint` function to `concat_view`](https://cplusplus.github.io/LWG/issue4553)
+    - C++26で`concat_view`に`reserve_hint`メンバ関数が追加された

--- a/reference/ranges/elements_view.md
+++ b/reference/ranges/elements_view.md
@@ -67,10 +67,19 @@ concept has-tuple-element =
 template<class T, size_t N>
 concept has-tuple-element =
   tuple-like<T> && N < tuple_size_v<T>;
+
+// C++26
+template<class T, size_t N>
+concept has-tuple-element =
+  tuple-like<T> && N < tuple_size_v<T> &&
+  requires(T t) {
+    { std::get<N>(t) } -> convertible_to<const tuple_element_t<N, T>&>;
+  };
 ```
 * tuple_size[link /reference/tuple/tuple_size.md]
 * tuple_element_t[link /reference/tuple/tuple_element.md]
 * get[link /reference/tuple/tuple/get.md]
+* std::get[link /reference/tuple/tuple/get.md]
 * tuple-like[link /reference/tuple/tuple-like.md]
 * tuple_size_v[link /reference/tuple/tuple_size.md]
 
@@ -166,3 +175,5 @@ three
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
 - [P2165R4 Compatibility between `tuple`, `pair` and *tuple-like* objects](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2165r4.pdf)
 - [P2017R1 Conditionally borrowed ranges](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p2017r1.html)
+- [LWG Issue 3797. `elements_view` insufficiently constrained](https://cplusplus.github.io/LWG/issue3797)
+    - C++26で、説明専用コンセプト`has-tuple-element`に`get<N>(t)`が`const tuple_element_t<N, T>&`へ変換可能であることの制約が追加された

--- a/reference/source_location/source_location.md
+++ b/reference/source_location/source_location.md
@@ -48,6 +48,10 @@ namespace std {
 | [`current`](source_location/current.md) | この関数の呼び出し元のソースコード上の位置を返す | C++20          |
 
 
+## 備考
+C++26では、コピーコンストラクタ・ムーブコンストラクタおよびコピー代入演算子・ムーブ代入演算子が`constexpr`であることが保証される（C++26より前は、これらが`constexpr`であるかどうかは未規定だった）。
+
+
 ## 例
 ```cpp example
 #include <iostream>
@@ -102,3 +106,5 @@ C言語から引き継いだ定義済みマクロ`__LINE__`、`__FILE__`や[事�
 ## 参照
 
 - [P1208R6 Adopt source_location for C++20](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1208r6.pdf)
+- [LWG Issue 4506. `source_location` is explicitly unspecified if is constexpr or not](https://cplusplus.github.io/LWG/issue4506)
+    - C++26で、コピー/ムーブのコンストラクタと代入演算子が`constexpr`であることが明確化された

--- a/reference/string/basic_string/append.md
+++ b/reference/string/basic_string/append.md
@@ -60,6 +60,11 @@ constexpr basic_string&
   append(const T& t,
         size_type pos,
         size_type n = npos); // (9) C++20
+
+constexpr basic_string&
+  append(const charT* s,
+         size_type pos,
+         size_type n);      // (10) C++26
 ```
 * initializer_list[link /reference/initializer_list/initializer_list.md]
 
@@ -122,6 +127,13 @@ constexpr basic_string&
     ```
     * substr[link /reference/string_view/basic_string_view/substr.md]
 
+- (10) 対象オブジェクトの末尾に、`s` が指すNULL終端された文字列の `pos` 番目から `n` 文字を追加する。
+    以下と等価。
+    ```cpp
+    return append(basic_string_view<charT, traits>(s).substr(pos, n));
+    ```
+    * substr[link /reference/string_view/basic_string_view/substr.md]
+
 
 ## 戻り値
 `*this`
@@ -148,6 +160,9 @@ constexpr basic_string&
     C++11 から：[`size`](size.md)`() +` [`distance`](/reference/iterator/distance.md)`(first, last) >` [`max_size`](max_size.md)`()` の場合、`length_error` が送出される。
 
 - (7) [`size`](size.md)`() + il.`[`size`](/reference/initializer_list/initializer_list/size.md)`() >` [`max_size`](max_size.md)`()` の場合、`length_error` が送出される。
+
+- (10) `pos` が `s` の長さ (`traits_type::length(s)`) を超える場合、`out_of_range` が送出される。  
+    追加後の文字列長が [`max_size`](max_size.md)`()` を超える場合、`length_error` が送出される。
 
 
 ## 備考
@@ -186,6 +201,11 @@ int main()
   std::string s8 = "Hello";
   s8.append(std::string_view{"Hi, world"}.substr(2));
   std::cout << s8 << std::endl;
+
+  // (10)
+  std::string s10 = "Hello";
+  s10.append("Hi, world", 4, 5); // "Hi, world"の4文字目から5文字 ("world")
+  std::cout << s10 << std::endl;
 }
 ```
 * append[color ff0000]
@@ -198,6 +218,7 @@ Hello, world
 Hello, world!!
 Hello, world!! :)
 Hello, world
+Helloworld
 ```
 
 ## 関連項目
@@ -220,3 +241,5 @@ Hello, world
 - [LWG Issue 2946. LWG 2758's resolution missed further corrections](https://wg21.cmeerw.net/lwg/issue2946)
     - 意図しない暗黙変換防止のために`string_view`を受けるオーバーロード(8), (9)の引数型を`const T&`に変更
 - [P0980R1 Making `std::string` constexpr](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0980r1.pdf)
+- [LWG Issue 3662 `basic_string::append/assign(NTBS, pos, n)` suboptimal](https://cplusplus.github.io/LWG/issue3662)
+    - C++26で、NULL終端文字列の一部分を追加する(10)のオーバーロードが追加された

--- a/reference/string/basic_string/assign.md
+++ b/reference/string/basic_string/assign.md
@@ -61,6 +61,11 @@ constexpr basic_string&
   assign(const T& t,
          size_type pos,
          size_type n = npos);   // (10) C++20
+
+constexpr basic_string&
+  assign(const charT* s,
+         size_type pos,
+         size_type n);          // (11) C++26
 ```
 * initializer_list[link /reference/initializer_list/initializer_list.md]
 
@@ -112,6 +117,13 @@ constexpr basic_string&
     ```
     * substr[link /reference/string_view/basic_string_view/substr.md]
 
+- (11) : `s` が指すNULL終端された文字列の `pos` 番目から `n` 文字をコピーして、`basic_string`オブジェクトを構築する。  
+以下と等価。
+    ```cpp
+    return assign(basic_string_view<charT, traits>(s).substr(pos, n));
+    ```
+    * substr[link /reference/string_view/basic_string_view/substr.md]
+
 
 ## 戻り値
 `*this`
@@ -121,6 +133,7 @@ constexpr basic_string&
 - (3) : `pos > str.`[`size()`](size.md)である場合、[`out_of_range`](/reference/stdexcept.md)例外を送出する
 - (4) : `n >` [`max_size()`](max_size.md)である場合、[`length_error`](/reference/stdexcept.md)例外を送出する
 - (10) : `pos >` [`sv.size()`](/reference/string_view/basic_string_view/size.md)である場合、[`out_of_range`](/reference/stdexcept.md)例外を送出する
+- (11) : `pos` が `s` の長さ (`traits_type::length(s)`) を超える場合、[`out_of_range`](/reference/stdexcept.md)例外を送出する
 
 
 
@@ -183,6 +196,11 @@ int main()
   std::string s10;
   s10.assign(std::string_view{"Hello World"}, 0, 5);
   std::cout << "s10 : " << s10 << std::endl;
+
+  // (11) 文字配列を範囲指定して代入
+  std::string s11;
+  s11.assign("Hello World", 0, 5);
+  std::cout << "s11 : " << s11 << std::endl;
 }
 ```
 * assign[color ff0000]
@@ -199,6 +217,7 @@ s7 : hello
 s8 : hello
 s9 : Hello
 s10 : Hello
+s11 : Hello
 ```
 
 ## 参照
@@ -211,3 +230,5 @@ s10 : Hello
 - [LWG Issue 2946. LWG 2758's resolution missed further corrections](https://wg21.cmeerw.net/lwg/issue2946)
     - 意図しない暗黙変換防止のために`string_view`を受けるオーバーロード(9), (10)の引数型を`const T&`に変更
 - [P0980R1 Making `std::string` constexpr](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0980r1.pdf)
+- [LWG Issue 3662 `basic_string::append/assign(NTBS, pos, n)` suboptimal](https://cplusplus.github.io/LWG/issue3662)
+    - C++26で、NULL終端文字列の一部分を代入する(11)のオーバーロードが追加された


### PR DESCRIPTION
- [P4146R0 C++ Standard Library Immediate Issues to be moved in Croydon, Mar. 2026](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4146r0.html)