### PR TITLE
C++23のLWG Issue対応第2弾

### DIFF
--- a/reference/concepts/Invoke.md
+++ b/reference/concepts/Invoke.md
@@ -48,10 +48,10 @@ C++における関数呼び出しという性質を抽象化しまとめた、�
 
 ## 要件（C++20）
 1. 仮想操作 *INVOKE*`(f, t1, t2, ..., tN)` を次のように定義する。
-	- `f` が型 `T` のメンバ関数へのポインタであり、[`is_base_of_v`](/reference/type_traits/is_base_of.md)`<T,` [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<decltype(t1)>> == true`（`t1` が `T` または `T` を継承した型のオブジェクト/参照）であるとき、 `(t1.*f)(t2, ..., tN)` と同じ効果を持つ。
+	- `f` が型 `T` のメンバ関数へのポインタであり、[`is_same_v`](/reference/type_traits/is_same.md)`<T,` [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<decltype(t1)>> || `[`is_base_of_v`](/reference/type_traits/is_base_of.md)`<T,` [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<decltype(t1)>>` が `true`（`t1` が `T` または `T` を継承した型のオブジェクト/参照）であるとき、 `(t1.*f)(t2, ..., tN)` と同じ効果を持つ。
 	- `f` が型 `T` のメンバ関数へのポインタであり、[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<decltype(t1)>`が[`reference_wrapper<T>`](/reference/functional/reference_wrapper.md)（`t1`が[`reference_wrapper`](/reference/functional/reference_wrapper.md)の特殊化）であるとき、 `(t1.get().*f)(t2, ..., tN)` と同じ効果を持つ。
 	- `f` が型 `T` のメンバ関数へのポインタであり、 `t1` が上記の条件に当てはまらない場合（例えば、t1が`T`のポインタ）、`((*t1).*f)(t2, ..., tN)` と同じ効果を持つ。
-	- `N == 1` で、`f` が型 `T` のメンバオブジェクトへのポインタであり、[`is_base_of_v`](/reference/type_traits/is_base_of.md)`<T,` [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<decltype(t1)>> == true`（`t1` が `T` または `T` を継承した型のオブジェクト/参照）であるとき、 `t1.*f` と同じ効果を持つ。
+	- `N == 1` で、`f` が型 `T` のメンバオブジェクトへのポインタであり、[`is_same_v`](/reference/type_traits/is_same.md)`<T,` [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<decltype(t1)>> || `[`is_base_of_v`](/reference/type_traits/is_base_of.md)`<T,` [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<decltype(t1)>>` が `true`（`t1` が `T` または `T` を継承した型のオブジェクト/参照）であるとき、 `t1.*f` と同じ効果を持つ。
 	- `N == 1` で、`f` が型 `T` のメンバオブジェクトへのポインタであり、[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<decltype(t1)>`が[`reference_wrapper<T>`](/reference/functional/reference_wrapper.md)（`t1`が[`reference_wrapper`](/reference/functional/reference_wrapper.md)の特殊化）であるとき、 `t1.get().*f` と同じ効果を持つ。
 	- `N == 1` で、`f` が型 `T` のメンバオブジェクトへのポインタであり、`t1` が上記の条件に当てはまらない場合（例えば、t1が`T`のポインタ）、 `(*t1).*f` と同じ効果を持つ。
 	- 上記の条件のどれにも当てはまらない場合、 `f(t1, t2, ..., tN)` と同じ効果を持つ。
@@ -84,3 +84,5 @@ C++20 における 2. について、次の文言を項目の最後に追加す�
 - [P0777R1 Treating Unnecessary `decay`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0777r1.pdf)
     - C++20から`decay_t`を`remove_cvref_t`へ変更。
 - [P2136R3 `invoke_r`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2136r3.html)
+- [LWG Issue 3655. The *INVOKE* operation and union types](https://cplusplus.github.io/LWG/issue3655)
+    - C++23で、メンバポインタの判定を`is_base_of_v`単独から`is_same_v || is_base_of_v`に変更し、共用体(union)型でも正しく扱えるようにした

--- a/reference/cstdint/intmax_t.md
+++ b/reference/cstdint/intmax_t.md
@@ -14,6 +14,11 @@ namespace std {
 ## 概要
 最大の符号付き整数型。
 
+
+## 備考
+最大幅の符号付き整数型ではあるが、`long long`より広い拡張整数型のすべての値を表現できる必要はない。
+
+
 ## バージョン
 ### 言語
 - C++11
@@ -23,3 +28,8 @@ namespace std {
 - [GCC](/implementation.md#gcc): 4.7.0 [mark verified]
 - [ICC](/implementation.md#icc): ??
 - [Visual C++](/implementation.md#visual_cpp): 2010 [mark verified], 2012 [mark verified], 2013 [mark verified]
+
+
+## 参照
+- [LWG Issue 3828. Sync `intmax_t` and `uintmax_t` with C2x](https://cplusplus.github.io/LWG/issue3828)
+    - C++23で、C23との同期のため、`intmax_t`は`long long`より広い拡張整数型のすべての値を表現できる必要はないことが明確化された

--- a/reference/cstdint/uintmax_t.md
+++ b/reference/cstdint/uintmax_t.md
@@ -14,6 +14,11 @@ namespace std {
 ## 概要
 最大の符号なし整数型。
 
+
+## 備考
+最大幅の符号なし整数型ではあるが、`unsigned long long`より広い拡張整数型のすべての値を表現できる必要はない。
+
+
 ## バージョン
 ### 言語
 - C++11
@@ -23,3 +28,8 @@ namespace std {
 - [GCC](/implementation.md#gcc): 4.7.0 [mark verified]
 - [ICC](/implementation.md#icc): ??
 - [Visual C++](/implementation.md#visual_cpp): 2010 [mark verified], 2012 [mark verified], 2013 [mark verified]
+
+
+## 参照
+- [LWG Issue 3828. Sync `intmax_t` and `uintmax_t` with C2x](https://cplusplus.github.io/LWG/issue3828)
+    - C++23で、C23との同期のため、`uintmax_t`は`unsigned long long`より広い拡張整数型のすべての値を表現できる必要はないことが明確化された

--- a/reference/expected/expected/and_then.md
+++ b/reference/expected/expected/and_then.md
@@ -30,8 +30,8 @@ class expected {
 
 
 ## テンプレートパラメータ制約
-- (1), (2) : [`is_copy_constructible_v`](/reference/type_traits/is_copy_constructible.md)`<E> == true`
-- (3), (4) : [`is_move_constructible_v`](/reference/type_traits/is_move_constructible.md)`<E> == true`
+- (1), (2) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, decltype(`[`error()`](error.md)`)> == true`
+- (3), (4) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, decltype(`[`std::move`](/reference/utility/move.md)`(`[`error()`](error.md)`))> == true`
 
 
 ## 適格要件
@@ -133,5 +133,7 @@ int main()
 
 ## 参照
 - [P2505R5 Monadic Functions for `std::expected`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2505r5.html)
+- [LWG Issue 3877. Incorrect constraints on `const`-qualified monadic overloads for `std::expected`](https://cplusplus.github.io/LWG/issue3877)
+    - C++23で、`const`修飾版で誤ってエラーになる問題を解消するため、制約が`is_copy_constructible_v<E>`から`is_constructible_v<E, decltype(error())>`（右辺値版は`decltype(std::move(error()))`）へ変更された
 - [LWG Issue 3938. Cannot use `std::expected` monadic ops with move-only `error_type`](https://cplusplus.github.io/LWG/issue3938)
     - C++26で、効果および適格要件で正常値へのアクセスに[`value()`](value.md)ではなく[`**this`](op_deref.md)を使うよう修正され、ムーブのみ可能な`error_type`でも使用できるようになった

--- a/reference/expected/expected/op_constructor.md
+++ b/reference/expected/expected/op_constructor.md
@@ -73,7 +73,7 @@ constexpr bool converts-from-any-cvref =
 - (4) : 次の制約を全て満たすこと
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<T, const U&> == true`
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, const G&> == true`
-    - `converts-from-any-cvref<T, expected<U, G>> == false`
+    - `T`が cv `bool` でない場合、`converts-from-any-cvref<T, expected<U, G>> == false`
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<`[`unexpected`](../unexpected.md)`<E>, expected<U, G>&> == false`
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<`[`unexpected`](../unexpected.md)`<E>, expected<U, G>> == false`
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<`[`unexpected`](../unexpected.md)`<E>, const expected<U, G>&> == false`
@@ -81,7 +81,7 @@ constexpr bool converts-from-any-cvref =
 - (5) : 次の制約を全て満たすこと
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<T, U> == true`
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, G> == true`
-    - `converts-from-any-cvref<T, expected<U, G>> == false`
+    - `T`が cv `bool` でない場合、`converts-from-any-cvref<T, expected<U, G>> == false`
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<`[`unexpected`](../unexpected.md)`<E>, expected<U, G>&> == false`
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<`[`unexpected`](../unexpected.md)`<E>, expected<U, G>> == false`
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<`[`unexpected`](../unexpected.md)`<E>, const expected<U, G>&> == false`
@@ -91,6 +91,7 @@ constexpr bool converts-from-any-cvref =
     - [`is_same_v`](/reference/type_traits/is_same.md)`<expected,` [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>> == false`
     - [`is_same_v`](/reference/type_traits/is_same.md)`<`[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>,` [`unexpect_t`](../unexpect_t.md)`> == false`
     - [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>`は[`unexpected`](../unexpected.md)の特殊化でない
+    - `T`が cv `bool` の場合、[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>`は`expected`の特殊化でない
     - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<T, U> == true`
 - (7) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, const G&> == true`
 - (8) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, G> == true`
@@ -320,5 +321,7 @@ int main()
 
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
+- [LWG Issue 3836. `std::expected<bool, E1>` conversion constructor `expected(const expected<U, G>&)` should take precedence over `expected(U&&)` with operator bool](https://cplusplus.github.io/LWG/issue3836)
+    - C++23で、`T`が cv `bool` のときに変換コンストラクタ(4)(5)が単一値コンストラクタ(6)に優先されるよう、(4)(5)の`converts-from-any-cvref`制約に「`T`が cv `bool` でない場合」の条件を付け、(6)に「`T`が cv `bool` の場合、`remove_cvref_t<U>`は`expected`の特殊化でない」制約を追加した
 - [LWG Issue 4222. `expected` constructor from a single value missing a constraint](https://cplusplus.github.io/LWG/issue4222)
     - C++26で、(6)の制約に[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<U>`が[`unexpect_t`](../unexpect_t.md)でないことが追加された

--- a/reference/expected/expected/or_else.md
+++ b/reference/expected/expected/or_else.md
@@ -30,8 +30,8 @@ class expected {
 
 
 ## テンプレートパラメータ制約
-- (1), (2) : [`is_copy_constructible_v`](/reference/type_traits/is_copy_constructible.md)`<T> == true`
-- (3), (4) : [`is_move_constructible_v`](/reference/type_traits/is_move_constructible.md)`<T> == true`
+- (1), (2) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<T, decltype(`[`value()`](value.md)`)> == true`
+- (3), (4) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<T, decltype(`[`std::move`](/reference/utility/move.md)`(`[`value()`](value.md)`))> == true`
 
 
 ## 適格要件
@@ -137,5 +137,7 @@ int main()
 
 ## 参照
 - [P2505R5 Monadic Functions for `std::expected`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2505r5.html)
+- [LWG Issue 3877. Incorrect constraints on `const`-qualified monadic overloads for `std::expected`](https://cplusplus.github.io/LWG/issue3877)
+    - C++23で、`const`修飾版で誤ってエラーになる問題を解消するため、制約が`is_copy_constructible_v<T>`から`is_constructible_v<T, decltype(value())>`（右辺値版は`decltype(std::move(value()))`）へ変更された
 - [LWG Issue 3938. Cannot use `std::expected` monadic ops with move-only `error_type`](https://cplusplus.github.io/LWG/issue3938)
     - C++26で、効果で正常値へのアクセスに[`value()`](value.md)ではなく[`**this`](op_deref.md)を使うよう修正され、ムーブのみ可能な`error_type`でも使用できるようになった

--- a/reference/expected/expected/transform.md
+++ b/reference/expected/expected/transform.md
@@ -30,8 +30,8 @@ class expected {
 
 
 ## テンプレートパラメータ制約
-- (1), (2) : [`is_copy_constructible_v`](/reference/type_traits/is_copy_constructible.md)`<E> == true`
-- (3), (4) : [`is_move_constructible_v`](/reference/type_traits/is_move_constructible.md)`<E> == true`
+- (1), (2) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, decltype(`[`error()`](error.md)`)> == true`
+- (3), (4) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, decltype(`[`std::move`](/reference/utility/move.md)`(`[`error()`](error.md)`))> == true`
 
 
 ## 適格要件
@@ -112,5 +112,7 @@ int main()
 
 ## 参照
 - [P2505R5 Monadic Functions for `std::expected`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2505r5.html)
+- [LWG Issue 3877. Incorrect constraints on `const`-qualified monadic overloads for `std::expected`](https://cplusplus.github.io/LWG/issue3877)
+    - C++23で、`const`修飾版で誤ってエラーになる問題を解消するため、制約が`is_copy_constructible_v<E>`から`is_constructible_v<E, decltype(error())>`（右辺値版は`decltype(std::move(error()))`）へ変更された
 - [LWG Issue 3938. Cannot use `std::expected` monadic ops with move-only `error_type`](https://cplusplus.github.io/LWG/issue3938)
     - C++26で、効果および適格要件で正常値へのアクセスに[`value()`](value.md)ではなく[`**this`](op_deref.md)を使うよう修正され、ムーブのみ可能な`error_type`でも使用できるようになった

--- a/reference/expected/expected/transform_error.md
+++ b/reference/expected/expected/transform_error.md
@@ -30,8 +30,8 @@ class expected {
 
 
 ## テンプレートパラメータ制約
-- (1), (2) : [`is_copy_constructible_v`](/reference/type_traits/is_copy_constructible.md)`<T> == true`
-- (3), (4) : [`is_move_constructible_v`](/reference/type_traits/is_move_constructible.md)`<T> == true`
+- (1), (2) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<T, decltype(`[`value()`](value.md)`)> == true`
+- (3), (4) : [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<T, decltype(`[`std::move`](/reference/utility/move.md)`(`[`value()`](value.md)`))> == true`
 
 
 ## 適格要件
@@ -111,5 +111,7 @@ int main()
 - [P2505R5 Monadic Functions for `std::expected`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2505r5.html)
 - [LWG Issue 3866. Bad Mandates for `expected::transform_error` overloads](https://cplusplus.github.io/LWG/issue3866)
     - C++23で、適格要件が「`G`が`expected`の有効なエラー値型である」から「`G`が[`unexpected`](../unexpected.md)の有効なテンプレート引数である」に修正された（`const int`のように`expected`のエラー値型としては有効でも`unexpected`のテンプレート引数としては無効な型があり、旧文言は実装不能だったため）
+- [LWG Issue 3877. Incorrect constraints on `const`-qualified monadic overloads for `std::expected`](https://cplusplus.github.io/LWG/issue3877)
+    - C++23で、`const`修飾版で誤ってエラーになる問題を解消するため、制約が`is_copy_constructible_v<T>`から`is_constructible_v<T, decltype(value())>`（右辺値版は`decltype(std::move(value()))`）へ変更された
 - [LWG Issue 3938. Cannot use `std::expected` monadic ops with move-only `error_type`](https://cplusplus.github.io/LWG/issue3938)
     - C++26で、効果で正常値へのアクセスに[`value()`](value.md)ではなく[`**this`](op_deref.md)を使うよう修正され、ムーブのみ可能な`error_type`でも使用できるようになった

--- a/reference/expected/expected/value.md
+++ b/reference/expected/expected/value.md
@@ -16,6 +16,11 @@ constexpr T&& value() &&;             // (4)
 正常値を取得する。
 
 
+## 適格要件
+- (1), (2) : [`is_copy_constructible_v`](/reference/type_traits/is_copy_constructible.md)`<E> == true`
+- (3), (4) : [`is_copy_constructible_v`](/reference/type_traits/is_copy_constructible.md)`<E> == true`、かつ、[`is_constructible_v`](/reference/type_traits/is_constructible.md)`<E, decltype(`[`std::move`](/reference/utility/move.md)`(`[`error()`](error.md)`))> == true`
+
+
 ## 戻り値
 動作説明用のメンバ変数として、正常値を保持する`val`を導入する。
 
@@ -28,7 +33,7 @@ constexpr T&& value() &&;             // (4)
 この関数は、例外を送出しうるため、フリースタンディング処理系では削除される（フリースタンディング処理系では使用できない）。
 
 ## 例外
-- (1), (2) : エラー値を保持していたら、例外[`bad_expected_access`](../bad_expected_access.md)`(`[`error()`](error.md)`)`を送出する
+- (1), (2) : エラー値を保持していたら、例外[`bad_expected_access`](../bad_expected_access.md)`(`[`as_const`](/reference/utility/as_const.md)`(`[`error()`](error.md)`))`を送出する
 - (3), (4) : エラー値を保持していたら、例外[`bad_expected_access`](../bad_expected_access.md)`(`[`std::move`](/reference/utility/move.md)`(`[`error()`](error.md)`))`を送出する
 
 
@@ -82,3 +87,5 @@ throw:ERR
 
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
+- [LWG Issue 3843. `std::expected<T,E>::value() &` assumes `E` is copy constructible](https://cplusplus.github.io/LWG/issue3843)
+    - C++23で、`E`のコピー構築可能性等を要求する適格要件が追加され、あわせて(1), (2)が送出する例外が`bad_expected_access(error())`から`bad_expected_access(as_const(error()))`に修正された

--- a/reference/flat_map/flat_map/op_constructor.md
+++ b/reference/flat_map/flat_map/op_constructor.md
@@ -451,6 +451,8 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3803. `flat_foo` constructors taking `KeyContainer` lack `KeyCompare` parameter](https://cplusplus.github.io/LWG/issue3803)
+    - C++23で、コンテナを取るコンストラクタに比較子`key_compare`を明示指定できる引数が追加された
 - [LWG Issue 3884. `flat_foo` is missing allocator-extended copy/move constructors](https://cplusplus.github.io/LWG/issue3884)
     - C++26で、`flat_map`にアロケータを指定するコピーコンストラクタ(5)とムーブコンストラクタ(6)が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/flat_map/flat_map/op_deduction_guide.md
+++ b/reference/flat_map/flat_map/op_deduction_guide.md
@@ -129,3 +129,5 @@ namespace std {
 
 ## 参照
 - [LWG Issue 3025. Map-like container deduction guides should use `pair<Key, T>`, not `pair<const Key, T>`](https://wg21.cmeerw.net/lwg/issue3025)
+- [LWG Issue 3786. Flat maps' deduction guide needs to default `Allocator` to be useful](https://cplusplus.github.io/LWG/issue3786)
+    - C++23で、`from_range_t`を取る推論補助で`Allocator`テンプレート引数がデフォルト化され、非デフォルトのアロケータのために推論補助が使えなかった問題が修正された。あわせて`(from_range_t, R&&, Allocator)`の推論補助が追加された

--- a/reference/flat_map/flat_multimap/op_constructor.md
+++ b/reference/flat_map/flat_multimap/op_constructor.md
@@ -447,6 +447,8 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3803. `flat_foo` constructors taking `KeyContainer` lack `KeyCompare` parameter](https://cplusplus.github.io/LWG/issue3803)
+    - C++23で、コンテナを取るコンストラクタに比較子`key_compare`を明示指定できる引数が追加された
 - [LWG Issue 3884. `flat_foo` is missing allocator-extended copy/move constructors](https://cplusplus.github.io/LWG/issue3884)
     - C++26で、`flat_multimap`にアロケータを指定するコピーコンストラクタ(5)とムーブコンストラクタ(6)が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/flat_map/flat_multimap/op_deduction_guide.md
+++ b/reference/flat_map/flat_multimap/op_deduction_guide.md
@@ -129,3 +129,5 @@ namespace std {
 
 ## 参照
 - [LWG Issue 3025. Map-like container deduction guides should use `pair<Key, T>`, not `pair<const Key, T>`](https://wg21.cmeerw.net/lwg/issue3025)
+- [LWG Issue 3786. Flat maps' deduction guide needs to default `Allocator` to be useful](https://cplusplus.github.io/LWG/issue3786)
+    - C++23で、`from_range_t`を取る推論補助で`Allocator`テンプレート引数がデフォルト化され、非デフォルトのアロケータのために推論補助が使えなかった問題が修正された。あわせて`(from_range_t, R&&, Allocator)`の推論補助が追加された

--- a/reference/flat_set/flat_multiset/erase_if_free.md
+++ b/reference/flat_set/flat_multiset/erase_if_free.md
@@ -28,11 +28,11 @@ namespace std {
 
 
 ## 事前条件
-- `Key`と`T`がムーブ代入可能であること
+- `Key`がムーブ代入可能であること
 
 
 ## 効果
-メンバ変数として保持しているコンテナ`c`の各要素`e`について、`bool(pred(e))`を`E`として、`E`が`true`であるすべての要素を削除する。
+メンバ変数として保持しているコンテナ`c`の各要素`e`について、`bool(pred(`[`as_const`](/reference/utility/as_const.md)`(e)))`を`E`として、`E`が`true`であるすべての要素を削除する。
 
 
 ## 戻り値
@@ -84,4 +84,6 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3879. `erase_if` for `flat_{,multi}set` is incorrectly specified](https://cplusplus.github.io/LWG/issue3879)
+    - C++23で、`flat_set`／`flat_multiset`は要素の`const`ビューしか提供しないため、述語を`bool(pred(as_const(e)))`として評価するよう効果が修正された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/flat_set/flat_multiset/op_constructor.md
+++ b/reference/flat_set/flat_multiset/op_constructor.md
@@ -432,6 +432,8 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3803. `flat_foo` constructors taking `KeyContainer` lack `KeyCompare` parameter](https://cplusplus.github.io/LWG/issue3803)
+    - C++23で、コンテナを取るコンストラクタに比較子`key_compare`を明示指定できる引数が追加された
 - [LWG Issue 3884. `flat_foo` is missing allocator-extended copy/move constructors](https://cplusplus.github.io/LWG/issue3884)
     - C++26で、`flat_multiset`にアロケータを指定するコピーコンストラクタ(5)とムーブコンストラクタ(6)が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/flat_set/flat_multiset/op_deduction_guide.md
+++ b/reference/flat_set/flat_multiset/op_deduction_guide.md
@@ -104,3 +104,8 @@ namespace std {
 - [Clang](/implementation.md#clang): ??
 - [GCC](/implementation.md#gcc): ??
 - [Visual C++](/implementation.md#visual_cpp): ??
+
+
+## 参照
+- [LWG Issue 3786. Flat maps' deduction guide needs to default `Allocator` to be useful](https://cplusplus.github.io/LWG/issue3786)
+    - C++23で、`from_range_t`を取る推論補助で`Allocator`テンプレート引数がデフォルト化され、非デフォルトのアロケータのために推論補助が使えなかった問題が修正された。あわせて`(from_range_t, R&&, Allocator)`の推論補助が追加された

--- a/reference/flat_set/flat_set/erase_if_free.md
+++ b/reference/flat_set/flat_set/erase_if_free.md
@@ -32,7 +32,7 @@ namespace std {
 
 
 ## 効果
-メンバ変数として保持しているコンテナ`c`の各要素`e`について、`bool(pred(e))`を`E`として、`E`が`true`であるすべての要素を削除する。
+メンバ変数として保持しているコンテナ`c`の各要素`e`について、`bool(pred(`[`as_const`](/reference/utility/as_const.md)`(e)))`を`E`として、`E`が`true`であるすべての要素を削除する。
 
 
 ## 戻り値
@@ -79,4 +79,6 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3879. `erase_if` for `flat_{,multi}set` is incorrectly specified](https://cplusplus.github.io/LWG/issue3879)
+    - C++23で、`flat_set`／`flat_multiset`は要素の`const`ビューしか提供しないため、述語を`bool(pred(as_const(e)))`として評価するよう効果が修正された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/flat_set/flat_set/op_constructor.md
+++ b/reference/flat_set/flat_set/op_constructor.md
@@ -433,6 +433,8 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3803. `flat_foo` constructors taking `KeyContainer` lack `KeyCompare` parameter](https://cplusplus.github.io/LWG/issue3803)
+    - C++23で、コンテナを取るコンストラクタに比較子`key_compare`を明示指定できる引数が追加された
 - [LWG Issue 3884. `flat_foo` is missing allocator-extended copy/move constructors](https://cplusplus.github.io/LWG/issue3884)
     - C++26で、`flat_set`にアロケータを指定するコピーコンストラクタ(5)とムーブコンストラクタ(6)が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/flat_set/flat_set/op_deduction_guide.md
+++ b/reference/flat_set/flat_set/op_deduction_guide.md
@@ -104,3 +104,8 @@ namespace std {
 - [Clang](/implementation.md#clang): ??
 - [GCC](/implementation.md#gcc): ??
 - [Visual C++](/implementation.md#visual_cpp): ??
+
+
+## 参照
+- [LWG Issue 3786. Flat maps' deduction guide needs to default `Allocator` to be useful](https://cplusplus.github.io/LWG/issue3786)
+    - C++23で、`from_range_t`を取る推論補助で`Allocator`テンプレート引数がデフォルト化され、非デフォルトのアロケータのために推論補助が使えなかった問題が修正された。あわせて`(from_range_t, R&&, Allocator)`の推論補助が追加された

--- a/reference/format/basic_format_arg/op_constructor.md
+++ b/reference/format/basic_format_arg/op_constructor.md
@@ -91,5 +91,7 @@ namespace std {
 ## 参照
 
 - [P0645R10 Text Formatting](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0645r10.html)
+- [LWG Issue 3631. `basic_format_arg(T&&)` should use `remove_cvref_t<T>` throughout](https://cplusplus.github.io/LWG/issue3631)
+    - C++23で、コンストラクタが検査する型プロパティをcvref除去後の型で判定するよう整理された（最終的にコンストラクタは左辺値参照`T&`をとり、`TD = remove_const_t<T>`で判定する形になった）
 - [P3391R2 `constexpr std::format`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3391r2.html)
     - C++26から`constexpr`に対応した

--- a/reference/format/basic_format_args.md
+++ b/reference/format/basic_format_args.md
@@ -32,6 +32,12 @@ namespace std {
 | [`(constructor)`](basic_format_args/op_constructor.md) | コンストラクタ                    | C++20          |
 | [`get`](basic_format_args/get.md)                      | フォーマット引数へアクセスする    | C++20          |
 
+## 推論補助
+
+| 名前 | 説明 | 対応バージョン |
+|--------------------------------------------------------------------|------------------------------------|-------|
+| [`(deduction_guide)`](basic_format_args/op_deduction_guide.md) | クラステンプレートの推論補助 | C++23 |
+
 ## バージョン
 ### 言語
 - C++20

--- a/reference/format/basic_format_args/op_deduction_guide.md
+++ b/reference/format/basic_format_args/op_deduction_guide.md
@@ -1,0 +1,63 @@
+# 推論補助
+* format[meta header]
+* std[meta namespace]
+* basic_format_args[meta class]
+* cpp23[meta cpp]
+
+```cpp
+namespace std {
+  template <class Context, class... Args>
+  basic_format_args(format_arg_store<Context, Args...>)
+    -> basic_format_args<Context>; // (1) C++23
+}
+```
+* format_arg_store[italic]
+
+## 概要
+[`basic_format_args`](../basic_format_args.md)クラステンプレートの型推論補助。
+
+- (1) : [`make_format_args`](../make_format_args.md)の戻り値（_`format_arg_store`_）から、テンプレートパラメータ`Context`を推論する。
+
+ただし、 _`format_arg_store`_ は`make_format_args`の戻り値と同じ型であることを示す便宜上の名前であり、規格には含まれない。
+
+
+## 備考
+この推論補助はC++23に対する欠陥報告 (LWG 3810) として追加されたものであり、コンパイラは早期に対応している場合がある。そのため、C++20モードでも使用できる可能性がある。
+
+
+## 例
+```cpp example
+#include <format>
+
+int main()
+{
+  // make_format_argsの戻り値から、basic_format_args<format_context>を推論する
+  std::basic_format_args args = std::make_format_args();
+  (void)args;
+}
+```
+* std::make_format_args[link ../make_format_args.md]
+
+### 出力
+```
+```
+
+
+## バージョン
+### 言語
+- C++23
+
+### 処理系
+- [Clang](/implementation.md#clang): 17 [mark verified]
+- [GCC](/implementation.md#gcc): 13.1 [mark verified]
+- [Visual C++](/implementation.md#visual_cpp): 2022 [mark verified]
+
+
+## 関連項目
+- [`basic_format_args`](../basic_format_args.md)
+- [`make_format_args`](../make_format_args.md)
+
+
+## 参照
+- [LWG Issue 3810. CTAD for `std::basic_format_args`](https://cplusplus.github.io/LWG/issue3810)
+    - C++23で、[`make_format_args`](../make_format_args.md)の戻り値から`Context`を推論するための推論補助が追加された

--- a/reference/format/formatter.md
+++ b/reference/format/formatter.md
@@ -48,7 +48,7 @@ namespace std {
 - `template<> struct formatter<char, wchar_t>`
 - `template<> struct formatter<charT*, charT>`
 - `template<> struct formatter<const charT*, charT>`
-- `template<size_t N> struct formatter<const charT[N], charT>`
+- `template<size_t N> struct formatter<charT[N], charT>`
 - `template<class traits, class Allocator> struct formatter<`[`basic_string`](/reference/string/basic_string.md)`<charT, traits, Allocator>, charT>`
 - `template<class traits> struct formatter<`[`basic_string_view`](/reference/string_view/basic_string_view.md)`<charT, traits>, charT>`
 - 第1テンプレート引数が`nullptr_t`, `void*`, `const void*`, `bool`, すべてのCV修飾されない標準の整数型, 拡張整数型, 浮動小数点数型であり、第2テンプレート引数が`charT`であるもの。
@@ -284,5 +284,7 @@ int main()
 - [P2286R8 Formatting Ranges](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2286r8.html)
 - [P2585R1 Improve default container formatting](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2585r1.html)
     - C++23から、Range・コンテナ、`pair`、`tuple`のフォーマット出力、および文字・文字列のデバッグ指定 (`"?"`) が追加された
+- [LWG Issue 3833. Remove specialization `template<size_t N> struct formatter<const charT[N], charT>`](https://cplusplus.github.io/LWG/issue3833)
+    - C++23で、`formatter`がCV修飾のないオブジェクト型に対してのみ特殊化される設計と矛盾するため、`formatter<const charT[N], charT>`の特殊化が有効な標準特殊化の一覧から削除された
 - [LWG Issue 3944. Formatters converting sequences of `char` to sequences of `wchar_t`](https://cplusplus.github.io/LWG/issue3944)
     - C++26で、`char`のシーケンスを`wchar_t`としてフォーマットする特殊化が、暗黙のマルチバイト／ワイド文字変換を避けるため明示的に無効化された

--- a/reference/iterator/basic_const_iterator/common_type.md
+++ b/reference/iterator/basic_const_iterator/common_type.md
@@ -80,3 +80,5 @@ int main() {
 ## 参照
 
 - [P2278R4 `cbegin` should always return a constant iterator](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2278r4.html)
+- [LWG Issue 3862. `basic_const_iterator`'s `common_type` specialization is underconstrained](https://cplusplus.github.io/LWG/issue3862)
+    - C++23で、3つの`common_type`特殊化に`common_type_t<T, U>`が`input_iterator`であることの制約が追加された

--- a/reference/iterator/basic_const_iterator/iter_move.md
+++ b/reference/iterator/basic_const_iterator/iter_move.md
@@ -81,3 +81,5 @@ int main() {
 ## 参照
 
 - [P2278R4 `cbegin` should always return a constant iterator](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2278r4.html)
+- [LWG Issue 3872. `basic_const_iterator` should have custom `iter_move`](https://cplusplus.github.io/LWG/issue3872)
+    - C++23で、`as_const`後に`as_rvalue`を適用しても効かない不整合を解消するため、専用の`iter_move`が追加された

--- a/reference/mdspan/layout_left/mapping.md
+++ b/reference/mdspan/layout_left/mapping.md
@@ -136,3 +136,5 @@ int main()
 ## 参照
 - [P0009R18 MDSPAN](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r18.html)
 - [P2630R4 Submdspan](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2630r4.html)
+- [LWG Issue 3876. Default constructor of `std::layout_XX::mapping` misses precondition](https://cplusplus.github.io/LWG/issue3876)
+    - C++23で、`Extents::rank_dynamic() == 0`のとき、多次元インデクス空間`Extents()`のサイズが`Extents::index_type`で表現可能であることの適格要件が追加された

--- a/reference/mdspan/layout_right/mapping.md
+++ b/reference/mdspan/layout_right/mapping.md
@@ -136,3 +136,5 @@ int main()
 ## 参照
 - [P0009R18 MDSPAN](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r18.html)
 - [P2630R4 Submdspan](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2630r4.html)
+- [LWG Issue 3876. Default constructor of `std::layout_XX::mapping` misses precondition](https://cplusplus.github.io/LWG/issue3876)
+    - C++23で、`Extents::rank_dynamic() == 0`のとき、多次元インデクス空間`Extents()`のサイズが`Extents::index_type`で表現可能であることの適格要件が追加された

--- a/reference/mdspan/layout_stride/mapping.md
+++ b/reference/mdspan/layout_stride/mapping.md
@@ -144,5 +144,7 @@ int main()
 ## 参照
 - [P0009R18 MDSPAN](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0009r18.html)
 - [P2630R4 Submdspan](https://open-std.org/jtc1/sc22/wg21/docs/papers/2023/p2630r4.html)
+- [LWG Issue 3876. Default constructor of `std::layout_XX::mapping` misses precondition](https://cplusplus.github.io/LWG/issue3876)
+    - C++23で、`Extents::rank_dynamic() == 0`のとき、多次元インデクス空間`Extents()`のサイズが`Extents::index_type`で表現可能であることの適格要件が追加された
 - [LWG Issue 4266. `layout_stride::mapping` should treat empty mappings as exhaustive](https://cplusplus.github.io/LWG/issue4266)
     - C++26で、`is_always_exhaustive()`が`rank() == 0`や静的要素数`0`の次元を持つ場合に`true`を返すよう変更された（C++23では常に`false`）。あわせて[`is_exhaustive()`](mapping/is_exhaustive.md)も多次元インデックス空間が空の場合に`true`を返すよう拡張された

--- a/reference/memory/construct_at.md
+++ b/reference/memory/construct_at.md
@@ -27,7 +27,7 @@ namespace std {
 ```cpp
 template<class T>
 constexpr void* voidify(T& ptr) noexcept {
-  return const_cast<void*>(static_cast<const volatile void*>(addressof(ptr)));
+  return addressof(ptr);
 }
 ```
 
@@ -89,3 +89,5 @@ int main()
 - [P0040R3 Extending memory management tools](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0040r3.html)
 - [P0784R7 More `constexpr` containers](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0784r7.html)
 - [LWG Issue 3436. `std::construct_at` should support arrays](https://wg21.cmeerw.net/lwg/issue3436)
+- [LWG Issue 3870. Remove `voidify`](https://cplusplus.github.io/LWG/issue3870)
+    - C++23で、説明専用関数`voidify`の本体が`const_cast`／`static_cast`を用いる形から`addressof`を返す形に変更され、`const`記憶域へのオブジェクト構築が禁じられた

--- a/reference/memory/out_ptr_t/op_constructor.md
+++ b/reference/memory/out_ptr_t/op_constructor.md
@@ -26,6 +26,12 @@ out_ptr_t(const out_ptr_t&) = delete;   // (2) C++23
 - `tuple<Args...>`型メンバ変数`a` : [`std::forward`](/reference/utility/forward.md)`<Args>(args)...`
 - `Pointer`型メンバ`p` : `{}`(値初期化)
 
+その後、以下と等価の処理を行う。
+
+- 式`s.reset()`が適格であれば、`s.reset()`
+- そうでなく、[`is_constructible_v`](/reference/type_traits/is_constructible.md)`<Smart> == true`であれば、`s = Smart()`
+- いずれでもなければ、プログラムは不適格となる
+
 
 ## バージョン
 ### 言語
@@ -47,4 +53,6 @@ out_ptr_t(const out_ptr_t&) = delete;   // (2) C++23
 
 ## 参照
 - [P1132R8 out_ptr - a scalable output pointer abstraction](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1132r8.html)
+- [LWG Issue 3734. Inconsistency in `inout_ptr` and `out_ptr` for empty case](https://cplusplus.github.io/LWG/issue3734)
+    - C++23で、`out_ptr_t`のコンストラクタが、`s`が保持していた既存の値を`s.reset()`（不可能なら`s = Smart()`）で解放するよう変更された。これにより、ポインタスタイル関数が`nullptr`を返した場合でも`out`が空状態になる
 - [P3037R6 `constexpr std::shared_ptr` and friends](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3037r6.pdf)

--- a/reference/memory/ranges_construct_at.md
+++ b/reference/memory/ranges_construct_at.md
@@ -27,7 +27,7 @@ namespace std::ranges {
 ```cpp
 template<class T>
 constexpr void* voidify(T& ptr) noexcept {
-  return const_cast<void*>(static_cast<const volatile void*>(addressof(ptr)));
+  return addressof(ptr);
 }
 ```
 
@@ -87,3 +87,5 @@ int main()
 ## 参照
 - [P0896R4 The One Ranges Proposal](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0896r4.pdf)
 - [LWG Issue 3436. `std::construct_at` should support arrays](https://wg21.cmeerw.net/lwg/issue3436)
+- [LWG Issue 3870. Remove `voidify`](https://cplusplus.github.io/LWG/issue3870)
+    - C++23で、説明専用関数`voidify`の本体が`const_cast`／`static_cast`を用いる形から`addressof`を返す形に変更され、`const`記憶域へのオブジェクト構築が禁じられた

--- a/reference/memory/ranges_uninitialized_copy.md
+++ b/reference/memory/ranges_uninitialized_copy.md
@@ -111,7 +111,7 @@ namespace std::ranges {
 ```cpp
 template<class T>
 constexpr void* voidify(T& obj) noexcept {
-  return const_cast<void*>(static_cast<const volatile void*>(addressof(obj)));
+  return addressof(obj);
 }
 ```
 
@@ -232,3 +232,5 @@ int main() {
 - [P3508R0 Wording for "constexpr for specialized memory algorithms"](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3508r0.html)
     - C++26から`constexpr`がついた
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 3870. Remove `voidify`](https://cplusplus.github.io/LWG/issue3870)
+    - C++23で、説明専用関数`voidify`の本体が`const_cast`／`static_cast`を用いる形から`addressof`を返す形に変更され、`const`記憶域へのオブジェクト構築が禁じられた

--- a/reference/memory/ranges_uninitialized_default_construct.md
+++ b/reference/memory/ranges_uninitialized_default_construct.md
@@ -73,7 +73,7 @@ namespace std::ranges {
 ```cpp
 template<class T>
 constexpr void* voidify(T& obj) noexcept {
-  return const_cast<void*>(static_cast<const volatile void*>(addressof(obj)));
+  return addressof(obj);
 }
 ```
 
@@ -190,3 +190,5 @@ done
 - [P3369R0 `constexpr` for `uninitialized_default_construct`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3369r0.html)
     - 上記2文書で、C++26から`constexpr`がついた
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 3870. Remove `voidify`](https://cplusplus.github.io/LWG/issue3870)
+    - C++23で、説明専用関数`voidify`の本体が`const_cast`／`static_cast`を用いる形から`addressof`を返す形に変更され、`const`記憶域へのオブジェクト構築が禁じられた

--- a/reference/memory/ranges_uninitialized_fill.md
+++ b/reference/memory/ranges_uninitialized_fill.md
@@ -80,7 +80,7 @@ namespace std::ranges {
 ```cpp
 template<class T>
 constexpr void* voidify(T& obj) noexcept {
-  return const_cast<void*>(static_cast<const volatile void*>(addressof(obj)));
+  return addressof(obj);
 }
 ```
 
@@ -241,3 +241,5 @@ int main() {
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
 - [P3787R2 Adjoints to "Enabling list-initialization for algorithms": `uninitialized_fill`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3787r2.html)
     - C++26から波カッコ初期化リストを入力として使用できるよう、要素型をデフォルトテンプレート引数とするオーバーロードが追加された
+- [LWG Issue 3870. Remove `voidify`](https://cplusplus.github.io/LWG/issue3870)
+    - C++23で、説明専用関数`voidify`の本体が`const_cast`／`static_cast`を用いる形から`addressof`を返す形に変更され、`const`記憶域へのオブジェクト構築が禁じられた

--- a/reference/memory/ranges_uninitialized_move.md
+++ b/reference/memory/ranges_uninitialized_move.md
@@ -99,7 +99,7 @@ namespace std::ranges {
 ```cpp
 template<class T>
 constexpr void* voidify(T& obj) noexcept {
-  return const_cast<void*>(static_cast<const volatile void*>(addressof(obj)));
+  return addressof(obj);
 }
 ```
 
@@ -222,3 +222,5 @@ hello world test
 - [P3508R0 Wording for "constexpr for specialized memory algorithms"](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3508r0.html)
     - C++26から`constexpr`がついた
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 3870. Remove `voidify`](https://cplusplus.github.io/LWG/issue3870)
+    - C++23で、説明専用関数`voidify`の本体が`const_cast`／`static_cast`を用いる形から`addressof`を返す形に変更され、`const`記憶域へのオブジェクト構築が禁じられた

--- a/reference/memory/ranges_uninitialized_value_construct.md
+++ b/reference/memory/ranges_uninitialized_value_construct.md
@@ -73,7 +73,7 @@ namespace std::ranges {
 ```cpp
 template<class T>
 constexpr void* voidify(T& obj) noexcept {
-  return const_cast<void*>(static_cast<const volatile void*>(addressof(obj)));
+  return addressof(obj);
 }
 ```
 
@@ -189,3 +189,5 @@ int main() {
 - [P3508R0 Wording for "constexpr for specialized memory algorithms"](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3508r0.html)
     - C++26から`constexpr`がついた
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 3870. Remove `voidify`](https://cplusplus.github.io/LWG/issue3870)
+    - C++23で、説明専用関数`voidify`の本体が`const_cast`／`static_cast`を用いる形から`addressof`を返す形に変更され、`const`記憶域へのオブジェクト構築が禁じられた

--- a/reference/queue/priority_queue/push_range.md
+++ b/reference/queue/priority_queue/push_range.md
@@ -66,4 +66,6 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3723. `priority_queue::push_range` needs to `append_range`](https://cplusplus.github.io/LWG/issue3723)
+    - C++23で、効果が`c.append_range(rg)`を利用して要素を追加し`make_heap`でヒープ性を回復する形に明確化された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/ranges/repeat_view.md
+++ b/reference/ranges/repeat_view.md
@@ -8,7 +8,7 @@
 namespace std::ranges {
   template<move_constructible T, semiregular Bound = unreachable_sentinel_t>
     requires (is_object_v<T> && same_as<T, remove_cv_t<T>> &&
-              (is-integer-like<Bound> || same_as<Bound, unreachable_sentinel_t>))
+              (integer-like-with-usable-difference-type<Bound> || same_as<Bound, unreachable_sentinel_t>))
   class repeat_view : public view_interface<repeat_view<T, Bound>> { …… }; // (1)
 
   namespace views {
@@ -17,7 +17,7 @@ namespace std::ranges {
 }
 ```
 * semiregular[link /reference/concepts/semiregular.md]
-* is-integer-like[link /reference/iterator/is_integer_like.md]
+* integer-like-with-usable-difference-type[italic]
 
 ## 概要
 - (1): 指定した値を指定回数繰り返す[`view`](view.md)
@@ -44,12 +44,12 @@ namespace std::ranges {
 | [`(constructor)`](repeat_view/op_constructor.md)  | コンストラクタ                   | C++23          |
 | [`begin`](repeat_view/begin.md)                   | 先頭を指すイテレータを取得する   | C++23          |
 | [`end`](repeat_view/end.md)                       | 番兵を取得する                   | C++23          |
-| [`size`](repeat_view/size.md)                     | 配列の先頭へのポインタを取得する | C++23          |
+| [`size`](repeat_view/size.md)                     | 要素数を取得する                 | C++23          |
 
 ## 継承しているメンバ関数
 
 | 名前                                         | 説明                              | 対応バージョン |
-|----------------------------------------------|------------------------------ ----|----------------|
+|----------------------------------------------|-----------------------------------|----------------|
 | [`operator bool`](view_interface/op_bool.md) | Rangeが空でないかどうかを判定する | C++23          |
 | [`front`](view_interface/front.md)           | 先頭要素への参照を取得する        | C++23          |
 | [`back`](view_interface/back.md)             | 末尾要素への参照を取得する        | C++23          |
@@ -103,5 +103,7 @@ int main() {
 
 ## 参照
 - [N4950 26 Ranges library](https://timsong-cpp.github.io/cppwp/n4950/ranges)
+- [LWG Issue 3875. `std::ranges::repeat_view<T, IntegerClass>::iterator` may be ill-formed](https://cplusplus.github.io/LWG/issue3875)
+    - C++23で、`Bound`の制約に使う説明専用コンセプトが`is-integer-like<Bound>`から`integer-like-with-usable-difference-type<Bound>`（`is-signed-integer-like<T> || (is-integer-like<T> && weakly_incrementable<T>)`）へ変更され、使用可能な差分型を持たない整数クラス型が排除されるようになった
 - [LWG Issue 4054. Repeating a `repeat_view` should repeat the view](https://cplusplus.github.io/LWG/issue4054)
     - C++26で、`views::repeat(E)`の効果が`repeat_view<decay_t<decltype((E))>>(E)`に修正され、引数を[`decay_t`](/reference/type_traits/decay.md)で減衰させて要素型を決定するようになった

--- a/reference/ranges/repeat_view/iterator.md
+++ b/reference/ranges/repeat_view/iterator.md
@@ -20,7 +20,7 @@
 namespace std::ranges {
   template<move_constructible T, semiregular Bound = unreachable_sentinel_t>
     requires (is_object_v<T> && same_as<T, remove_cv_t<T>> &&
-              (is-integer-like<Bound> || same_as<Bound, unreachable_sentinel_t>))
+              (integer-like-with-usable-difference-type<Bound> || same_as<Bound, unreachable_sentinel_t>))
   class repeat_view<T, Bound>::iterator {
   private:
     using index_type = conditional_t<same_as<Bound, unreachable_sentinel_t>, ptrdiff_t, Bound>;
@@ -106,7 +106,7 @@ namespace std::ranges {
 }
 ```
 * semiregular[link /reference/concepts/semiregular.md]
-* is-integer-like[link /reference/iterator/is_integer_like.md]
+* integer-like-with-usable-difference-type[italic]
 * repeat_view[link ../repeat_view.md]
 * conditional_t[link /reference/type_traits/conditional.md]
 * ptrdiff_t[link /reference/cstddef/ptrdiff_t.md]
@@ -126,3 +126,5 @@ namespace std::ranges {
 
 ## 参照
 - [N4950 26 Ranges library](https://timsong-cpp.github.io/cppwp/n4950/ranges)
+- [LWG Issue 3875. `std::ranges::repeat_view<T, IntegerClass>::iterator` may be ill-formed](https://cplusplus.github.io/LWG/issue3875)
+    - C++23で、`Bound`の制約に使う説明専用コンセプトが`is-integer-like<Bound>`から`integer-like-with-usable-difference-type<Bound>`へ変更された

--- a/reference/ranges/repeat_view/op_constructor.md
+++ b/reference/ranges/repeat_view/op_constructor.md
@@ -47,7 +47,7 @@ constexpr explicit
 - (4) :
     - `value_`を[`make_from_tuple`](/reference/tuple/make_from_tuple.md)`<T>(`[`std::move`](/reference/utility/move.md)`(value_args))`で初期化する
     - `bound_`を[`make_from_tuple`](/reference/tuple/make_from_tuple.md)`<Bound>(`[`std::move`](/reference/utility/move.md)`(bound_args))`で初期化する
-    - `bound`が型`unreachable_sentinel_t`である場合、もしくは`bound < 0`である場合、未定義動作を引き起こす
+    - 型`Bound`が[`unreachable_sentinel_t`](/reference/iterator/unreachable_sentinel_t.md)でなく、かつ`bound_ < 0`である場合、動作は未定義
 
 
 ## 例
@@ -116,3 +116,8 @@ aaa
 - [GCC](/implementation.md#gcc): 13 [mark verified]
 - [ICC](/implementation.md#icc): ?
 - [Visual C++](/implementation.md#visual_cpp): 2022 Update 6 [mark verified]
+
+
+## 参照
+- [LWG Issue 3772. `repeat_view`'s piecewise constructor is missing Postconditions](https://cplusplus.github.io/LWG/issue3772)
+    - C++23で、piecewiseコンストラクタ(4)の効果が[`make_from_tuple`](/reference/tuple/make_from_tuple.md)を用いる形に整理され、`Bound`が`unreachable_sentinel_t`でなく`bound_`が負の場合に動作は未定義であることが規定された

--- a/reference/ranges/to.md
+++ b/reference/ranges/to.md
@@ -234,6 +234,8 @@ int main() {
     - C++26で要素数の事前確保に[`ranges::size`](size.md)の代わりに[`ranges::reserve_hint`](reserve_hint.md)を使用するよう変更
 - [LWG Issue 3733. `ranges::to` misuses *cpp17-input-iterator*](https://cplusplus.github.io/LWG/issue3733)
     - C++23で、Cpp17InputIterator判定に説明専用コンセプト`cpp17-input-iterator`を使用するのをやめ、`iterator_traits<iterator_t<R>>::iterator_category`が`input_iterator_tag`から派生する有効な型であることを判定するよう修正された（[`common_iterator`](/reference/iterator/common_iterator.md)のように`iterator_traits`の特殊化を持つイテレータで正しく判定されるようにするため）
+- [LWG Issue 3847. `ranges::to` can still return views](https://cplusplus.github.io/LWG/issue3847)
+    - C++23で、(1)(3)に`C`がcv非修飾のクラス型であることの適格要件が追加され、`view`が返される問題が解消された
 - [LWG Issue 3984. `ranges::to`'s recursion branch may be ill-formed](https://cplusplus.github.io/LWG/issue3984)
     - C++26で、再帰分岐において`r`を[`ranges::ref_view`](ref_view.md)で包むよう修正され、`r`がviewでない左辺値rangeの場合に不適格となる問題が解消された
 - [LWG Issue 4016. *container-insertable* checks do not match what *container-inserter* does](https://cplusplus.github.io/LWG/issue4016)

--- a/reference/utility/pair/op_compare_3way.md
+++ b/reference/utility/pair/op_compare_3way.md
@@ -5,13 +5,25 @@
 * function template[meta id-type]
 
 ```cpp
-friend constexpr common_comparison_category_t<synth-three-way-result<T1>, synth-three-way-result<T2>>
-   operator<=>(const pair& x, const pair& y);
+namespace std {
+  template <class T1, class T2>
+  struct pair {
+    friend constexpr common_comparison_category_t<synth-three-way-result<T1>, synth-three-way-result<T2>>
+       operator<=>(const pair& x, const pair& y);                       // (1) C++20
+  };
+
+  template <class T1, class T2, class U1, class U2>
+  constexpr common_comparison_category_t<synth-three-way-result<T1, U1>, synth-three-way-result<T2, U2>>
+     operator<=>(const pair<T1, T2>& x, const pair<U1, U2>& y);         // (2) C++23
+}
 ```
 * common_comparison_category_t[link /reference/compare/common_comparison_category.md]
 
 ## 概要
 2つの`pair`の三方比較を行う。
+
+- (1) : 同じ型の`pair`同士の三方比較を行う。
+- (2) : 左辺と右辺で要素型が異なる`pair`同士の三方比較を行う。
 
 
 ## 効果
@@ -30,6 +42,7 @@ return synth-three-way(x.second, y.second);
     - `operator<=`
     - `operator>`
     - `operator>=`
+- (2) : C++23で追加された。これにより、`reference`が`pair<T&, U&>`、`value_type`が`pair<T, U>`となるような（[`views::zip`](/reference/ranges/zip_view.md)相当の）Rangeを[`ranges::sort`](/reference/algorithm/ranges_sort.md)などでソートできるようになる。
 
 
 ## 例
@@ -60,3 +73,5 @@ int main()
 ## 参照
 - [P1614R2 The Mothership has Landed](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1614r2.html)
     - C++20での三方比較演算子の追加と、関連する演算子の自動導出
+- [LWG Issue 3865. Sorting a range of `pair`s](https://cplusplus.github.io/LWG/issue3865)
+    - C++23で、`operator<=>`が左辺と右辺で要素型の異なる`pair`同士を比較できる異種比較に変更された

--- a/reference/utility/pair/op_equal.md
+++ b/reference/utility/pair/op_equal.md
@@ -18,12 +18,20 @@ namespace std {
     friend constexpr bool operator==(const pair& x, const pair& y)        // (2) C++20
         requires (is_reference_v<T1> || is_reference_v<T2>);
   };
+
+  template <class T1, class T2, class U1, class U2>
+  constexpr bool operator==(const pair<T1, T2>& x,
+                            const pair<U1, U2>& y);                       // (3) C++23
 }
 ```
 * is_reference_v[link /reference/type_traits/is_reference.md]
 
 ## 概要
-2つの`pair`の等値比較を行う
+2つの`pair`の等値比較を行う。
+
+- (1) : 同じ型の`pair`同士の等値比較を行う。
+- (2) : 要素型のいずれかが参照型である`pair`同士の等値比較を行う。
+- (3) : 左辺と右辺で要素型が異なる`pair`同士の等値比較を行う。
 
 
 ## テンプレートパラメータ制約
@@ -39,6 +47,7 @@ return x.first == y.first && x.second == y.second;
 ## 備考
 - この演算子により、以下の演算子が使用可能になる (C++20)：
     - `operator!=`
+- (3) : C++23で追加された。これにより、`reference`が`pair<T&, U&>`、`value_type`が`pair<T, U>`となるような（[`views::zip`](/reference/ranges/zip_view.md)相当の）Rangeを[`ranges::sort`](/reference/algorithm/ranges_sort.md)などでソートできるようになる。
 
 
 ## 例
@@ -69,5 +78,7 @@ false
 - [N3471 Constexpr Library Additions: utilities, v3](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2012/n3471.html)
 - [P1614R2 The Mothership has Landed](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1614r2.html)
     - C++20での三方比較演算子の追加と、関連する演算子の自動導出
+- [LWG Issue 3865. Sorting a range of `pair`s](https://cplusplus.github.io/LWG/issue3865)
+    - C++23で、`operator==`が左辺と右辺で要素型の異なる`pair`同士を比較できる異種比較に変更された
 - [P2944R3 Comparisons for `reference_wrapper`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2944r3.html)
     - C++26でテンプレートパラメータ制約が整理された


### PR DESCRIPTION
- [P2790R0 C++ Standard Library Immediate Issues to be moved in Issaquah, Feb. 2023](https://wg21.link/p2790r0)

これに全て対応しました。