### PR TITLE
C++26 LWG Issueへの対応第9弾

### DIFF
--- a/reference/cfenv/fexcept_t.md
+++ b/reference/cfenv/fexcept_t.md
@@ -14,6 +14,8 @@ namespace std {
 ## 概要
 実装が持つ浮動小数点例外の状態フラグを表す型。
 
+この型はオブジェクト型であり、整数型であるとは限らない。
+
 
 ## 例
 ```cpp example
@@ -58,3 +60,8 @@ zero divided
 - [ICC](/implementation.md#icc): ??
 - [Visual C++](/implementation.md#visual_cpp): 2013 [mark verified], 2015 [mark verified]
 	- コンパイルオプション`/fp:strict`または`#pragma fenv_access (on)`が必要。さもなくば、正しく動作しないおそれがある。
+
+
+## 参照
+- [LWG Issue 3905. Type of `std::fexcept_t`](https://cplusplus.github.io/LWG/issue3905)
+    - C++26で、`fexcept_t`が「整数型」ではなく「オブジェクト型」であることが明確化された

--- a/reference/complex/complex/op_assign.md
+++ b/reference/complex/complex/op_assign.md
@@ -80,3 +80,5 @@ c = (7,0), d = (2,3)
 
 ## 参照
 - [P0415R1 Constexpr for `std::complex`](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0415r1.html)
+- [LWG Issue 3935. `template<class X> constexpr complex& operator=(const complex<X>&)` has no specification](https://cplusplus.github.io/LWG/issue3935)
+    - C++26で、別の要素型をもつ複素数からの変換コピー代入演算子(3)の効果と戻り値が規定された

--- a/reference/expected/expected.void/op_assign.md
+++ b/reference/expected/expected.void/op_assign.md
@@ -33,6 +33,9 @@ constexpr expected& operator=(unexpected<G>&& e);      // (4)
 
 
 ## テンプレートパラメータ制約
+- (2) : 次の制約を全て満たすこと
+    - [`is_move_constructible_v`](/reference/type_traits/is_move_constructible.md)`<E> == true`
+    - [`is_move_assignable_v`](/reference/type_traits/is_move_assignable.md)`<E> == true`
 - (3) : 次の制約を全て満たすこと
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, const G&> == true`
     - [`is_assignable_v`](/reference/type_traits/is_assignable.md)`<E&, const G&> == true`
@@ -175,5 +178,7 @@ int main()
 
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
+- [LWG Issue 4025. Move assignment operator of `std::expected<cv void, E>` should not be conditionally deleted](https://cplusplus.github.io/LWG/issue4025)
+    - C++26で、ムーブ代入演算子(2)が条件付きでdelete定義されるのではなく、テンプレートパラメータ制約によってオーバーロード解決から除外されるよう修正された
 - [LWG Issue 4026. Assignment operators of `std::expected` should propagate triviality](https://cplusplus.github.io/LWG/issue4026)
     - C++26で、`E`が対応する操作をトリビアルに持つ場合に、コピー代入演算子(1)とムーブ代入演算子(2)もトリビアルに定義されるようになった

--- a/reference/expected/expected.void/value.md
+++ b/reference/expected/expected.void/value.md
@@ -15,6 +15,11 @@ constexpr void value() &&;      // (2)
 正常値(`void`)を取得する。
 
 
+## 適格要件
+- (1) : [`is_copy_constructible_v`](/reference/type_traits/is_copy_constructible.md)`<E> == true`であること
+- (2) : [`is_copy_constructible_v`](/reference/type_traits/is_copy_constructible.md)`<E> == true`かつ[`is_move_constructible_v`](/reference/type_traits/is_move_constructible.md)`<E> == true`であること
+
+
 ## 戻り値
 なし
 
@@ -74,3 +79,5 @@ throw:42
 
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
+- [LWG Issue 3940. `std::expected<void, E>::value()` also needs `E` to be copy constructible](https://cplusplus.github.io/LWG/issue3940)
+    - C++26で、(1)に`E`がコピー構築可能であること、(2)に`E`がコピー構築可能かつムーブ構築可能であることを要求する適格要件が追加された

--- a/reference/expected/expected/and_then.md
+++ b/reference/expected/expected/and_then.md
@@ -35,10 +35,10 @@ class expected {
 
 
 ## 適格要件
-- (1), (2) : 型`U`を[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<F, decltype(`[`value()`](value.md)`)>>`としたとき、次を全て満たすこと
+- (1), (2) : 型`U`を[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<F, decltype(`[`**this`](op_deref.md)`)>>`としたとき、次を全て満たすこと
     - `U`が`expected`の特殊化である
     - [`is_same_v`](/reference/type_traits/is_same.md)`<U::error_type, E> == true`
-- (3), (4) : 型`U`を[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<F, decltype(`[`std::move`](/reference/utility/move.md)`(`[`value()`](value.md)`))>>`としたとき、次を全て満たすこと
+- (3), (4) : 型`U`を[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<F, decltype(`[`std::move`](/reference/utility/move.md)`(`[`**this`](op_deref.md)`))>>`としたとき、次を全て満たすこと
     - `U`が`expected`の特殊化である
     - [`is_same_v`](/reference/type_traits/is_same.md)`<U::error_type, E> == true`
 
@@ -47,12 +47,12 @@ class expected {
 - (1), (2) : 次の処理と等価
     ```cpp
     if (has_value())
-      return invoke(std::forward<F>(f), value());
+      return invoke(std::forward<F>(f), **this);
     else
       return U(unexpect, error());
     ```
     * has_value[link has_value.md]
-    * value()[link value.md]
+    * **this[link op_deref.md]
     * error()[link error.md]
     * unexpect[link ../unexpect_t.md]
     * invoke[link /reference/functional/invoke.md]
@@ -60,12 +60,12 @@ class expected {
 - (3), (4) : 次の処理と等価
     ```cpp
     if (has_value())
-      return invoke(std::forward<F>(f), std::move(value()));
+      return invoke(std::forward<F>(f), std::move(**this));
     else
       return U(unexpect, std::move(error()));
     ```
     * has_value[link has_value.md]
-    * value()[link value.md]
+    * **this[link op_deref.md]
     * error()[link error.md]
     * unexpect[link ../unexpect_t.md]
     * invoke[link /reference/functional/invoke.md]
@@ -133,3 +133,5 @@ int main()
 
 ## 参照
 - [P2505R5 Monadic Functions for `std::expected`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2505r5.html)
+- [LWG Issue 3938. Cannot use `std::expected` monadic ops with move-only `error_type`](https://cplusplus.github.io/LWG/issue3938)
+    - C++26で、効果および適格要件で正常値へのアクセスに[`value()`](value.md)ではなく[`**this`](op_deref.md)を使うよう修正され、ムーブのみ可能な`error_type`でも使用できるようになった

--- a/reference/expected/expected/or_else.md
+++ b/reference/expected/expected/or_else.md
@@ -47,24 +47,24 @@ class expected {
 - (1), (2) : 次の処理と等価
     ```cpp
     if (has_value())
-      return G(in_place, value());
+      return G(in_place, **this);
     else
       return invoke(std::forward<F>(f), error());
     ```
     * has_value()[link has_value.md]
-    * value()[link value.md]
+    * **this[link op_deref.md]
     * error()[link error.md]
     * invoke[link /reference/functional/invoke.md]
 
 - (3), (4) : 次の処理と等価
     ```cpp
     if (has_value())
-      return G(in_place, std::move(value()));
+      return G(in_place, std::move(**this));
     else
       return invoke(std::forward<F>(f), std::move(error()));
     ```
     * has_value()[link has_value.md]
-    * value()[link value.md]
+    * **this[link op_deref.md]
     * error()[link error.md]
     * invoke[link /reference/functional/invoke.md]
     * std::move[link /reference/utility/move.md]
@@ -137,3 +137,5 @@ int main()
 
 ## 参照
 - [P2505R5 Monadic Functions for `std::expected`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2505r5.html)
+- [LWG Issue 3938. Cannot use `std::expected` monadic ops with move-only `error_type`](https://cplusplus.github.io/LWG/issue3938)
+    - C++26で、効果で正常値へのアクセスに[`value()`](value.md)ではなく[`**this`](op_deref.md)を使うよう修正され、ムーブのみ可能な`error_type`でも使用できるようになった

--- a/reference/expected/expected/transform.md
+++ b/reference/expected/expected/transform.md
@@ -35,23 +35,23 @@ class expected {
 
 
 ## 適格要件
-- (1), (2) : 型`U`を[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<F, decltype(`[`value()`](value.md)`)>>`としたとき、次を全て満たすこと
+- (1), (2) : 型`U`を[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<F, decltype(`[`**this`](op_deref.md)`)>>`としたとき、次を全て満たすこと
     - `U`が`expected`の有効な正常値型である
-    - `U`が（CV修飾された）`void`ではないとき、宣言`U u(`[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`value()`](value.md)`));`が妥当である
-- (3), (4) : 型`U`を[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<F, decltype(`[`std::move`](/reference/utility/move.md)`(`[`value()`](value.md)`))>>`としたとき、次を全て満たすこと
+    - `U`が（CV修飾された）`void`ではないとき、宣言`U u(`[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`**this`](op_deref.md)`));`が妥当である
+- (3), (4) : 型`U`を[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<`[`invoke_result_t`](/reference/type_traits/invoke_result.md)`<F, decltype(`[`std::move`](/reference/utility/move.md)`(`[`**this`](op_deref.md)`))>>`としたとき、次を全て満たすこと
     - `U`が`expected`の有効な正常値型である
-    - `U`が（CV修飾された）`void`ではないとき、宣言`U u(`[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`std::move`](/reference/utility/move.md)`(`[`value()`](value.md)`)));`が妥当である
+    - `U`が（CV修飾された）`void`ではないとき、宣言`U u(`[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`std::move`](/reference/utility/move.md)`(`[`**this`](op_deref.md)`)));`が妥当である
 
 
 ## 効果
 - (1), (2) : 次の効果をもつ
     - エラー値を保持していたら、`expected<U, E>(`[`unexpect`](../unexpect_t.md)`,` [`error()`](error.md)`)`を返す。
-    - 型`U`が（CV修飾された）`void`でなければ、正常値を[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`value()`](value.md)`)`で直接非リスト初期化した`expected<U, E>`オブジェクトを返す。
-    - そうでなければ、[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`value()`](value.md)`)`を評価し、`expected<U, E>()`を返す。
+    - 型`U`が（CV修飾された）`void`でなければ、正常値を[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`**this`](op_deref.md)`)`で直接非リスト初期化した`expected<U, E>`オブジェクトを返す。
+    - そうでなければ、[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`**this`](op_deref.md)`)`を評価し、`expected<U, E>()`を返す。
 - (3), (4) : 次の効果をもつ
     - エラー値を保持していたら、`expected<U, E>(`[`unexpect`](../unexpect_t.md)`,` [`std::move`](/reference/utility/move.md)`(`[`error()`](error.md)`))`を返す。
-    - 型`U`が（CV修飾された）`void`でなければ、正常値を[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`std::move`](/reference/utility/move.md)`(`[`value()`](value.md)`))`で直接非リスト初期化した`expected<U, E>`オブジェクトを返す。
-    - そうでなければ、[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`std::move`](/reference/utility/move.md)`(`[`value()`](value.md)`))`を評価し、`expected<U, E>()`を返す。
+    - 型`U`が（CV修飾された）`void`でなければ、正常値を[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`std::move`](/reference/utility/move.md)`(`[`**this`](op_deref.md)`))`で直接非リスト初期化した`expected<U, E>`オブジェクトを返す。
+    - そうでなければ、[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`std::move`](/reference/utility/move.md)`(`[`**this`](op_deref.md)`))`を評価し、`expected<U, E>()`を返す。
 
 
 ## 備考
@@ -112,3 +112,5 @@ int main()
 
 ## 参照
 - [P2505R5 Monadic Functions for `std::expected`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2505r5.html)
+- [LWG Issue 3938. Cannot use `std::expected` monadic ops with move-only `error_type`](https://cplusplus.github.io/LWG/issue3938)
+    - C++26で、効果および適格要件で正常値へのアクセスに[`value()`](value.md)ではなく[`**this`](op_deref.md)を使うよう修正され、ムーブのみ可能な`error_type`でも使用できるようになった

--- a/reference/expected/expected/transform_error.md
+++ b/reference/expected/expected/transform_error.md
@@ -45,10 +45,10 @@ class expected {
 
 ## 効果
 - (1), (2) : 次の効果をもつ
-    - 正常値を保持していたら、`expected<T, G>(`[`in_place`](/reference/utility/in_place_t.md)`,` [`value()`](value.md)`)`を返す。
+    - 正常値を保持していたら、`expected<T, G>(`[`in_place`](/reference/utility/in_place_t.md)`,` [`**this`](op_deref.md)`)`を返す。
     - そうでなければ、エラー値を[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`error()`](error.md)`)`で直接非リスト初期化した`expected<T, G>`オブジェクトを返す。
 - (3), (4) : 次の効果をもつ
-    - 正常値を保持していたら、`expected<T, G>(`[`in_place`](/reference/utility/in_place_t.md)`,` [`std::move`](/reference/utility/move.md)`(`[`value()`](value.md)`))`を返す。
+    - 正常値を保持していたら、`expected<T, G>(`[`in_place`](/reference/utility/in_place_t.md)`,` [`std::move`](/reference/utility/move.md)`(`[`**this`](op_deref.md)`))`を返す。
     - そうでなければ、エラー値を[`invoke`](/reference/functional/invoke.md)`(`[`std::forward`](/reference/utility/forward.md)`<F>(f),` [`std::move`](/reference/utility/move.md)`(`[`error()`](error.md)`))`で直接非リスト初期化した`expected<T, G>`オブジェクトを返す。
 
 
@@ -109,3 +109,5 @@ int main()
 
 ## 参照
 - [P2505R5 Monadic Functions for `std::expected`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2505r5.html)
+- [LWG Issue 3938. Cannot use `std::expected` monadic ops with move-only `error_type`](https://cplusplus.github.io/LWG/issue3938)
+    - C++26で、効果で正常値へのアクセスに[`value()`](value.md)ではなく[`**this`](op_deref.md)を使うよう修正され、ムーブのみ可能な`error_type`でも使用できるようになった

--- a/reference/flat_map/flat_map/op_constructor.md
+++ b/reference/flat_map/flat_map/op_constructor.md
@@ -451,4 +451,6 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3884. `flat_foo` is missing allocator-extended copy/move constructors](https://cplusplus.github.io/LWG/issue3884)
+    - C++26で、`flat_map`にアロケータを指定するコピーコンストラクタ(5)とムーブコンストラクタ(6)が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/flat_map/flat_multimap/op_constructor.md
+++ b/reference/flat_map/flat_multimap/op_constructor.md
@@ -447,4 +447,6 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3884. `flat_foo` is missing allocator-extended copy/move constructors](https://cplusplus.github.io/LWG/issue3884)
+    - C++26で、`flat_multimap`にアロケータを指定するコピーコンストラクタ(5)とムーブコンストラクタ(6)が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/flat_set/flat_multiset/op_constructor.md
+++ b/reference/flat_set/flat_multiset/op_constructor.md
@@ -432,4 +432,6 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3884. `flat_foo` is missing allocator-extended copy/move constructors](https://cplusplus.github.io/LWG/issue3884)
+    - C++26で、`flat_multiset`にアロケータを指定するコピーコンストラクタ(5)とムーブコンストラクタ(6)が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/flat_set/flat_set/op_constructor.md
+++ b/reference/flat_set/flat_set/op_constructor.md
@@ -433,4 +433,6 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3884. `flat_foo` is missing allocator-extended copy/move constructors](https://cplusplus.github.io/LWG/issue3884)
+    - C++26で、`flat_set`にアロケータを指定するコピーコンストラクタ(5)とムーブコンストラクタ(6)が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/format/basic_format_context.md
+++ b/reference/format/basic_format_context.md
@@ -33,6 +33,8 @@ namespace std {
 
 C++26では、コピーコンストラクタとコピー代入演算子が`= delete`で明示的に削除され、このクラスがコピー構築・コピー代入できないことが明確化された（これにともないムーブおよびデフォルト構築もできない）。
 
+また、このクラステンプレートの明示的特殊化または部分特殊化をユーザーが宣言した場合、プログラムは不適格となる（診断不要）。
+
 ## メンバ関数
 
 | 名前                                 | 説明                                         | 対応バージョン |
@@ -106,5 +108,7 @@ namespace std {
 ## 参照
 
 * [P0645R10 Text Formatting](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0645r10.html)
+* [LWG Issue 3975. Specializations of `basic_format_context` should not be permitted](https://cplusplus.github.io/LWG/issue3975)
+    * C++26で、ユーザーによる明示的特殊化・部分特殊化が不適格（診断不要）とされた
 * [LWG Issue 4061. Should `std::basic_format_context` be default-constructible/copyable/movable?](https://cplusplus.github.io/LWG/issue4061)
     * C++26で、コピーコンストラクタとコピー代入演算子が`= delete`で明示的に削除され、コピー・ムーブ・デフォルト構築ができないことが明確化された

--- a/reference/format/basic_format_parse_context.md
+++ b/reference/format/basic_format_parse_context.md
@@ -24,6 +24,11 @@ namespace std {
 
 このクラスのオブジェクトはコピーできない。
 
+
+## 備考
+このクラステンプレートの明示的特殊化または部分特殊化をユーザーが宣言した場合、プログラムは不適格となる（診断不要）。
+
+
 ## メンバ関数
 
 | 名前            | 説明                                               | 対応バージョン |
@@ -143,3 +148,5 @@ namespace std {
 
 * [P0645R10 Text Formatting](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0645r10.html)
 * [P2757R3 Type-checking format args](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2757r3.html)
+* [LWG Issue 3975. Specializations of `basic_format_context` should not be permitted](https://cplusplus.github.io/LWG/issue3975)
+    * C++26で、`basic_format_parse_context`についてもユーザーによる明示的特殊化・部分特殊化が不適格（診断不要）とされた

--- a/reference/format/formattable.md
+++ b/reference/format/formattable.md
@@ -23,7 +23,7 @@ namespace std {
 
   template <class T, class charT>
   concept formattable =
-    formattable-with<remove_reference_t<T>, basic_format_context<fmt-iter-for<charT>>>;
+    formattable-with<remove_reference_t<T>, basic_format_context<fmt-iter-for<charT>, charT>>;
 }
 ```
 * fmt-iter-for[italic]
@@ -79,3 +79,5 @@ hello
 ## 参照
 - [P2286R8 Formatting Ranges](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2286r8.html)
 - [N4950 22.14.6.2 Concept formattable](https://timsong-cpp.github.io/cppwp/n4950/format.formattable#concept:formattable-with)
+- [LWG Issue 3925. Concept `formattable`'s definition is incorrect](https://cplusplus.github.io/LWG/issue3925)
+    - C++26で、`basic_format_context`のテンプレート引数に文字型`charT`が欠けていた誤りが修正された

--- a/reference/generator/generator/promise_type/yield_value.md
+++ b/reference/generator/generator/promise_type/yield_value.md
@@ -18,7 +18,7 @@ auto yield_value(ranges::elements_of<generator<T2, V2, Alloc2>&&, Unused> g) noe
 
 template<ranges::input_range Rng, class Alloc>
   requires convertible_to<ranges::range_reference_t<Rng>, yielded>
-auto yield_value(ranges::elements_of<Rng, Alloc> r) noexcept; // (4)
+auto yield_value(ranges::elements_of<Rng, Alloc> r); // (4)
 ```
 * generator[link ../../generator.md]
 * yielded[link ../../generator.md]
@@ -107,6 +107,8 @@ return yield_value(ranges::elements_of(nested(
 
 
 ## 参照
+- [LWG Issue 3894. `generator::promise_type::yield_value(ranges::elements_of<Rng, Alloc>)` should not be `noexcept`](https://cplusplus.github.io/LWG/issue3894)
+    - C++26で、(4)から`noexcept`が削除された（効果内で例外を送出しうる`generator`の構築を行うため）
 - [LWG Issue 3899. co_yielding elements of an lvalue generator is unnecessarily inefficient](https://cplusplus.github.io/LWG/issue3899)
     - C++26で、(4)の効果で用いるネストした`generator`の型を`generator<yielded, void, Alloc>`に変更し、左辺値`generator`の要素をco_yieldする際の非効率を解消した
 - [LWG Issue 4119. `generator::promise_type::yield_value(ranges::elements_of<R, Alloc>)`'s nested generator may be ill-formed](https://cplusplus.github.io/LWG/issue4119)

--- a/reference/locale/ctype_base.md
+++ b/reference/locale/ctype_base.md
@@ -20,20 +20,20 @@ namespace std {
 
 ### メンバ定数
 
-| 名前 | 説明 |
-|-------------------------------------------------------|-----------------------------------|
-| `static const mask space = 1 << 0;` | 空白類文字のマスク値 |
-| `static const mask print = 1 << 1;` | 印字可能文字のマスク値 |
-| `static const mask cntrl = 1 << 2;` | 制御文字のマスク値 |
-| `static const mask upper = 1 << 3;` | 英大文字のマスク値 |
-| `static const mask lower = 1 << 4;` | 英小文字のマスク値 |
-| `static const mask alpha = 1 << 5;` | 英字のマスク値 |
-| `static const mask digit = 1 << 6;` | 数字のマスク値 |
-| `static const mask punct = 1 << 7;` | 区切り文字のマスク値 |
-| `static const mask xdigit = 1 << 8;` | 十六進数字のマスク値 |
-| `static const mask blank = 1 << 9;` | ブランク文字のマスク値 |
-| <code>static const mask alnum = alpha &#x7C; digit;</code> | 英字・数字のマスク値 |
-| <code>static const mask graph = alnum &#x7C; punct;</code> | 図形文字のマスク値 |
+| 名前 | 説明 | 対応バージョン |
+|-------------------------------------------------------|-----------------------------------|-------|
+| `static const mask space = 1 << 0;`<br/>`static constexpr mask space = 1 << 0;` | 空白類文字のマスク値 | C++98<br/>C++26 |
+| `static const mask print = 1 << 1;`<br/>`static constexpr mask print = 1 << 1;` | 印字可能文字のマスク値 | C++98<br/>C++26 |
+| `static const mask cntrl = 1 << 2;`<br/>`static constexpr mask cntrl = 1 << 2;` | 制御文字のマスク値 | C++98<br/>C++26 |
+| `static const mask upper = 1 << 3;`<br/>`static constexpr mask upper = 1 << 3;` | 英大文字のマスク値 | C++98<br/>C++26 |
+| `static const mask lower = 1 << 4;`<br/>`static constexpr mask lower = 1 << 4;` | 英小文字のマスク値 | C++98<br/>C++26 |
+| `static const mask alpha = 1 << 5;`<br/>`static constexpr mask alpha = 1 << 5;` | 英字のマスク値 | C++98<br/>C++26 |
+| `static const mask digit = 1 << 6;`<br/>`static constexpr mask digit = 1 << 6;` | 数字のマスク値 | C++98<br/>C++26 |
+| `static const mask punct = 1 << 7;`<br/>`static constexpr mask punct = 1 << 7;` | 区切り文字のマスク値 | C++98<br/>C++26 |
+| `static const mask xdigit = 1 << 8;`<br/>`static constexpr mask xdigit = 1 << 8;` | 十六進数字のマスク値 | C++98<br/>C++26 |
+| `static const mask blank = 1 << 9;`<br/>`static constexpr mask blank = 1 << 9;` | ブランク文字のマスク値 | C++11<br/>C++26 |
+| <code>static const mask alnum = alpha &#x7C; digit;</code><br/><code>static constexpr mask alnum = alpha &#x7C; digit;</code> | 英字・数字のマスク値 | C++98<br/>C++26 |
+| <code>static const mask graph = alnum &#x7C; punct;</code><br/><code>static constexpr mask graph = alnum &#x7C; punct;</code> | 図形文字のマスク値 | C++98<br/>C++26 |
 
 
 ## 例
@@ -44,4 +44,6 @@ namespace std {
 ```
 ```
 
-### 参照
+## 参照
+- [LWG Issue 4037. Static data members of `ctype_base` are not yet required to be usable in constant expressions](https://cplusplus.github.io/LWG/issue4037)
+    - C++26で、各メンバ定数が`static const`から`static constexpr`に変更され、定数式で使用できることが規定された

--- a/reference/numeric/saturating_add.md
+++ b/reference/numeric/saturating_add.md
@@ -71,4 +71,6 @@ int main()
 
 ## 参照
 - [P0543R3 Saturation arithmetic](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p0543r3.html)
+- [LWG Issue 4030. Clarify whether arithmetic expressions in [numeric.sat.func] are mathematical or C++](https://cplusplus.github.io/LWG/issue4030)
+    - C++26で、飽和演算関数の算術演算が無限精度の数学的演算として行われることが明確化された（cpprefjpでは既に「無限の範囲で計算した値」と記述している）
 - [P4052R0 Renaming saturation arithmetic functions](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4052r0.html)

--- a/reference/numeric/saturating_div.md
+++ b/reference/numeric/saturating_div.md
@@ -74,4 +74,6 @@ int main()
 
 ## 参照
 - [P0543R3 Saturation arithmetic](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p0543r3.html)
+- [LWG Issue 4030. Clarify whether arithmetic expressions in [numeric.sat.func] are mathematical or C++](https://cplusplus.github.io/LWG/issue4030)
+    - C++26で、飽和演算関数の算術演算が無限精度の数学的演算として行われることが明確化された（cpprefjpでは既に「無限の範囲で計算した値」と記述している）
 - [P4052R0 Renaming saturation arithmetic functions](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4052r0.html)

--- a/reference/numeric/saturating_mul.md
+++ b/reference/numeric/saturating_mul.md
@@ -71,4 +71,6 @@ int main()
 
 ## 参照
 - [P0543R3 Saturation arithmetic](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p0543r3.html)
+- [LWG Issue 4030. Clarify whether arithmetic expressions in [numeric.sat.func] are mathematical or C++](https://cplusplus.github.io/LWG/issue4030)
+    - C++26で、飽和演算関数の算術演算が無限精度の数学的演算として行われることが明確化された（cpprefjpでは既に「無限の範囲で計算した値」と記述している）
 - [P4052R0 Renaming saturation arithmetic functions](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4052r0.html)

--- a/reference/numeric/saturating_sub.md
+++ b/reference/numeric/saturating_sub.md
@@ -70,4 +70,6 @@ int main()
 
 ## 参照
 - [P0543R3 Saturation arithmetic](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p0543r3.html)
+- [LWG Issue 4030. Clarify whether arithmetic expressions in [numeric.sat.func] are mathematical or C++](https://cplusplus.github.io/LWG/issue4030)
+    - C++26で、飽和演算関数の算術演算が無限精度の数学的演算として行われることが明確化された（cpprefjpでは既に「無限の範囲で計算した値」と記述している）
 - [P4052R0 Renaming saturation arithmetic functions](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p4052r0.html)

--- a/reference/ranges/common_view/begin.md
+++ b/reference/ranges/common_view/begin.md
@@ -6,9 +6,11 @@
 * cpp20[meta cpp]
 
 ```cpp
-constexpr auto begin();                              // (1)
+constexpr auto begin()
+  requires (!simple-view<V>);                         // (1)
 constexpr auto begin() const requires range<const V>; // (2)
 ```
+* simple-view[link /reference/ranges/simple-view.md]
 
 ## 概要
 
@@ -85,3 +87,5 @@ int main() {
 
 ## 参照
 - [N4861 24.7.5.1 Overview](https://timsong-cpp.github.io/cppwp/n4861/range.common.view)
+- [LWG Issue 4012. `common_view::begin`/`end` are missing the *simple-view* check](https://cplusplus.github.io/LWG/issue4012)
+    - C++26で、非`const`版に`requires (!simple-view<V>)`制約が追加され、`simple-view`である場合に`const`版と曖昧にならないよう修正された

--- a/reference/ranges/common_view/end.md
+++ b/reference/ranges/common_view/end.md
@@ -6,10 +6,12 @@
 * cpp20[meta cpp]
 
 ```cpp
-constexpr auto end();      // (1) C++20
+constexpr auto end()
+  requires (!simple-view<V>); // (1) C++20
 constexpr auto end() const
-  requires range<const V>; // (2) C++20
+  requires range<const V>;    // (2) C++20
 ```
+* simple-view[link /reference/ranges/simple-view.md]
 
 ## 概要
 
@@ -84,3 +86,5 @@ int main() {
 
 ## 参照
 - [N4861 24.7.5.1 Overview](https://timsong-cpp.github.io/cppwp/n4861/range.common.view)
+- [LWG Issue 4012. `common_view::begin`/`end` are missing the *simple-view* check](https://cplusplus.github.io/LWG/issue4012)
+    - C++26で、非`const`版に`requires (!simple-view<V>)`制約が追加され、`simple-view`である場合に`const`版と曖昧にならないよう修正された

--- a/reference/ranges/enumerate_view.md
+++ b/reference/ranges/enumerate_view.md
@@ -101,3 +101,5 @@ int main() {
 
 ## 参照
 - [N4950 26 Ranges library](https://timsong-cpp.github.io/cppwp/n4950/ranges)
+- [LWG Issue 3914. Inconsistent `template-head` of `ranges::enumerate_view`](https://cplusplus.github.io/LWG/issue3914)
+    - C++26で、`<ranges>`のシノプシスにおける`enumerate_view`の`template-head`が、クラス定義（`template<view V> requires range-with-movable-references<V>`）と一致するよう修正された

--- a/reference/ranges/enumerate_view/end.md
+++ b/reference/ranges/enumerate_view/end.md
@@ -19,7 +19,7 @@ constexpr auto end() const
 
 ## 効果
 
-`common_range<V> && sized_range<V>`が`true`の場合：
+`common_range<V> && sized_range<V> && forward_range<V>`が`true`の場合：
 
 - (1) : `return iterator<false>(ranges::end(base_), ranges::distance(base_));`
 - (2) : `return iterator<true>(ranges::end(base_), ranges::distance(base_));`
@@ -73,3 +73,5 @@ int main() {
 
 ## 参照
 - [N4950 26.7.23 Enumerate view](https://timsong-cpp.github.io/cppwp/n4950/range.enumerate)
+- [LWG Issue 3919. `enumerate_view` may invoke UB for sized common non-forward underlying ranges](https://cplusplus.github.io/LWG/issue3919)
+    - C++26で、`iterator`を返す条件に`forward_range<V>`が追加され、sizedかつcommonだが非forwardな元Rangeで未定義動作を引き起こす問題が修正された

--- a/reference/ranges/repeat_view.md
+++ b/reference/ranges/repeat_view.md
@@ -34,7 +34,7 @@ namespace std::ranges {
 - (1) `Bound = unreachable_sentinel_t` ではない場合
 
 ## 効果
-- 式`views::repeat(E)`の効果は`repeat_view(E)`と等しい。
+- 式`views::repeat(E)`の効果は`repeat_view<`[`decay_t`](/reference/type_traits/decay.md)`<decltype((E))>>(E)`と等しい。
 - 式`views::repeat(E, F)`の効果は`repeat_view(E, F)`と等しい。
 
 ## メンバ関数
@@ -103,3 +103,5 @@ int main() {
 
 ## 参照
 - [N4950 26 Ranges library](https://timsong-cpp.github.io/cppwp/n4950/ranges)
+- [LWG Issue 4054. Repeating a `repeat_view` should repeat the view](https://cplusplus.github.io/LWG/issue4054)
+    - C++26で、`views::repeat(E)`の効果が`repeat_view<decay_t<decltype((E))>>(E)`に修正され、引数を[`decay_t`](/reference/type_traits/decay.md)で減衰させて要素型を決定するようになった

--- a/reference/ranges/repeat_view/op_deduction_guide.md
+++ b/reference/ranges/repeat_view/op_deduction_guide.md
@@ -47,3 +47,8 @@ int main() {
 - [GCC](/implementation.md#gcc): 13 [mark verified]
 - [ICC](/implementation.md#icc): ?
 - [Visual C++](/implementation.md#visual_cpp): 2022 Update 6 [mark verified]
+
+
+## 参照
+- [LWG Issue 4053. Unary call to `std::views::repeat` does not decay the argument](https://cplusplus.github.io/LWG/issue4053)
+    - C++26で、`Bound`にデフォルトテンプレート引数`unreachable_sentinel_t`とデフォルト引数`Bound()`が追加され、`repeat_view(E)`のように第2引数を省略した推論が可能になった

--- a/reference/ranges/single_view/empty.md
+++ b/reference/ranges/single_view/empty.md
@@ -28,3 +28,8 @@ return false;
 - [GCC](/implementation.md#gcc): 10.1.0 [mark verified]
 - [ICC](/implementation.md#icc): ?
 - [Visual C++](/implementation.md#visual_cpp): 2019 Update 10 [mark verified]
+
+
+## 参照
+- [LWG Issue 4035. `single_view` should provide `empty`](https://cplusplus.github.io/LWG/issue4035)
+    - C++26で、常に`false`を返す静的メンバ関数`empty`が`single_view`に明示的に追加された（従来は[`view_interface`](../view_interface.md)経由で提供されていた）

--- a/reference/ranges/to.md
+++ b/reference/ranges/to.md
@@ -137,12 +137,14 @@ constexpr bool reservable-container =
     { c.max_size() } -> same_as<decltype(n)>;  // コンテナのサイズ型を返すmax_sizeメンバ関数がある
   };
 
-// container-insertable: push_backまたはinsertが使えることを要求するコンセプト
+// container-insertable: emplace_back/push_back/emplace/insertのいずれかが使えることを要求するコンセプト
 template<class Container, class Ref>
 constexpr bool container-insertable =
   requires(Container& c, Ref&& ref) {
-    requires (requires { c.push_back(std::forward<Ref>(ref)); } ||
-              requires { c.insert(c.end(), std::forward<Ref>(ref)); });
+    requires (requires { c.emplace_back(declval<Ref>()); } ||
+              requires { c.push_back(declval<Ref>()); } ||
+              requires { c.emplace(c.end(), declval<Ref>()); } ||
+              requires { c.insert(c.end(), declval<Ref>()); });
   };
 
 // container-inserter: push_backが使えればback_inserter, そうでなければinserterを返す関数
@@ -232,3 +234,5 @@ int main() {
     - C++26で要素数の事前確保に[`ranges::size`](size.md)の代わりに[`ranges::reserve_hint`](reserve_hint.md)を使用するよう変更
 - [LWG Issue 3984. `ranges::to`'s recursion branch may be ill-formed](https://cplusplus.github.io/LWG/issue3984)
     - C++26で、再帰分岐において`r`を[`ranges::ref_view`](ref_view.md)で包むよう修正され、`r`がviewでない左辺値rangeの場合に不適格となる問題が解消された
+- [LWG Issue 4016. *container-insertable* checks do not match what *container-inserter* does](https://cplusplus.github.io/LWG/issue4016)
+    - C++26で、説明専用コンセプト`container-insertable`の判定が`emplace_back`/`push_back`/`emplace`/`insert`の4つを試す形に修正され、実際の挿入処理と一致するようになった

--- a/reference/ranges/to.md
+++ b/reference/ranges/to.md
@@ -77,11 +77,12 @@ Rangeの各要素を要素とするコンテナを構築する。
 [`input_range`](input_range.md)`<`[`range_reference_t`](range_reference_t.md)`<R>>`である場合:
 
 ```cpp
-to<C>(r | views::transform([](auto&& elem) {
+to<C>(ref_view(r) | views::transform([](auto&& elem) {
   return to<range_value_t<C>>(std::forward<decltype(elem)>(elem));
 }), std::forward<Args>(args)...);
 ```
 * views::transform[link transform_view.md]
+* ref_view[link ref_view.md]
 
 どの条件にもあてはまらない場合、プログラムは不適格である。
 
@@ -229,3 +230,5 @@ int main() {
 - [26.5.7.2 ranges::to](https://timsong-cpp.github.io/cppwp/n4950/range.utility.conv.to)
 - [P2846R6 `reserve_hint`: Eagerly reserving memory for not-quite-sized lazy ranges](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2846r6.pdf)
     - C++26で要素数の事前確保に[`ranges::size`](size.md)の代わりに[`ranges::reserve_hint`](reserve_hint.md)を使用するよう変更
+- [LWG Issue 3984. `ranges::to`'s recursion branch may be ill-formed](https://cplusplus.github.io/LWG/issue3984)
+    - C++26で、再帰分岐において`r`を[`ranges::ref_view`](ref_view.md)で包むよう修正され、`r`がviewでない左辺値rangeの場合に不適格となる問題が解消された

--- a/reference/span/span.md
+++ b/reference/span/span.md
@@ -66,7 +66,7 @@ namespace std {
 | 名前 | 説明 | 対応バージョン |
 |------|------|----------------|
 | [`(constructor)`](span/op_constructor.md) | コンストラクタ | C++20 |
-| `~span() = default;` | デストラクタ | C++20 |
+| [`(destructor)`](span/op_destructor.md) | デストラクタ | C++20 |
 | `span& operator=(const span&) = default;`<br/> `span& operator=(span&&) = default;` | 代入演算子 | C++20 |
 
 

--- a/reference/span/span/back.md
+++ b/reference/span/span/back.md
@@ -27,6 +27,10 @@ return *(data() + (size() - 1));
 * size()[link size.md]
 
 
+## 例外
+投げない
+
+
 ## 計算量
 定数時間
 
@@ -68,3 +72,5 @@ int main()
 ## 参照
 - [P3471R4 Standard library hardening](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3471r4.html)
 - [P3878R1 Standard library hardening should not use the 'observe' semantic](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3878r1.html)
+- [LWG Issue 4011. "Effects: Equivalent to return" in [span.elem]](https://cplusplus.github.io/LWG/issue4011)
+    - C++26で、要素アクセス関数の効果記述が「戻り値」として整理され、例外を投げないことが明示された

--- a/reference/span/span/data.md
+++ b/reference/span/span/data.md
@@ -57,3 +57,8 @@ int main()
 - [Clang](/implementation.md#clang): 9.0 [mark verified]
 - [GCC](/implementation.md#gcc): ??
 - [Visual C++](/implementation.md#visual_cpp): ??
+
+
+## 参照
+- [LWG Issue 4011. "Effects: Equivalent to return" in [span.elem]](https://cplusplus.github.io/LWG/issue4011)
+    - C++26で、要素アクセス関数の効果記述が「戻り値」として整理され、例外を投げないことが明示された

--- a/reference/span/span/front.md
+++ b/reference/span/span/front.md
@@ -26,6 +26,10 @@ return *data();
 * data()[link data.md]
 
 
+## 例外
+投げない
+
+
 ## 計算量
 定数時間
 
@@ -67,3 +71,5 @@ int main()
 ## 参照
 - [P3471R4 Standard library hardening](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3471r4.html)
 - [P3878R1 Standard library hardening should not use the 'observe' semantic](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3878r1.html)
+- [LWG Issue 4011. "Effects: Equivalent to return" in [span.elem]](https://cplusplus.github.io/LWG/issue4011)
+    - C++26で、要素アクセス関数の効果記述が「戻り値」として整理され、例外を投げないことが明示された

--- a/reference/span/span/op_at.md
+++ b/reference/span/span/op_at.md
@@ -26,6 +26,10 @@ return *(data() + i);
 * data()[link data.md]
 
 
+## 例外
+投げない
+
+
 ## 計算量
 定数時間
 
@@ -73,3 +77,5 @@ int main()
 - [P1872R0 `span` should have `size_type`, not `index_type`](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1872r0.pdf)
 - [P3471R4 Standard library hardening](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3471r4.html)
 - [P3878R1 Standard library hardening should not use the 'observe' semantic](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3878r1.html)
+- [LWG Issue 4011. "Effects: Equivalent to return" in [span.elem]](https://cplusplus.github.io/LWG/issue4011)
+    - C++26で、要素アクセス関数の効果記述が「戻り値」として整理され、例外を投げないことが明示された

--- a/reference/span/span/op_destructor.md
+++ b/reference/span/span/op_destructor.md
@@ -1,0 +1,31 @@
+# デストラクタ
+* span[meta header]
+* std[meta namespace]
+* span[meta class]
+* function[meta id-type]
+* cpp20[meta cpp]
+
+```cpp
+~span() noexcept = default; // (1) C++20
+~span() = default;          // (1) C++26
+```
+
+## 概要
+`span`オブジェクトを破棄する。
+
+`span`は要素列を所有しない（非所有の）ビューであるため、このデストラクタは参照先の要素に対しては何もしない。トリビアルにデフォルト定義される。
+
+
+## 例外
+投げない
+
+
+## バージョン
+### 言語
+- C++20
+
+
+## 参照
+- [P0122R7 `<span>`](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0122r7.pdf)
+- [LWG Issue 3903. `span` destructor is redundantly `noexcept`](https://cplusplus.github.io/LWG/issue3903)
+    - C++26で、デストラクタの冗長な`noexcept`指定が削除された（暗黙に`noexcept`であるため）

--- a/reference/streambuf/basic_streambuf/setg.md
+++ b/reference/streambuf/basic_streambuf/setg.md
@@ -19,6 +19,9 @@ namespace std {
 ## 概要
 入力部分列の各ポインタを設定する。
 
+## 事前条件
+`[gbeg, gnext)`、`[gbeg, gend)`、`[gnext, gend)`がすべて有効な範囲であること。
+
 ## 事後条件
 `gbeg ==` [`eback()`](eback.md) および `gnext ==` [`gptr()`](gptr.md) および `gend ==` [`egptr()`](egptr.md)。
 
@@ -57,3 +60,5 @@ A
 - [`eback()`](eback.md)
 - [`gptr()`](gptr.md)
 - [`egptr()`](egptr.md)
+- [LWG Issue 4023. Preconditions of `std::basic_streambuf::setg`/`setp`](https://cplusplus.github.io/LWG/issue4023)
+    - C++26で、引数が有効な範囲を表すことを要求する事前条件が追加された

--- a/reference/streambuf/basic_streambuf/setp.md
+++ b/reference/streambuf/basic_streambuf/setp.md
@@ -19,6 +19,9 @@ namespace std {
 ## 概要
 出力部分列の各ポインタを設定する。
 
+## 事前条件
+`[pbeg, pend)`が有効な範囲であること。
+
 ## 事後条件
 `pbeg ==` [`pbase()`](pbase.md) および `pbeg ==` [`pptr()`](pptr.md) および `pend ==` [`epptr()`](epptr.md)。
 
@@ -60,3 +63,5 @@ ABC
 - [`pbase()`](pbase.md)
 - [`pptr()`](pptr.md)
 - [`epptr()`](epptr.md)
+- [LWG Issue 4023. Preconditions of `std::basic_streambuf::setg`/`setp`](https://cplusplus.github.io/LWG/issue4023)
+    - C++26で、引数が有効な範囲を表すことを要求する事前条件が追加された

--- a/reference/string_view/basic_string_view/op_compare_3way.md
+++ b/reference/string_view/basic_string_view/op_compare_3way.md
@@ -7,11 +7,16 @@
 ```cpp
 namespace std {
   template<class charT, class traits>
-    constexpr see below
-  operator<=>(basic_string_view<charT, traits> x,
-              basic_string_view<charT, traits> y) noexcept; // (1) C++20
+  constexpr see below
+    operator<=>(basic_string_view<charT, traits> x,
+                basic_string_view<charT, traits> y) noexcept; // (1) C++20
+  template<class charT, class traits>
+  constexpr see below
+    operator<=>(basic_string_view<charT, traits> x,
+                type_identity_t<basic_string_view<charT, traits>> y) noexcept; // (1) C++26
 }
 ```
+* type_identity_t[link /reference/type_traits/type_identity.md]
 
 ## 概要
 `basic_string_view`オブジェクトの三方比較を行う。
@@ -72,3 +77,5 @@ equal
 ## 参照
 - [P1614R2 The Mothership has Landed](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1614r2.html)
     - C++20での三方比較演算子の追加と、関連する演算子の自動導出
+- [LWG Issue 3950. `std::basic_string_view` comparison operators are overspecified](https://cplusplus.github.io/LWG/issue3950)
+    - C++26で、第2引数が`type_identity_t`で包まれ、`basic_string_view`へ暗黙変換可能な型と直接比較できるようになった（追加の比較オーバーロードの規定が不要になった）

--- a/reference/string_view/basic_string_view/op_equal.md
+++ b/reference/string_view/basic_string_view/op_equal.md
@@ -7,10 +7,16 @@
 ```cpp
 namespace std {
   template <class CharT, class Traits>
-  constexpr bool operator==(basic_string_view<CharT, Traits> x,
-                            basic_string_view<CharT, Traits> y) noexcept; // (1) C++17
+  constexpr bool
+    operator==(basic_string_view<CharT, Traits> x,
+               basic_string_view<CharT, Traits> y) noexcept; // (1) C++17
+  template <class CharT, class Traits>
+  constexpr bool
+    operator==(basic_string_view<CharT, Traits> x,
+               type_identity_t<basic_string_view<CharT, Traits>> y) noexcept; // (1) C++26
 }
 ```
+* type_identity_t[link /reference/type_traits/type_identity.md]
 
 ## 概要
 `basic_string_view`オブジェクトの等値比較を行う。
@@ -26,6 +32,7 @@ return x.compare(y) == 0;
 ## 備考
 - この演算子により、以下の演算子が使用可能になる (C++20)：
     - `operator!=`
+- C++26では、第2引数が[`type_identity_t`](/reference/type_traits/type_identity.md)で包まれて非推論文脈となる。これにより、`basic_string_view`へ暗黙変換可能な型（[`basic_string`](/reference/string/basic_string.md)や文字列リテラルなど）と直接比較できるようになり、従来別途規定されていた追加の比較オーバーロードが不要になった。
 
 
 ## 例
@@ -66,3 +73,5 @@ equal
 ## 参照
 - [P1614R2 The Mothership has Landed](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1614r2.html)
     - C++20での三方比較演算子の追加と、関連する演算子の自動導出
+- [LWG Issue 3950. `std::basic_string_view` comparison operators are overspecified](https://cplusplus.github.io/LWG/issue3950)
+    - C++26で、比較演算子の第2引数が`type_identity_t`で包まれ、追加の比較オーバーロードの規定が不要になった

--- a/reference/text_encoding/text_encoding/aliases_view.md
+++ b/reference/text_encoding/text_encoding/aliases_view.md
@@ -24,6 +24,8 @@ struct text_encoding::aliases_view : ranges::view_interface<text_encoding::alias
 
 [`ranges::range_value_t`](/reference/ranges/range_value_t.md)`<text_encoding::aliases_view>`および[`ranges::range_reference_t`](/reference/ranges/range_reference_t.md)`<text_encoding::aliases_view>`はともに`const char*`を表す。
 
+[`ranges::iterator_t`](/reference/ranges/iterator_t.md)`<text_encoding::aliases_view>`はconstexprイテレータである。
+
 
 ## 例
 ```cpp example
@@ -76,3 +78,5 @@ Number of aliases: 3
 
 ## 参照
 - [P1885R12 Naming Text Encodings to Demystify Them](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/p1885r12.pdf)
+- [LWG Issue 4038. `std::text_encoding::aliases_view` should have constexpr iterators](https://cplusplus.github.io/LWG/issue4038)
+    - C++26で、`aliases_view`のイテレータがconstexprイテレータであることが規定された

--- a/reference/tuple/tuple/op_constructor.md
+++ b/reference/tuple/tuple/op_constructor.md
@@ -340,6 +340,7 @@ explicit(see below) constexpr
 - (14) :
     - `I`をパラメータパック`0, 1, ..., (sizeof...(Types) - 1)`と定義して、
     - C++23 : `!(`[`is_convertible_v`](/reference/type_traits/is_convertible.md)`<decltype(get<I>(`[`std::forward`](/reference/utility/forward.md)`<UTuple>(u))), Types> && ...)`である場合、この関数は`explicit`となる
+    - C++26 : `(`[`reference_constructs_from_temporary_v`](/reference/type_traits/reference_constructs_from_temporary.md)`<Types, decltype(get<I>(`[`std::forward`](/reference/utility/forward.md)`<UTuple>(u)))> || ...)`である場合、この関数は削除定義される
 - (15) :
     - C++20 : 対応するコンストラクタ (1) と同じ条件で`explicit`となる
 - (16) :
@@ -452,3 +453,5 @@ int main()
     - C++23 での (3) のコンストラクタの制約の変更（`disambiguating-constraint`等）について
 - [P2321R2 `zip`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2321r2.html#tuple)
     - すべての要素が[プロキシ参照](/reference/iterator/indirectly_writable.md)の場合、[プロキシ参照](/reference/iterator/indirectly_writable.md)として使用できるようにする
+- [LWG Issue 4045. `tuple` can create dangling references from `tuple-like`](https://cplusplus.github.io/LWG/issue4045)
+    - C++26で、[`tuple-like`](../tuple-like.md)なオブジェクトから構築するコンストラクタ(14)について、いずれかの要素がダングリング参照を作成する場合に削除定義されることが規定された（C++23での`tuple-like`コンストラクタ導入時に欠けていた保護の追加）


### PR DESCRIPTION
- [P2910R0 C++ Standard Library Issues to be moved in Varna, Jun. 2023](http://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2910r0.html)
- [P3180R0 C++ Standard Library Ready Issues to be moved in Tokyo, Mar. 2024](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3180r0.html)

これに全て対応しました。
C++26のLWG Issueへの対応が完了です。