### PR TITLE
workflows : PRへのコメントをghコマンドで投稿する

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -180,8 +180,7 @@ jobs:
             echo "$content_prologue$content$content_epilogue" >> "$GITHUB_OUTPUT"
             echo 'EOF' >> "$GITHUB_OUTPUT"
       - name: Comment on the pull request
-        run: |
-          gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body "$COMMENT_BODY"
+        run: gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body "$COMMENT_BODY"
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           COMMENT_BODY: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -179,18 +179,19 @@ jobs:
             echo 'content<<EOF' >> "$GITHUB_OUTPUT"
             echo "$content_prologue$content$content_epilogue" >> "$GITHUB_OUTPUT"
             echo 'EOF' >> "$GITHUB_OUTPUT"
-      - uses: thollander/actions-comment-pull-request@v3
-        with:
-          message: |
-            :zap: [**プレビュー (HTML)**](${{ steps.vars.outputs.base_url }}) (更新時刻: ${{ steps.vars.outputs.time }})
+      - name: Comment on the pull request
+        run: |
+          gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body '
+          :zap: [**プレビュー (HTML)**](${{ steps.vars.outputs.base_url }}) (更新時刻: ${{ steps.vars.outputs.time }})
 
-            - **⫯** Commit: ${{ steps.vars.outputs.sha }}
-            - プレビューの生成には時間がかかります (3～5分)。進捗状況は[こちら](https://github.com/${{ steps.vars.outputs.repo_full }}/actions?query=event%3Apull_request_target+branch%3A${{ steps.vars.outputs.ubranch }})をご確認ください。
+          - **⫯** Commit: ${{ steps.vars.outputs.sha }}
+          - プレビューの生成には時間がかかります (3～5分)。進捗状況は[こちら](https://github.com/${{ steps.vars.outputs.repo_full }}/actions?query=event%3Apull_request_target+branch%3A${{ steps.vars.outputs.ubranch }})をご確認ください。
 
-            #### 変更記事一覧
+          #### 変更記事一覧
 
-            ${{ steps.file_list.outputs.content }}
+          ${{ steps.file_list.outputs.content }}
 
-            ※ソース (.md) に直接変更のあった記事を列挙しています。グローバル修飾や変換規則の変更による変化は考慮していません。
-          comment-tag: cpprefjp-preview_link
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          ※ソース (.md) に直接変更のあった記事を列挙しています。グローバル修飾や変換規則の変更による変化は考慮していません。
+          '
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -181,17 +181,18 @@ jobs:
             echo 'EOF' >> "$GITHUB_OUTPUT"
       - name: Comment on the pull request
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --edit-last --create-if-none --body '
-          :zap: [**プレビュー (HTML)**](${{ steps.vars.outputs.base_url }}) (更新時刻: ${{ steps.vars.outputs.time }})
-
-          - **⫯** Commit: ${{ steps.vars.outputs.sha }}
-          - プレビューの生成には時間がかかります (3～5分)。進捗状況は[こちら](https://github.com/${{ steps.vars.outputs.repo_full }}/actions?query=event%3Apull_request_target+branch%3A${{ steps.vars.outputs.ubranch }})をご確認ください。
-
-          #### 変更記事一覧
-
-          ${{ steps.file_list.outputs.content }}
-
-          ※ソース (.md) に直接変更のあった記事を列挙しています。グローバル修飾や変換規則の変更による変化は考慮していません。
-          '
+          gh pr comment "$PR_NUMBER" --edit-last --create-if-none --body "$COMMENT_BODY"
         env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          COMMENT_BODY: |
+            :zap: [**プレビュー (HTML)**](${{ steps.vars.outputs.base_url }}) (更新時刻: ${{ steps.vars.outputs.time }})
+
+            - **⫯** Commit: ${{ steps.vars.outputs.sha }}
+            - プレビューの生成には時間がかかります (3～5分)。進捗状況は[こちら](https://github.com/${{ steps.vars.outputs.repo_full }}/actions?query=event%3Apull_request_target+branch%3A${{ steps.vars.outputs.ubranch }})をご確認ください。
+
+            #### 変更記事一覧
+
+            ${{ steps.file_list.outputs.content }}
+
+            ※ソース (.md) に直接変更のあった記事を列挙しています。グローバル修飾や変換規則の変更による変化は考慮していません。
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
ワークフローでPRにコメントを投稿するためのGitHubアクション `thollander/actions-comment-pull-request@v3` は、廃止された Node.js 20 を使おうとするため次のような警告が表示されます。

> ⚠️  **preview_link**
> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: thollander/actions-comment-pull-request@v3. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

このアクションは更新が2年間止まっており、警告に対応したバージョンが出ることは期待できません。
このPRでは、このアクションを使わず、 `gh pr comment` コマンドによりコメントを投稿するように変更します。


## 変更点

cpprefjpのPRプレビュー生成のワークフローは、生成完了後にそのPRにプレビューのリンクを含めたコメントを投稿しますが、再生成された後はコメントを新規投稿する代わりにすでに投稿したコメントを更新します。

従来は `comment-tag` をつけることでプレビューリンクのコメントを識別し、それを更新していました。
このPRでは、 **github-actions がプレビューリンク以外でコメントを投稿しないと仮定**し、直前の同ユーザーのコメントを更新するオプション `--edit-last` を使っています（この仮定に反例があると壊れます）。


## 動作確認

フォークしたリポジトリのPRでコメントが投稿できることを確認しています。

https://github.com/Raclamusi/site/actions/runs/31986353227/job/95262560086
https://github.com/Raclamusi/site/pull/2

<img width="498" height="179" alt="image" src="https://github.com/user-attachments/assets/04821385-4164-4ffd-803f-e8b3db6251fe" />
