### PR TITLE
C++26 LWG Issueへの対応第5弾

### DIFF
--- a/reference/expected/expected/op_constructor.md
+++ b/reference/expected/expected/op_constructor.md
@@ -89,6 +89,7 @@ constexpr bool converts-from-any-cvref =
 - (6) : 次の制約を全て満たすこと
     - [`is_same_v`](/reference/type_traits/is_same.md)`<`[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>,` [`in_place_t`](/reference/utility/in_place_t.md)`> == false`
     - [`is_same_v`](/reference/type_traits/is_same.md)`<expected,` [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>> == false`
+    - [`is_same_v`](/reference/type_traits/is_same.md)`<`[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>,` [`unexpect_t`](../unexpect_t.md)`> == false`
     - [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>`は[`unexpected`](../unexpected.md)の特殊化でない
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<T, U> == true`
 - (7) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, const G&> == true`
@@ -319,3 +320,5 @@ int main()
 
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
+- [LWG Issue 4222. `expected` constructor from a single value missing a constraint](https://cplusplus.github.io/LWG/issue4222)
+    - C++26で、(6)の制約に[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>`が[`unexpect_t`](../unexpect_t.md)でないことが追加された

--- a/reference/flat_map/flat_map/try_emplace.md
+++ b/reference/flat_map/flat_map/try_emplace.md
@@ -118,14 +118,14 @@ constexpr iterator
 
 - (5), (6) :
     ```cpp
-    auto key_it = ranges::upper_bound(c.keys, k, compare);
+    auto key_it = upper_bound(c.keys.begin(), c.keys.end(), k, compare);
     auto value_it = c.values.begin() + distance(c.keys.begin(), key_it);
     c.keys.emplace(key_it, std::forward<K>(k));
     c.values.emplace(value_it, std::forward<Args>(args)...);
     ```
     * c.keys[link containers.md]
     * c.values[link containers.md]
-    * ranges::upper_bound[link /reference/algorithm/ranges_upper_bound.md]
+    * upper_bound[link /reference/algorithm/upper_bound.md]
     * begin()[link /reference/vector/vector/begin.md]
     * distance[link /reference/iterator/distance.md]
     * emplace[link /reference/vector/vector/emplace.md]
@@ -204,3 +204,5 @@ false, 114, false
 
 ## 参照
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)
+- [LWG Issue 4239. `flat_map`'s transparent comparator no longer works for string literals](https://cplusplus.github.io/LWG/issue4239)
+    - C++26で、(5), (6)の効果で範囲版[`ranges::upper_bound`](/reference/algorithm/ranges_upper_bound.md)からイテレータ版[`upper_bound`](/reference/algorithm/upper_bound.md)に変更された（文字列リテラルをキーとする透過的比較が機能しなくなる問題を修正）

--- a/reference/hive/hive/erase_free.md
+++ b/reference/hive/hive/erase_free.md
@@ -75,3 +75,5 @@ erased = 2
 ## 参照
 - [P0447R28 Introduction of `std::hive` to the standard library](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0447r28.html)
     - C++26で`hive`が追加された
+- [LWG Issue 4233. The helper lambda of `std::erase` for `hive` should specify return type as `bool`](https://cplusplus.github.io/LWG/issue4233)
+    - C++26で、テンプレートパラメータ`U`にデフォルト引数`= T`が追加され、効果のラムダに戻り値型`-> bool`が明示された

--- a/reference/iterator/counted_iterator/op_equal.md
+++ b/reference/iterator/counted_iterator/op_equal.md
@@ -8,7 +8,7 @@
 template<common_with<I> I2>
 friend constexpr bool operator==(const counted_iterator& x, const counted_iterator<I2>& y);  // (1)
 
-friend constexpr bool operator==(const counted_iterator& x, default_sentinel_t);             // (2)
+friend constexpr bool operator==(const counted_iterator& x, default_sentinel_t) noexcept;    // (2)
 ```
 
 ## 概要
@@ -34,17 +34,17 @@ C++20以降、これらの演算子により以下の演算子が使用可能に
 template<common_with<I> I2>
 friend constexpr bool operator==(const counted_iterator<I2>& y, const counted_iterator& x);
 
-friend constexpr bool operator==(default_sentinel_t, const counted_iterator& x);
+friend constexpr bool operator==(default_sentinel_t, const counted_iterator& x) noexcept;
 
 template<common_with<I> I2>
 friend constexpr bool operator!=(const counted_iterator& x, const counted_iterator<I2>& y);
 
-friend constexpr bool operator!=(const counted_iterator& x, default_sentinel_t); 
+friend constexpr bool operator!=(const counted_iterator& x, default_sentinel_t) noexcept;
 
 template<common_with<I> I2>
 friend constexpr bool operator!=(const counted_iterator<I2>& y, const counted_iterator& x);
 
-friend constexpr bool operator!=(default_sentinel_t, const counted_iterator& x);
+friend constexpr bool operator!=(default_sentinel_t, const counted_iterator& x) noexcept;
 ```
 
 また、これらの演算子は全て[*Hidden friends*](/article/lib/hidden_friends.md)として定義される。
@@ -99,3 +99,5 @@ true
 
 ## 参照
 - [P0896R4 The One Ranges Proposal (was Merging the Ranges TS)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0896r4.pdf)
+- [LWG Issue 4245. Operators that interact with `counted_iterator` and `default_sentinel_t` should be `noexcept`](https://cplusplus.github.io/LWG/issue4245)
+    - C++26で、(2)（および`default_sentinel_t`と相互作用する派生演算子）に`noexcept`が追加された

--- a/reference/iterator/counted_iterator/op_minus.md
+++ b/reference/iterator/counted_iterator/op_minus.md
@@ -10,10 +10,10 @@ friend constexpr iter_difference_t<I2> operator-(
   const counted_iterator& x, const counted_iterator<I2>& y);  // (1)
 
 friend constexpr iter_difference_t<I> operator-(
-  const counted_iterator& x, default_sentinel_t);             // (2)
+  const counted_iterator& x, default_sentinel_t) noexcept;    // (2)
 
 friend constexpr iter_difference_t<I> operator-(
-  default_sentinel_t, const counted_iterator& y);             // (3)
+  default_sentinel_t, const counted_iterator& y) noexcept;    // (3)
 ```
 
 ## 概要
@@ -84,3 +84,5 @@ int main() {
 
 ## 参照
 - [P0896R4 The One Ranges Proposal (was Merging the Ranges TS)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0896r4.pdf)
+- [LWG Issue 4245. Operators that interact with `counted_iterator` and `default_sentinel_t` should be `noexcept`](https://cplusplus.github.io/LWG/issue4245)
+    - C++26で、(2), (3)に`noexcept`が追加された

--- a/reference/mdspan/LayoutMapping.md
+++ b/reference/mdspan/LayoutMapping.md
@@ -80,6 +80,7 @@ LayoutMappingを満たす型`M`は
 - `m.stride(r)` : `M::index_type`型を返すこと。
     - 前提条件 : `m.is_strided() == true`
     - 戻り値 : `r`番目次元のストライド幅
+    - `m.extents().rank()`が`0`のときは、`M::is_always_strided()`が`true`であっても`m.stride(r)`が妥当である必要はない
 - `M::is_always_unique()` : `bool`型の定数式となること。
     - 戻り値 : 型`M`のあらゆるオブジェクトにおいてUnique特性を満たすときに`true`。
 - `M::is_always_exhaustive()` : `bool`型の定数となること。
@@ -114,3 +115,5 @@ LayoutMappingを満たす型`M`は
 ## 参照
 - [P0009R18 MDSPAN](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r18.html)
 - [P2604R0 `mdspan`: rename `pointer` and `contiguous`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2604r0.html)
+- [LWG Issue 4217. Clarify `mdspan` layout mapping requirements for `rank == 0`](https://cplusplus.github.io/LWG/issue4217)
+    - C++26で、`rank()`が`0`の場合は`m.stride(r)`が妥当である必要はないことが明確化された

--- a/reference/ostream/basic_ostream/sentry/op_destructor.md
+++ b/reference/ostream/basic_ostream/sentry/op_destructor.md
@@ -13,8 +13,10 @@
 
 ## 効果
 `(os.`[`flags`](../../../ios/ios_base/flags.md)`() & unitbuf) && !`[`uncaught_exception`](../../../exception/uncaught_exception.md)`() && os.`[`good`](../../../ios/basic_ios/good.md)`()` が `true` なら、`os.`[`rdbuf`](../../../ios/basic_ios/rdbuf.md)`()->`[`pubsync`](../../../streambuf/basic_streambuf/pubsync.md)`()` を呼び出す。  
-`os.`[`rdbuf`](../../../ios/basic_ios/rdbuf.md)`()->`[`pubsync`](../../../streambuf/basic_streambuf/pubsync.md)`()` が `-1` を返したら、`badbit` を設定する。ただし、これにより例外を投げることはない。
+`os.`[`rdbuf`](../../../ios/basic_ios/rdbuf.md)`()->`[`pubsync`](../../../streambuf/basic_streambuf/pubsync.md)`()` が `-1` を返す、または例外を送出して終了した場合、`badbit` を設定する。ただし、これにより例外が伝播することはない。
 
 ## 参照
 - [`(constructor)`](op_constructor.md)
 - [`operator bool`](op_bool.md)
+- [LWG Issue 4188. `ostream::sentry` destructor should handle exceptions](https://cplusplus.github.io/LWG/issue4188)
+    - C++26で、`pubsync()`が例外を送出して終了した場合も`badbit`を設定し、例外を伝播しないことが明確化された

--- a/reference/random/discard_block_engine.md
+++ b/reference/random/discard_block_engine.md
@@ -86,6 +86,10 @@ namespace std {
 | [`operator>>`](discard_block_engine/op_istream.md)   | ストリームからの入力 | C++11 |
 
 
+## 備考
+このクラステンプレートは、ストリーム挿入子（[`operator<<`](discard_block_engine/op_ostream.md)）と抽出子（[`operator>>`](discard_block_engine/op_istream.md)）を除いて、フリースタンディング処理系でも使用できる。
+
+
 ## 例
 ```cpp example
 #include <iostream>

--- a/reference/random/independent_bits_engine.md
+++ b/reference/random/independent_bits_engine.md
@@ -77,6 +77,10 @@ namespace std {
 | [`operator>>`](independent_bits_engine/op_istream.md)   | ストリームからの入力 | C++11 |
 
 
+## 備考
+このクラステンプレートは、ストリーム挿入子（[`operator<<`](independent_bits_engine/op_ostream.md)）と抽出子（[`operator>>`](independent_bits_engine/op_istream.md)）を除いて、フリースタンディング処理系でも使用できる。
+
+
 ## 例
 ```cpp example
 #include <iostream>

--- a/reference/random/linear_congruential_engine.md
+++ b/reference/random/linear_congruential_engine.md
@@ -100,7 +100,7 @@ C言語から引き継いだ標準ライブラリ関数[`std::rand()`](/referenc
 
 
 ## 備考
-このクラステンプレートは、フリースタンディング処理系でも使用できる。
+このクラステンプレートは、ストリーム挿入子（[`operator<<`](linear_congruential_engine/op_ostream.md)）と抽出子（[`operator>>`](linear_congruential_engine/op_istream.md)）を除いて、フリースタンディング処理系でも使用できる。
 
 ## 例
 ```cpp example

--- a/reference/random/mersenne_twister_engine.md
+++ b/reference/random/mersenne_twister_engine.md
@@ -124,7 +124,7 @@ namespace std {
 
 
 ## 備考
-このクラステンプレートは、フリースタンディング処理系でも使用できる。
+このクラステンプレートは、ストリーム挿入子（[`operator<<`](mersenne_twister_engine/op_ostream.md)）と抽出子（[`operator>>`](mersenne_twister_engine/op_istream.md)）を除いて、フリースタンディング処理系でも使用できる。
 
 ## 例
 ```cpp example

--- a/reference/random/philox_engine.md
+++ b/reference/random/philox_engine.md
@@ -163,7 +163,7 @@ $ r \cdot w $ ビット
 
 
 ## 備考
-このクラステンプレートは、フリースタンディング処理系でも使用できる。
+このクラステンプレートは、ストリーム挿入子（[`operator<<`](philox_engine/op_ostream.md)）と抽出子（[`operator>>`](philox_engine/op_istream.md)）を除いて、フリースタンディング処理系でも使用できる。
 
 ## 例
 ### 基本的な使い方
@@ -273,3 +273,5 @@ int main()
     - 2011年に発表されたこの論文でPhilox乱数生成器が考案された
 - [P4037R1 Supporting `signed char` and `unsigned char` in random number generation](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4037r1.html)
     - `UIntType`テンプレートパラメータの要件が明文化された（拡張符号なし整数型および処理系定義のサブセットを許容）。この仕様はC++26から導入されたが、仕様の欠陥を修正したものであるためコンパイラは早期に対応している場合がある
+- [LWG Issue 4224. Philox engines should be freestanding](https://cplusplus.github.io/LWG/issue4224)
+    - C++26で、このクラステンプレートおよび[`philox4x32`](philox4x32.md)/[`philox4x64`](philox4x64.md)がフリースタンディング処理系に対応した（ストリーム挿入子・抽出子はホスト処理系専用）

--- a/reference/random/shuffle_order_engine.md
+++ b/reference/random/shuffle_order_engine.md
@@ -93,6 +93,10 @@ namespace std {
 | [`operator>>`](shuffle_order_engine/op_istream.md)   | ストリームからの入力 | C++11 |
 
 
+## 備考
+このクラステンプレートは、ストリーム挿入子（[`operator<<`](shuffle_order_engine/op_ostream.md)）と抽出子（[`operator>>`](shuffle_order_engine/op_istream.md)）を除いて、フリースタンディング処理系でも使用できる。
+
+
 ## 例
 ```cpp example
 #include <iostream>

--- a/reference/random/subtract_with_carry_engine.md
+++ b/reference/random/subtract_with_carry_engine.md
@@ -98,7 +98,7 @@ namespace std {
 
 
 ## 備考
-このクラステンプレートは、フリースタンディング処理系でも使用できる。
+このクラステンプレートは、ストリーム挿入子（[`operator<<`](subtract_with_carry_engine/op_ostream.md)）と抽出子（[`operator>>`](subtract_with_carry_engine/op_istream.md)）を除いて、フリースタンディング処理系でも使用できる。
 
 ## 例
 ```cpp example

--- a/reference/ranges/cache_latest_view.md
+++ b/reference/ranges/cache_latest_view.md
@@ -60,6 +60,7 @@ v | std::views::transform(expensive) // 重い変換関数
 | [`begin`](cache_latest_view/begin.md)                         | 先頭を指すイテレータを取得する   | C++26 |
 | [`end`](cache_latest_view/end.md)                             | 番兵を取得する                   | C++26 |
 | [`size`](cache_latest_view/size.md)                           | 要素数を取得する                 | C++26 |
+| [`reserve_hint`](cache_latest_view/reserve_hint.md)           | 要素数の推定値を取得する         | C++26 |
 
 
 ## 継承しているメンバ関数
@@ -167,3 +168,5 @@ call_count: 5
 
 ## 参照
 - [P3138R5 `views::cache_latest`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3138r5.html)
+- [LWG Issue 4235. `cache_latest_view` and `to_input_view` miss `reserve_hint`](https://cplusplus.github.io/LWG/issue4235)
+    - C++26で、[`approximately_sized_range`](approximately_sized_range.md)のときに要素数の推定値を返す[`reserve_hint`](cache_latest_view/reserve_hint.md)メンバ関数が追加された

--- a/reference/ranges/cache_latest_view/reserve_hint.md
+++ b/reference/ranges/cache_latest_view/reserve_hint.md
@@ -1,0 +1,63 @@
+# reserve_hint
+* ranges[meta header]
+* std::ranges[meta namespace]
+* cache_latest_view[meta class]
+* function[meta id-type]
+* cpp26[meta cpp]
+
+```cpp
+constexpr auto reserve_hint()
+  requires approximately_sized_range<V>;       // (1) C++26
+
+constexpr auto reserve_hint() const
+  requires approximately_sized_range<const V>; // (2) C++26
+```
+* approximately_sized_range[link ../approximately_sized_range.md]
+
+## 概要
+要素数の推定値（確保のヒント）を取得する。
+
+
+## 効果
+- (1), (2) : 以下と等価：
+
+```cpp
+return ranges::reserve_hint(base_);
+```
+* ranges::reserve_hint[link ../reserve_hint.md]
+
+
+## 例
+```cpp example
+#include <ranges>
+#include <vector>
+#include <print>
+
+int main() {
+  std::vector<int> v = {1, 2, 3, 4, 5};
+
+  std::ranges::cache_latest_view view{v};
+
+  std::println("{}", view.reserve_hint());
+}
+```
+
+### 出力
+```
+5
+```
+
+
+## バージョン
+### 言語
+- C++26
+
+### 処理系
+- [Clang](/implementation.md#clang): 22 [mark noimpl]
+- [GCC](/implementation.md#gcc): 16.1 [mark noimpl]
+- [Visual C++](/implementation.md#visual_cpp): 2026 Update 2 [mark noimpl]
+
+
+## 関連項目
+- [`size`](size.md)
+- [`std::ranges::reserve_hint`](../reserve_hint.md)

--- a/reference/simd/chunk.md
+++ b/reference/simd/chunk.md
@@ -97,3 +97,5 @@ int main()
     - C++26で`std::simd`ライブラリが追加された
 - [P3441R2 Rename `simd_split` to `simd_chunk`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3441r2.html)
     - 分割関数の名前が`simd_split`から`chunk`に改名された
+- [LWG Issue 4231. `datapar::chunk<N>` should use `simd-size-type` instead of `size_t`](https://cplusplus.github.io/LWG/issue4231)
+    - C++26で、(3)(4)のテンプレートパラメータ`N`の型が`size_t`から`simd-size-type`に修正された

--- a/reference/simd/resize.md
+++ b/reference/simd/resize.md
@@ -68,3 +68,5 @@ true
 ## 参照
 - [P1928R15 std::simd — merge data-parallel types from the Parallelism TS 2](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1928r15.pdf)
     - C++26で`std::simd`ライブラリが追加された
+- [LWG Issue 4232. `datapar::resize` does not resize](https://cplusplus.github.io/LWG/issue4232)
+    - C++26で、`type`のABIタグを選ぶ際に元の要素数ではなく`N`を用いることが明確化された（元の要素数のまま変化しないバグを修正）

--- a/reference/stdbit.h.md
+++ b/reference/stdbit.h.md
@@ -11,6 +11,10 @@ C言語では型総称マクロ (type-generic macro) として提供される汎
 C++固有のビット操作機能が必要な場合は、[`<bit>`](bit.md)ヘッダの使用を推奨する。
 
 
+## フリースタンディング
+このヘッダは、フリースタンディング処理系でも使用できる。本ヘッダが提供する全ての機能がフリースタンディング処理系で使用可能である。
+
+
 ## マクロ
 
 | 名前 | 説明 | 対応バージョン |
@@ -89,3 +93,5 @@ C++固有のビット操作機能が必要な場合は、[`<bit>`](bit.md)ヘッ
 ## 参照
 - [N3022 Modern Bit Utilities](https://www.open-std.org/jtc1/sc22/wg14/www/docs/n3022.htm)
 - [P3370R1 Add new C headers as C++ headers](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3370r1.html)
+- [LWG Issue 4247. Header `<stdbit.h>` is not yet freestanding](https://cplusplus.github.io/LWG/issue4247)
+    - C++26で、このヘッダがフリースタンディング処理系に対応した


### PR DESCRIPTION
- [P3742R0 C++ Standard Library Issues to be moved in Sofia, Jun. 2025](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3742r0.html)

これに全て対応しました。