### PR TITLE
workflows : 依存するActionsのバージョン更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
 
     # site_generator
     - name: Check out cpprefjp/site_generator
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: cpprefjp/site_generator
         path: site_generator
@@ -39,7 +39,7 @@ jobs:
 
     # kunai
     - name: Check out cpprefjp/kunai
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: cpprefjp/kunai
         path: site_generator/kunai
@@ -48,7 +48,7 @@ jobs:
 
     # site (typically cpprefjp/site)
     - name: Check out ${{ steps.vars.outputs.head_repo }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: ${{ steps.vars.outputs.head_repo }}
         # atom 生成のために全履歴が必要
@@ -61,13 +61,13 @@ jobs:
 
     # image
     - name: Check out cpprefjp/image
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: cpprefjp/image
         path: site_generator/cpprefjp/image
 
     - name: Set up Python 3.x
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: 3.11
         # 3.12でUndefined symbolエラーがでた
@@ -77,7 +77,7 @@ jobs:
     # head の build.sh に悪意のあるコードが埋め込まれていると秘密鍵な
     # ど盗まれてしまう。
     - name: Check out build.sh
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: ${{ steps.vars.outputs.base_repo }}
         ref: master
@@ -97,7 +97,7 @@ jobs:
     # Deploy 用
     - name: "(Deploy) Check out cpprefjp.github.io"
       if: inputs.arguments == ''
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: cpprefjp/cpprefjp.github.io
         path: site_generator/cpprefjp/cpprefjp.github.io
@@ -106,7 +106,7 @@ jobs:
     - name: "(Preview build) Check out gh-pages"
       if: startsWith(inputs.arguments, '--pull ')
       continue-on-error: true
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         repository: ${{ github.event.pull_request.base.repo.full_name }}
         ref: gh-pages
@@ -114,7 +114,7 @@ jobs:
     - name: "(Preview build) Collect GitHub context"
       id: preview_vars
       if: startsWith(inputs.arguments, '--pull ')
-      uses: actions/github-script@v7
+      uses: actions/github-script@v9
       with:
         script: |
           const sha0 = context.payload.pull_request.base.sha;

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -18,19 +18,19 @@ jobs:
     name: check (${{ matrix.item.name }})
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install requests
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name || github.event.repository.full_name }}
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.ref || github.ref }}
         allow-unsafe-pr-checkout: true
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         repository: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.base.repo.full_name || github.event.repository.full_name }}
         ref: ${{ github.event_name == 'pull_request_target' && 'master' || github.ref }}
@@ -55,7 +55,7 @@ jobs:
       cache-version: v1
     steps:
     - id: cache-ripgrep
-      uses: actions/cache@v3
+      uses: actions/cache@v5
       with:
         path: ${{ env.BIN_DIR }}
         key: ${{ env.cache-version }}-ripgrep-${{ env.RIPGREP_VERSION }}
@@ -66,7 +66,7 @@ jobs:
         mkdir -p $BIN_DIR
         tar xvf ripgrep-$RIPGREP_VERSION-x86_64-unknown-linux-musl.tar.gz --strip=1 --no-anchor -C $BIN_DIR rg
       working-directory: ${{ runner.temp }}
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         path: ${{ env.REPO_DIR }}
     - name: check
@@ -85,7 +85,7 @@ jobs:
     needs: preview_build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
@@ -93,7 +93,7 @@ jobs:
           allow-unsafe-pr-checkout: true
 
       - id: vars
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const sha0 = context.payload.pull_request.base.sha;

--- a/.github/workflows/outer_link_check.yml
+++ b/.github/workflows/outer_link_check.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.x'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install requests
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         ref: master
     - name: check

--- a/.github/workflows/preview_clear.yml
+++ b/.github/workflows/preview_clear.yml
@@ -8,7 +8,7 @@ jobs:
       group: cpprefjp.gh-pages.lock
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: gh-pages
           fetch-depth: 0


### PR DESCRIPTION
GitHub Actionsで以下のような警告が出ています。
cpprefjpで使用している他のActionsがNode.js 20を使用しようとしているためです。

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/cache@v3, actions/checkout@v4. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

このPRでは、警告されているActionsのバージョンを以下の通り更新します。

- `actions/cache@v3` → `v5`
- `actions/checkout@v4` → `v7`
- `actions/setup-python@v5` → `v7`
- `actions/github-script@v7` → `v9`
- `thollander/actions-comment-pull-request@v3` → （対応バージョンなし）

PRでのプレビュー生成のコメント送信に使っている `thollander/actions-comment-pull-request` は、更新が止まっているようで、この警告に対応したバージョンはありませんでした。
現状はGitHubにより強制的にNode.js 24に切り替わっていて、それで動いているので、緊急に対応する必要はなさそうです。
`gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body ":zap: [**プレビュー (HTML)**]…"` で同じようなことができそうなので、それに置換するべきかもしれません。