### PR TITLE
forkリポジトリからのPull RequestでCI実行できなくなった問題を修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,7 @@ jobs:
         fetch-depth: 0
         ref: ${{ steps.vars.outputs.head_ref }}
         path: site_generator/cpprefjp/site
+        allow-unsafe-pr-checkout: true
     - run: git submodule update --init
       working-directory: site_generator/cpprefjp/site
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -29,6 +29,7 @@ jobs:
       with:
         repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.ref }}
+        allow-unsafe-pr-checkout: true
     - uses: actions/checkout@v4
       with:
         repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.full_name || github.event.repository.full_name }}
@@ -89,6 +90,7 @@ jobs:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
 
       - id: vars
         uses: actions/github-script@v7


### PR DESCRIPTION
- https://github.com/cpprefjp/site/pull/1714

forkリポジトリから提出されたPull RequestでのCI実行がエラーになるようになりました。
これはGitHubのセキュリティアップデートによるもので、悪意あるコードを含むPRを実行させないように、 `actions/checkout@v4` に、デフォルトで `allow-unsafe-pr-checkout: false`がつくようになったのが原因です。

しかし本リポジトリはほぼほぼMarkdownドキュメントで構成されているので、そのリスクは低いと考え、 `allow-unsafe-pr-checkout`を`true`にする対応を入れました。