### PR TITLE
C++26 LWG Issueへの対応第6弾

### DIFF
--- a/reference/algorithm/inplace_merge.md
+++ b/reference/algorithm/inplace_merge.md
@@ -70,7 +70,7 @@ namespace std {
 ## 計算量
 `N = last - first`であるとして説明する。
 
-- (1), (2) : 余分なメモリを使用する場合は、`N - 1` 回比較する。そうでない場合は、O(N log(N))回比較する
+- (1), (2) : 余分なメモリを使用する場合は、最大で `N - 1` 回比較する。そうでない場合は、O(N log(N))回比較する
 - (3), (4) : O(N log N)回比較する
 
 
@@ -115,3 +115,5 @@ int main()
 ## 参照
 - [P2562R1 `constexpr` Stable Sorting](https://open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2562r1.pdf)
     - C++26から`constexpr`に対応した
+- [LWG Issue 4196. Complexity of `inplace_merge()` is incorrect](https://cplusplus.github.io/LWG/issue4196)
+    - C++26で、余分なメモリを使用する場合の比較回数が「ちょうど`N - 1`回」から「最大で`N - 1`回」に修正された

--- a/reference/algorithm/ranges_inplace_merge.md
+++ b/reference/algorithm/ranges_inplace_merge.md
@@ -121,7 +121,7 @@ namespace std::ranges {
 ## 計算量
 `N = last - first`であるとして説明する。
 
-- 余分なメモリを使用する場合は、`N - 1` 回比較する。そうでない場合は、O(N log(N))回比較する
+- 余分なメモリを使用する場合は、最大で `N - 1` 回比較する。そうでない場合は、O(N log(N))回比較する
 
 ## 備考
 この操作は安定である。つまり、各入力範囲内の要素の前後関係は保たれ、また、1 番目の範囲と 2 番目に等値の要素があった場合には、1 番目の範囲の要素の方が先に来る。
@@ -204,5 +204,7 @@ int main() {
 - [P2562R1 `constexpr` Stable Sorting](https://open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2562r1.pdf)
     - C++26から`constexpr`に対応した
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 4196. Complexity of `inplace_merge()` is incorrect](https://cplusplus.github.io/LWG/issue4196)
+    - C++26で、余分なメモリを使用する場合の比較回数が「ちょうど`N - 1`回」から「最大で`N - 1`回」に修正された
 - [LWG Issue 4441. `ranges::rotate` do not handle sized-but-not-sized-sentinel ranges correctly](https://cplusplus.github.io/LWG/issue4441)
     - C++26で、実行ポリシーをとる範囲版の効果を規定する等価コードで、末尾イテレータの算出が`ranges::end(r)`から`ranges::begin(r) + ranges::distance(r)`へ変更された。サイズは判るがsized sentinelを持たない範囲を正しく扱うため

--- a/reference/algorithm/ranges_search.md
+++ b/reference/algorithm/ranges_search.md
@@ -86,7 +86,7 @@ namespace std::ranges {
 
 ## 戻り値
 - (1) :
-    - `[first1,last1 - (last2 - first2))` 内のイテレータ `i` があるとき、0 以上 `last2 - first2` 未満の整数 `n` について、それぞれ [`invoke`](/reference/functional/invoke.md)`(pred,` [`invoke`](/reference/functional/invoke.md)`(proj1, *(i + n)),` [`invoke`](/reference/functional/invoke.md)`(proj2, *(first2 + n)))` であるようなサブシーケンスを探し、見つかった最初のサブシーケンスを返す。
+    - `[first1,last1 - (last2 - first2)]` 内のイテレータ `i` があるとき、0 以上 `last2 - first2` 未満の整数 `n` について、それぞれ [`invoke`](/reference/functional/invoke.md)`(pred,` [`invoke`](/reference/functional/invoke.md)`(proj1, *(i + n)),` [`invoke`](/reference/functional/invoke.md)`(proj2, *(first2 + n)))` であるようなサブシーケンスを探し、見つかった最初のサブシーケンスを返す。
     - そのようなイテレータが見つからない場合は `{last1, last1}` を返し、`[first2,last2)` が空である場合には `{first1, first1}` を返す。
 - (2): `first1 = begin(r1)`, `last1 = end(r1)`, `first2 = begin(r2)`, `last2 = end(r2)`の下で(1)と等しい。
 
@@ -197,4 +197,6 @@ inline constexpr search_impl search;
 
 ## 参照
 - [N4861 25 Algorithms library](https://timsong-cpp.github.io/cppwp/n4861/algorithms)
+- [LWG Issue 4179. Wrong range in [alg.search]](https://cplusplus.github.io/LWG/issue4179)
+    - C++26で、探索対象のイテレータ`i`の範囲が`[first1, last1 - (last2 - first2)]`（右端を含む閉区間）であることが明確化された
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)

--- a/reference/algorithm/search.md
+++ b/reference/algorithm/search.md
@@ -81,10 +81,10 @@ namespace std {
 
 ## 戻り値
 - (1), (3) :
-    - `[first1,last1 - (last2 - first2))` 内のイテレータ `i` があるとき、0 以上 `last2 - first2` 未満の整数 `n` について、それぞれ `*(i + n) == *(first2 + n)` であるようなサブシーケンスを探し、見つかった最初のサブシーケンスの先頭のイテレータを返す。
+    - `[first1,last1 - (last2 - first2)]` 内のイテレータ `i` があるとき、0 以上 `last2 - first2` 未満の整数 `n` について、それぞれ `*(i + n) == *(first2 + n)` であるようなサブシーケンスを探し、見つかった最初のサブシーケンスの先頭のイテレータを返す。
     - そのようなイテレータが見つからない場合は `last1` を返し、`[first2,last2)` が空である場合には `first1` を返す。
 - (2), (4) :
-    - `[first1,last1 - (last2 - first2))` 内のイテレータ `i` があるとき、0 以上 `last2 - first2` 未満の整数 `n` について、それぞれ `*(i + n) == *(first2 + n)` であるようなサブシーケンスを探し、見つかった最初のサブシーケンスの先頭のイテレータを返す。
+    - `[first1,last1 - (last2 - first2)]` 内のイテレータ `i` があるとき、0 以上 `last2 - first2` 未満の整数 `n` について、それぞれ `*(i + n) == *(first2 + n)` であるようなサブシーケンスを探し、見つかった最初のサブシーケンスの先頭のイテレータを返す。
     - そのようなイテレータが見つからない場合は `last1` を返し、`[first2,last2)` が空である場合には `first1` を返す。
 - (5) : 以下と等価
     ```cpp
@@ -224,6 +224,8 @@ ForwardIterator1 search(ForwardIterator1 first1, ForwardIterator1 last1,
 
 ## 参照
 - [LWG Issue 2150. Unclear specification of `find_end`](http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#2150)
+- [LWG Issue 4179. Wrong range in [alg.search]](https://cplusplus.github.io/LWG/issue4179)
+    - C++26で、探索対象のイテレータ`i`の範囲が`[first1, last1 - (last2 - first2)]`（右端を含む閉区間）であることが明確化された
 - [N3905 Extending `std::search` to use Additional Searching Algorithms (Version 4)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2014/n3905.html)
 - [P0220R1 Adopt Library Fundamentals V1 TS Components for C++17 (R1)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0220r1.html)
 - [P0253R1 Fixing a design mistake in the searchers interface in Library Fundamentals](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0253r1.pdf)

--- a/reference/chrono/parse.md
+++ b/reference/chrono/parse.md
@@ -189,3 +189,5 @@ JST
 - [LWG Issue 3272. `%I%p` should `parse`/`format` `duration` since midnight](https://wg21.cmeerw.net/lwg/issue3272)
 - [LWG Issue 3831. Two-digit formatting of negative `year` is ambiguous](https://cplusplus.github.io/LWG/issue3831)
     - C++26で、`%y`が年の符号によらず年のうしろ2桁を表すことが明確化された
+- [LWG Issue 3956. `chrono::parse` uses `from_stream` as a customization point](https://cplusplus.github.io/LWG/issue3956)
+    - C++26で、`from_stream`が実引数依存の名前探索（ADL）で解決されるカスタマイゼーションポイントであることが、ライブラリ全体の一般規定に明記された

--- a/reference/complex/complex/pow.md
+++ b/reference/complex/complex/pow.md
@@ -63,6 +63,7 @@ namespace std {
         - そうでなくて、いずれかの実引数の型が `complex<float>` か `float` の場合、両方の引数が `complex<float>` にキャストされているかのように振る舞う
         - また、これらの追加のオーバーロードが関数テンプレートなのか否か、あるいは、引数が参照型なのか否かなどについては、規格では何も言及されていない
     - C++23 : `complex<T1>`と、`T2`もしくは`complex<T2>`の組み合わせ、およびその逆の組み合わせに対するオーバーロードとなり、戻り値はその共通の型`complex<`[`common_type_t`](/reference/type_traits/common_type.md)`<T1, T2>>`となった
+    - C++26 : `T2`が整数型の場合は`double`として扱われ、戻り値は`complex<`[`common_type_t`](/reference/type_traits/common_type.md)`<T1, T3>>`（`T3`は`T2`が整数型なら`double`、そうでなければ`T2`）となる。これにより、たとえば`pow(`[`complex`](/reference/complex/complex.md)`<float>, int)`の戻り値は`complex<double>`となる
 
 
 ## 戻り値
@@ -155,3 +156,5 @@ pow( (1,2), (3,4) ) = (0.12901,0.0339241)
     - C++23で拡張浮動小数点数型への対応が行われた
 - [P1383R2 More constexpr for `<cmath>` and `<complex>`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1383r2.pdf)
     - C++26で`constexpr`対応した
+- [LWG Issue 4191. P1467 changed the return type of `pow(complex<float>, int)`](https://cplusplus.github.io/LWG/issue4191)
+    - C++26で、追加のオーバーロードにおいて指数側の引数が整数型の場合は`double`として扱うことが規定され、P1467による戻り値型の変化が修正された

--- a/reference/map/map/merge.md
+++ b/reference/map/map/merge.md
@@ -47,7 +47,7 @@ constexpr void merge(multimap<Key, T, C2, Allocator>&& source); // (4) C++26
 
 
 ## 備考
-- `source` の転送された要素へのポインタおよび参照は、それらと同じ要素を参照するが、`*this` のメンバとして参照する。また、転送された要素を参照する反復子は、引き続きその要素を参照するが、転送後は `source` ではなく `*this` への反復子として動作する。
+- `source` の転送された要素へのポインタおよび参照は、それらと同じ要素を参照するが、`*this` のメンバとして参照する。また、`*this`と`source`の`begin()`が同じ型を返す場合、転送された要素を参照する反復子は、引き続きその要素を参照するが、転送後は `source` ではなく `*this` への反復子として動作する。
 - (2), (4) : これらの右辺値参照オーバーロードは、一時オブジェクトを受け取った場合にコピーを発生させないためだけのものである。パラメータのオブジェクト内のポインタを破壊したり、高速なmerge処理が行われるわけではない
 
 
@@ -111,3 +111,5 @@ m2 :
 ## 参照
 - [Splicing Maps and Sets(Revision 5)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0083r3.pdf)
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)
+- [LWG Issue 3578. Iterator SCARYness in the context of associative container merging](https://cplusplus.github.io/LWG/issue3578)
+    - C++26で、転送された要素を参照する反復子が引き続き有効となるのは、`*this`と`source`の反復子が同じ型である場合であることが明確化された

--- a/reference/map/multimap/merge.md
+++ b/reference/map/multimap/merge.md
@@ -46,7 +46,7 @@ constexpr void merge(multimap<Key, T, C2, Allocator>&& source); // (4) C++26
 
 
 ## 備考
-- `source` の転送された要素へのポインタおよび参照は、それらと同じ要素を参照するが、`*this` のメンバとして参照する。また、転送された要素を参照する反復子は、引き続きその要素を参照するが、転送後は `source` ではなく `*this` への反復子として動作する
+- `source` の転送された要素へのポインタおよび参照は、それらと同じ要素を参照するが、`*this` のメンバとして参照する。また、`*this`と`source`の`begin()`が同じ型を返す場合、転送された要素を参照する反復子は、引き続きその要素を参照するが、転送後は `source` ではなく `*this` への反復子として動作する
 - (2), (4) : これらの右辺値参照オーバーロードは、一時オブジェクトを受け取った場合にコピーを発生させないためだけのものである。パラメータのオブジェクト内のポインタを破壊したり、高速なmerge処理が行われるわけではない
 
 
@@ -110,3 +110,5 @@ m2 :
 ## 参照
 - [Splicing Maps and Sets(Revision 5)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0083r3.pdf)
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)
+- [LWG Issue 3578. Iterator SCARYness in the context of associative container merging](https://cplusplus.github.io/LWG/issue3578)
+    - C++26で、転送された要素を参照する反復子が引き続き有効となるのは、`*this`と`source`の反復子が同じ型である場合であることが明確化された

--- a/reference/mutex/unique_lock/op_assign.md
+++ b/reference/mutex/unique_lock/op_assign.md
@@ -9,6 +9,7 @@
 unique_lock& operator=(const unique_lock&) = delete; // (1) C++11
 unique_lock& operator=(unique_lock&& u) noexcept;    // (2) C++11
 unique_lock& operator=(unique_lock&& u);             // (2) C++14
+unique_lock& operator=(unique_lock&& u) noexcept;    // (2) C++26
 ```
 
 ## 概要
@@ -18,6 +19,7 @@ unique_lock& operator=(unique_lock&& u);             // (2) C++14
 
 ## 効果
 - (2) : [`owns_lock()`](/reference/mutex/unique_lock/owns_lock.md) `== true`だった場合、[`unlock()`](/reference/mutex/unique_lock/unlock.md)を呼び出す。`unique_lock`オブジェクト`u`が保持しているミューテックスの所有権を自分のオブジェクトに移動する。ミューテックスオブジェクトへのポインタおよび[`owns_lock()`](/reference/mutex/unique_lock/owns_lock.md)の状態を`u`から移動する。
+    - C++26 : `unique_lock{`[`std::move`](/reference/utility/move.md)`(u)}.`[`swap`](swap.md)`(*this)`と等価に規定され、自己ムーブ代入も安全に扱われる。
 
 
 ## 事後条件
@@ -65,3 +67,5 @@ int main()
 
 ## 参照
 - [LWG Issue 2104. `unique_lock` move-assignment should not be `noexcept`](http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#2104)
+- [LWG Issue 4172. `unique_lock` self-move-assignment is broken](https://cplusplus.github.io/LWG/issue4172)
+    - C++26で、ムーブ代入がmove-and-swapイディオムで規定され、自己ムーブ代入が安全に扱われるようになり、あわせて`noexcept`指定された

--- a/reference/ranges/cache_latest_view.md
+++ b/reference/ranges/cache_latest_view.md
@@ -87,6 +87,10 @@ v | std::views::transform(expensive) // 重い変換関数
 | [`(deduction_guide)`](cache_latest_view/op_deduction_guide.md)    | クラステンプレートの推論補助 | C++26          |
 
 
+## 備考
+このビュー（および`views::cache_latest`アダプタ）は、フリースタンディング処理系でも使用できる。
+
+
 ## 例
 ### 基本的な使い方
 ```cpp example
@@ -168,5 +172,7 @@ call_count: 5
 
 ## 参照
 - [P3138R5 `views::cache_latest`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3138r5.html)
+- [LWG Issue 4189. `cache_latest_view` should be freestanding](https://cplusplus.github.io/LWG/issue4189)
+    - C++26で、このビューがフリースタンディング処理系に対応した
 - [LWG Issue 4235. `cache_latest_view` and `to_input_view` miss `reserve_hint`](https://cplusplus.github.io/LWG/issue4235)
     - C++26で、[`approximately_sized_range`](approximately_sized_range.md)のときに要素数の推定値を返す[`reserve_hint`](cache_latest_view/reserve_hint.md)メンバ関数が追加された

--- a/reference/set/multiset/merge.md
+++ b/reference/set/multiset/merge.md
@@ -46,7 +46,7 @@ constexpr void merge(multiset<Key, C2, Allocator>&& source); // (4) C++26
 
 
 ## 備考
-- `source` の転送された要素へのポインタおよび参照は、それらと同じ要素を参照するが、`*this` のメンバとして参照する。また、転送された要素を参照するイテレータは、引き続きその要素を参照するが、転送後は `source` ではなく `*this` へのイテレータとして動作する
+- `source` の転送された要素へのポインタおよび参照は、それらと同じ要素を参照するが、`*this` のメンバとして参照する。また、`*this`と`source`の`begin()`が同じ型を返す場合、転送された要素を参照するイテレータは、引き続きその要素を参照するが、転送後は `source` ではなく `*this` へのイテレータとして動作する
 - (2), (4) : これらの右辺値参照オーバーロードは、一時オブジェクトを受け取った場合にコピーを発生させないためだけのものである。パラメータのオブジェクト内のポインタを破壊したり、高速なmerge処理が行われるわけではない
 
 
@@ -103,3 +103,5 @@ s2 = { 10, 10, 20, 30 }
 ## 参照
 - [Splicing Maps and Sets(Revision 5)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0083r3.pdf)
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)
+- [LWG Issue 3578. Iterator SCARYness in the context of associative container merging](https://cplusplus.github.io/LWG/issue3578)
+    - C++26で、転送された要素を参照するイテレータが引き続き有効となるのは、`*this`と`source`のイテレータが同じ型である場合であることが明確化された

--- a/reference/set/set/merge.md
+++ b/reference/set/set/merge.md
@@ -47,7 +47,7 @@ constexpr void merge(multiset<Key, C2, Allocator>&& source); // (4) C++26
 
 
 ## 備考
-- `source` の転送された要素へのポインタおよび参照は、それらと同じ要素を参照するが、`*this` のメンバとして参照する。また、転送された要素を参照する反復子は、引き続きその要素を参照するが、転送後は `source` ではなく `*this` への反復子として動作する
+- `source` の転送された要素へのポインタおよび参照は、それらと同じ要素を参照するが、`*this` のメンバとして参照する。また、`*this`と`source`の`begin()`が同じ型を返す場合、転送された要素を参照する反復子は、引き続きその要素を参照するが、転送後は `source` ではなく `*this` への反復子として動作する
 - (2), (4) : これらの右辺値参照オーバーロードは、一時オブジェクトを受け取った場合にコピーを発生させないためだけのものである。パラメータのオブジェクト内のポインタを破壊したり、高速なmerge処理が行われるわけではない
 
 
@@ -100,3 +100,5 @@ s2 = { 10, 20, 30 }
 ## 参照
 - [Splicing Maps and Sets(Revision 5)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0083r3.pdf)
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)
+- [LWG Issue 3578. Iterator SCARYness in the context of associative container merging](https://cplusplus.github.io/LWG/issue3578)
+    - C++26で、転送された要素を参照する反復子が引き続き有効となるのは、`*this`と`source`の反復子が同じ型である場合であることが明確化された


### PR DESCRIPTION
- [P3615R0 C++ Standard Library Ready Issues to be moved in Hagenberg, Feb. 2025](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3615r0.html)

こちらに全て対応しました。