### PR TITLE
C++26 LWG Issueへの対応第8弾

### DIFF
--- a/reference/algorithm/ranges_ends_with.md
+++ b/reference/algorithm/ranges_ends_with.md
@@ -98,7 +98,7 @@ namespace std::ranges {
 * (2): 
     * `N1 =` [`ranges::distance`](/reference/iterator/ranges_distance.md)`(r1)`, `N2 =` [`ranges::distance`](/reference/iterator/ranges_distance.md)`(r2)` とする。
     * `N1 < N2` のとき、`false`
-    * それ以外のとき、[`ranges::equal`](ranges_equal.md)`(`[`ranges::drop_view`](/reference/ranges/drop_view.md)`(`[`ranges::ref_view`](/reference/ranges/ref_view.md)`(r1), N1 - N2), r2, pred, proj1, proj2)`
+    * それ以外のとき、[`ranges::equal`](ranges_equal.md)`(`[`ranges::drop_view`](/reference/ranges/drop_view.md)`(`[`ranges::ref_view`](/reference/ranges/ref_view.md)`(r1), N1 - static_cast<decltype(N1)>(N2)), r2, pred, proj1, proj2)`
 
 
 ## 計算量
@@ -204,3 +204,5 @@ inline constexpr ends_with_impl ends_with;
 ## 参照
 - [N4950 27 Algorithms library](https://timsong-cpp.github.io/cppwp/n4950/algorithms)
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 4105. `ranges::ends_with`'s Returns misses difference casting](https://cplusplus.github.io/LWG/issue4105)
+    - C++26で、範囲版の戻り値で`N1 - N2`が`N1 - static_cast<decltype(N1)>(N2)`に修正され、`N1`と`N2`の差分型が異なる場合にも正しく計算されるようになった

--- a/reference/format/basic_format_args/op_constructor.md
+++ b/reference/format/basic_format_args/op_constructor.md
@@ -7,7 +7,7 @@
 * cpp20[meta cpp]
 
 ```cpp
-basic_format_args() noexcept; // (1) C++20
+basic_format_args() noexcept; // (1) C++20 (C++26で削除)
 
 template<class... Args>
 basic_format_args(
@@ -22,7 +22,7 @@ basic_format_args(
 
 ## 概要
 
-* (1): 空の`basic_format_args`を構築する
+* (1): 空の`basic_format_args`を構築する（このデフォルトコンストラクタはC++26で削除された）
 * (2): [`make_format_args`](../make_format_args.md)の戻り値から浅いコピーで`basic_format_args`を構築する。
 
 ただし、 _`format_arg_store`_ は`make_format_args`の戻り値と同じ型であることを示す便宜上の名前であり、規格には含まれない。
@@ -71,3 +71,5 @@ namespace std {
 - [P0645R10 Text Formatting](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0645r10.html)
 - [P3391R2 `constexpr std::format`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3391r2.html)
     - C++26から`constexpr`に対応した
+- [LWG Issue 4106. `basic_format_args` should not be default-constructible](https://cplusplus.github.io/LWG/issue4106)
+    - C++26で、(1)のデフォルトコンストラクタが削除された

--- a/reference/format/basic_format_context.md
+++ b/reference/format/basic_format_context.md
@@ -31,6 +31,8 @@ namespace std {
 
 出力イテレータの型はフォーマット関数に指定したイテレータである必要はない。内部でバッファリングを行う実装が可能である。
 
+C++26では、コピーコンストラクタとコピー代入演算子が`= delete`で明示的に削除され、このクラスがコピー構築・コピー代入できないことが明確化された（これにともないムーブおよびデフォルト構築もできない）。
+
 ## メンバ関数
 
 | 名前                                 | 説明                                         | 対応バージョン |
@@ -104,3 +106,5 @@ namespace std {
 ## 参照
 
 * [P0645R10 Text Formatting](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0645r10.html)
+* [LWG Issue 4061. Should `std::basic_format_context` be default-constructible/copyable/movable?](https://cplusplus.github.io/LWG/issue4061)
+    * C++26で、コピーコンストラクタとコピー代入演算子が`= delete`で明示的に削除され、コピー・ムーブ・デフォルト構築ができないことが明確化された

--- a/reference/format/formatter.md
+++ b/reference/format/formatter.md
@@ -57,7 +57,7 @@ namespace std {
 
 標準でもユーザー定義でも特殊化されない場合、その型に対する`formatter`は無効であり、そのような型はフォーマット関数の引数にできない。
 
-ワイド文字列とマルチバイト文字列を相互に変換するような特殊化は意図的に用意されていないが、ユーザーが用意することは禁止していない。
+ワイド文字列とマルチバイト文字列を相互に変換するような特殊化は意図的に用意されていない。とくにC++26では、`char`のシーケンス（`char*`, `const char*`, `char[N]`, `basic_string<char>`, `basic_string_view<char>`）を`wchar_t`としてフォーマットする特殊化が、暗黙のマルチバイト／ワイド文字変換を避けるため、`<format>`ヘッダで明示的に無効化された特殊化として提供される。
 
 ## ユーザーの型で`formatter`を特殊化する場合の要件
 
@@ -284,3 +284,5 @@ int main()
 - [P2286R8 Formatting Ranges](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2286r8.html)
 - [P2585R1 Improve default container formatting](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2585r1.html)
     - C++23から、Range・コンテナ、`pair`、`tuple`のフォーマット出力、および文字・文字列のデバッグ指定 (`"?"`) が追加された
+- [LWG Issue 3944. Formatters converting sequences of `char` to sequences of `wchar_t`](https://cplusplus.github.io/LWG/issue3944)
+    - C++26で、`char`のシーケンスを`wchar_t`としてフォーマットする特殊化が、暗黙のマルチバイト／ワイド文字変換を避けるため明示的に無効化された

--- a/reference/functional/reference_wrapper/op_compare_3way.md
+++ b/reference/functional/reference_wrapper/op_compare_3way.md
@@ -5,15 +5,15 @@
 * function template[meta id-type]
 
 ```cpp
-friend constexpr synth-three-way-result<T>
+friend constexpr auto
   operator<=>(reference_wrapper x,
               reference_wrapper y);          // (1) C++26
 
-friend constexpr synth-three-way-result<T>
+friend constexpr auto
   operator<=>(reference_wrapper x,
               const T& y);                   // (2) C++26
 
-friend constexpr synth-three-way-result<T>
+friend constexpr auto
   operator<=>(reference_wrapper x,
               reference_wrapper<const T> y); // (3) C++26
 ```
@@ -29,7 +29,9 @@ friend constexpr synth-three-way-result<T>
 
 
 ## テンプレートパラメータ制約
-- (3) : [`is_const_v`](/reference/type_traits/is_const.md)`<T>`が`false`であること
+- (1) : `synth-three-way(x.get(), y.get())`が適格であること
+- (2) : `synth-three-way(x.get(), y)`が適格であること
+- (3) : [`is_const_v`](/reference/type_traits/is_const.md)`<T>`が`false`であり、かつ`synth-three-way(x.get(), y.get())`が適格であること
 
 
 ## 戻り値
@@ -102,3 +104,5 @@ int main()
 
 ## 参照
 - [P2944R3 Comparisons for `reference_wrapper`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2944r3.html)
+- [LWG Issue 4071. `reference_wrapper` comparisons are not SFINAE-friendly](https://cplusplus.github.io/LWG/issue4071)
+    - C++26で、`operator<=>`の戻り値型が`synth-three-way-result<T>`から`auto`に変更され、`synth-three-way`が適格であることが制約に加わり、SFINAEフレンドリに振る舞うようになった

--- a/reference/mdspan/submdspan.md
+++ b/reference/mdspan/submdspan.md
@@ -59,14 +59,14 @@ namespace std {
 
 ```cpp
 auto [...slices] = canonical_slices(src, raw_slices...);
-auto sub_map_offset = submdspan_mapping(src.mapping(), slices...);
-return mdspan(src.accessor().offset(src.data_handle(), sub_map_offset.offset),
-              sub_map_offset.mapping,
+auto sub_map_result = submdspan_mapping(src.mapping(), slices...);
+return mdspan(src.accessor().offset(src.data_handle(), sub_map_result.offset),
+              sub_map_result.mapping,
               typename AccessorPolicy::offset_policy(src.accessor()));
 ```
 * mdspan[link mdspan.md]
 * canonical_slices[link canonical_slices.md]
-* sub_map_offset[link submdspan_mapping_result.md]
+* sub_map_result[link submdspan_mapping_result.md]
 * src.mapping()[link mdspan/mapping.md]
 * src.data_handle()[link mdspan/data_handle.md]
 * src.accessor()[link mdspan/accessor.md]
@@ -281,3 +281,5 @@ int main()
 ## 参照
 - [P2630R4 Submdspan](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2630r4.html)
 - [P3663R3 Future-proof `submdspan_mapping`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3663r3.html)
+- [LWG Issue 4060. `submdspan` preconditions do not forbid creating invalid pointer](https://cplusplus.github.io/LWG/issue4060)
+    - C++26で、スライスが次元の境界に達する場合に`offset`を`required_span_size()`とすることで境界外ポインタの生成を防ぐことが明確化され（各`submdspan_mapping`に反映済み）、あわせて`submdspan`の効果の説明変数名が`sub_map_result`に変更された

--- a/reference/ranges/adjacent_transform_view.md
+++ b/reference/ranges/adjacent_transform_view.md
@@ -44,7 +44,7 @@ namespace std::ranges {
 
 - (2): 式 `views::adjacent_transform<N>(E, F)` の効果は以下の通り。
     - `N` > 0 のとき、`adjacent_transform_view<`[`views::all_t`](all.md)`<decltype((E))>,` [`decay_t`](/reference/type_traits/decay.md)`<decltype((F))>, N>(E, F)` と等しい
-    - `N` = 0 のとき、`((void)E,` [`views::zip_transform`](zip_transform_view.md)`(F))` と等しい(ただし`E`と`F`の評価順は不定)
+    - `N` = 0 かつ`decltype((E))`が[`forward_range`](forward_range.md)のモデルであるとき、`((void)E,` [`views::zip_transform`](zip_transform_view.md)`(F))` と等しい(ただし`E`と`F`の評価順は不定)
 
 ## 備考
 
@@ -117,3 +117,5 @@ int main() {
 ## 参照
 - [N4950 26 Ranges library](https://timsong-cpp.github.io/cppwp/n4950/ranges)
 - [P2321R2 zip](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2321r2.html)
+- [LWG Issue 4098. `views::adjacent<0>` should reject non-forward ranges](https://cplusplus.github.io/LWG/issue4098)
+    - C++26で、`N` = 0 の場合に`views::empty`（または`views::zip_transform`）と等しくなる条件に`decltype((E))`が`forward_range`のモデルであることが追加され、forward_rangeでない範囲が拒否されるようになった

--- a/reference/ranges/adjacent_view.md
+++ b/reference/ranges/adjacent_view.md
@@ -44,7 +44,7 @@ namespace std::ranges {
 
 - (2): 式`views::adjacent<N>(E)`の効果は次の通り
     - `N` > 0 のとき、`adjacent_view<`[`views::all_t`](all.md)`<decltype((E))>, N>(E)` と等しい
-    - `N` = 0 のとき、`auto((void)E,` [`views::empty`](empty_view.md)`<`[`tuple`](/reference/tuple/tuple.md)`<>>)` と等しい
+    - `N` = 0 かつ`decltype((E))`が[`forward_range`](forward_range.md)のモデルであるとき、`auto((void)E,` [`views::empty`](empty_view.md)`<`[`tuple`](/reference/tuple/tuple.md)`<>>)` と等しい
 
 
 ## メンバ関数
@@ -112,3 +112,5 @@ int main() {
 ## 参照
 - [N4950 26 Ranges library](https://timsong-cpp.github.io/cppwp/n4950/ranges)
 - [P2321R2 zip](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2321r2.html)
+- [LWG Issue 4098. `views::adjacent<0>` should reject non-forward ranges](https://cplusplus.github.io/LWG/issue4098)
+    - C++26で、`N` = 0 の場合に`views::empty`（または`views::zip_transform`）と等しくなる条件に`decltype((E))`が`forward_range`のモデルであることが追加され、forward_rangeでない範囲が拒否されるようになった

--- a/reference/ranges/as_rvalue_view.md
+++ b/reference/ranges/as_rvalue_view.md
@@ -47,7 +47,7 @@ std::ranges::copy(words | views::as_rvalue, std::back_inserter(new_words));
 ## 効果
 
 - (2): 式`views::as_rvalue(E)`はRangeアダプタオブジェクトを表し、その効果は次の通り
-    - 要素がすでに右辺値参照であれば(`T = decltype((E))`として、[`same_as`](/reference/concepts/same_as.md)`<`[`range_rvalue_reference_t`](range_rvalue_reference_t.md)`<T>,` [`range_reference_t`](range_reference_t.md)`<T>>`)、[`views::all`](all.md)`(E)`と等しい
+    - `T = decltype((E))`が[`input_range`](input_range.md)のモデルであり、かつ要素がすでに右辺値参照であれば([`same_as`](/reference/concepts/same_as.md)`<`[`range_rvalue_reference_t`](range_rvalue_reference_t.md)`<T>,` [`range_reference_t`](range_reference_t.md)`<T>>`)、[`views::all`](all.md)`(E)`と等しい
     - それ以外のとき、`as_rvalue_view{E}`と等しい
 
 ## メンバ関数
@@ -169,3 +169,5 @@ constexpr explicit as_rvalue_view(V base);
 
 ## 参照
 - [P2446R2 `views::as_rvalue`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2446r2.html)
+- [LWG Issue 4083. `views::as_rvalue` should reject non-input ranges](https://cplusplus.github.io/LWG/issue4083)
+    - C++26で、`views::all(E)`と等しくなる条件に`T`が`input_range`のモデルであることが追加され、input_rangeでない範囲が拒否されるようになった

--- a/reference/ranges/concat_view.md
+++ b/reference/ranges/concat_view.md
@@ -53,6 +53,8 @@ namespace std::ranges {
 
 ## 備考
 
+このビュー（および`views::concat`アダプタ）は、フリースタンディング処理系でも使用できる。
+
 本説明に用いる説明専用要素を以下のように定義する。
 
 ```cpp
@@ -166,3 +168,5 @@ int main() {
 ## 参照
 - [26.7.18 Concat view](https://timsong-cpp.github.io/cppwp/range.concat) (2024-08-10)
 - [P2542R8 views::concat](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2542r8.html)
+- [LWG Issue 4076. `concat_view` should be freestanding](https://cplusplus.github.io/LWG/issue4076)
+    - C++26で、このビューがフリースタンディング処理系に対応した

--- a/reference/ranges/concat_view.md
+++ b/reference/ranges/concat_view.md
@@ -48,7 +48,7 @@ namespace std::ranges {
 ## 効果
 
 - (2): 式`views::concat(Es...)`の効果は次の通り
-    - `Es...`が1要素で、その型が [`input_range`](input_range.md)のモデルであるとき、[`views::all`](all.md)`(Es...)` と等しい
+    - `Es...`が1要素で、その型が [`input_range`](input_range.md)のモデルであるとき、`decltype((Es...[0]))(Es...[0])`（その要素自身）と等しい
     - それ以外のとき、`concat_view(Es...)` と等しい
 
 ## 備考
@@ -170,3 +170,5 @@ int main() {
 - [P2542R8 views::concat](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2542r8.html)
 - [LWG Issue 4076. `concat_view` should be freestanding](https://cplusplus.github.io/LWG/issue4076)
     - C++26で、このビューがフリースタンディング処理系に対応した
+- [LWG Issue 4082. `views::concat(r)` is well-formed when `r` is an `output_range`](https://cplusplus.github.io/LWG/issue4082)
+    - C++26で、単一の`input_range`を渡した場合の`views::concat`が`views::all`ではなくその要素自身を返すよう変更され、`output_range`に対しても適格となった

--- a/reference/ranges/iota_view.md
+++ b/reference/ranges/iota_view.md
@@ -48,7 +48,7 @@ namespace std::ranges {
 
 ## 効果
 
-- 式`views::iota(E)`の効果は`iota_view(E)`と等しい。
+- 式`views::iota(E)`の効果は`iota_view<`[`decay_t`](/reference/type_traits/decay.md)`<decltype((E))>>(E)`と等しい。
 - 式`views::iota(E, F)`の効果は`iota_view(E, F)`と等しい。
 
 ## メンバ関数
@@ -201,3 +201,5 @@ FizzBuzz
 - [P2325R3 Views should not be required to be default constructible](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2325r3.html) (本提案文書はC++20に遡って適用されている)
 - [P2367R0 Remove misuses of list-initialization from Clause 24](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2367r0.html) (本提案文書はC++20に遡って適用されている)
 - [LWG Issue 4001. `iota_view` should provide `empty`](https://cplusplus.github.io/LWG/issue4001)
+- [LWG Issue 4096. `views::iota(views::iota(0))` should be rejected](https://cplusplus.github.io/LWG/issue4096)
+    - C++26で、`views::iota(E)`の効果が`iota_view<decay_t<decltype((E))>>(E)`とテンプレート引数を明示する形になり、`views::iota(views::iota(0))`のような入れ子が拒否されるようになった


### PR DESCRIPTION
- [P3341R0 C++ Standard Library Ready Issues to be moved in St. Louis, Jun. 2024](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3341r0.html)

これに全て対応しました。