### PR TITLE
C++23のLWG Issue対応第3弾

### DIFF
--- a/reference/atomic.md
+++ b/reference/atomic.md
@@ -161,3 +161,5 @@
 - [Boost Atomic Library](http://www.boost.org/doc/libs/release/libs/atomic/)
 - [P1642R11 Freestanding Library: Easy `[utilities]`, `[ranges]`, and `[iterators]`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1642r11.html)
     - C++23で、フリースタンディング処理系での`<atomic>`の要件が、フリースタンディングエンティティの仕組みに基づいて整理された
+- [LWG Issue 3814. Add freestanding items requested by NB comments](https://cplusplus.github.io/LWG/issue3814)
+    - C++23で、`memory_order`の各定数などがフリースタンディング処理系で使用可能であることが追加で規定された

--- a/reference/flat_map/flat_map.md
+++ b/reference/flat_map/flat_map.md
@@ -369,5 +369,7 @@ int main()
     - C++23で`flat_map`が導入された経緯・動機・設計について記載されている
 - [P0429R9 A Standard `flat_map`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0429r9.pdf)
     - C++23で導入された`flat_map`の仕様
+- [LWG Issue 3816. `flat_map` and `flat_multimap` should impose sequence container requirements](https://cplusplus.github.io/LWG/issue3816)
+    - C++23で、コンテナ要件が「シーケンスコンテナ要件を満たし、`iterator`がランダムアクセスイテレータ要件を満たし、`size`／`max_size`が例外を投げない型」という形に整理された
 - [P3567R2 flat_meow Fixes](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3567r2.html)
     - C++26で`swap`の条件付き`noexcept`、`insert_range`のソート済みオーバーロード追加などの修正が行われた

--- a/reference/flat_map/flat_multimap.md
+++ b/reference/flat_map/flat_multimap.md
@@ -284,5 +284,7 @@ int main()
     - C++23で`flat_map`が導入された経緯・動機・設計について記載されている
 - [P0429R9 A Standard `flat_map`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0429r9.pdf)
     - C++23で導入された`flat_map`の仕様
+- [LWG Issue 3816. `flat_map` and `flat_multimap` should impose sequence container requirements](https://cplusplus.github.io/LWG/issue3816)
+    - C++23で、コンテナ要件が「シーケンスコンテナ要件を満たし、`iterator`がランダムアクセスイテレータ要件を満たし、`size`／`max_size`が例外を投げない型」という形に整理された
 - [P3567R2 flat_meow Fixes](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3567r2.html)
     - C++26で`swap`の条件付き`noexcept`、`insert_range`のソート済みオーバーロード追加などの修正が行われた

--- a/reference/forward_list/forward_list/emplace_after.md
+++ b/reference/forward_list/forward_list/emplace_after.md
@@ -24,8 +24,12 @@ constexpr iterator
 第1パラメータ`position`で指定された要素の後ろに追加する。
 
 
-## 要件
-第1パラメータ`position`が、[`before_begin()`](before_begin.md)もしくはイテレータ範囲`[`[`begin()`](begin.md)`,` [`end()`](end.md)`)`の間接参照可能なイテレータであること。
+## テンプレートパラメータ制約
+- 型`T`が`std::forward<Args>(args)...`から`forward_list`に対して直接構築可能 (`EmplaceConstructible`) であること。
+
+
+## 事前条件
+- 第1パラメータ`position`が、[`before_begin()`](before_begin.md)もしくはイテレータ範囲`[`[`begin()`](begin.md)`,` [`end()`](end.md)`)`の間接参照可能なイテレータであること。
 
 
 ## 戻り値
@@ -86,4 +90,6 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3817. Missing preconditions on `forward_list` modifiers](https://cplusplus.github.io/LWG/issue3817)
+    - C++23で、要素型`T`が`std::forward<Args>(args)...`から`EmplaceConstructible`であることの事前条件が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/forward_list/forward_list/insert_after.md
+++ b/reference/forward_list/forward_list/insert_after.md
@@ -60,7 +60,13 @@ constexpr iterator
 - (5) : `initializer_list`の全て要素を挿入する
 
 
-## 要件
+## テンプレートパラメータ制約
+- (1), (3) : 型`T`が`forward_list`に対してコピー挿入可能 (`CopyInsertable`) であること。
+- (2) : 型`T`が`forward_list`に対してムーブ挿入可能 (`MoveInsertable`) であること。
+- (4) : 型`T`が`*first`から`forward_list`に対して直接構築可能 (`EmplaceConstructible`) であること。
+
+
+## 事前条件
 - 第1パラメータ`position`が、[`before_begin()`](/reference/forward_list/forward_list/before_begin.md)もしくはイテレータ範囲`[`[`begin()`](begin.md)`,` [`end()`](/reference/forward_list/forward_list/end.md)`)`の間接参照可能なイテレータであること。
 - `first`、`last`は`*this`のイテレータではないこと。
 
@@ -169,5 +175,7 @@ insert initializer_list : 1 2 3 4 5 6
 - [N2679 Initializer Lists for Standard Containers(Revision 1)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2008/n2679.pdf)
     - (5)の経緯となる提案文書
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)
+- [LWG Issue 3817. Missing preconditions on `forward_list` modifiers](https://cplusplus.github.io/LWG/issue3817)
+    - C++23で、各オーバーロードに要素型`T`の挿入可能性（`CopyInsertable`／`MoveInsertable`／`EmplaceConstructible`）に関する事前条件が追加された
 - [LWG Issue 4164. Missing guarantees for `forward_list` modifiers](https://cplusplus.github.io/LWG/issue4164)
     - C++26で、`insert_after`各オーバーロードの計算量の保証が明文化された

--- a/reference/memory.md
+++ b/reference/memory.md
@@ -166,5 +166,7 @@
 - [P1132R8 out_ptr - a scalable output pointer abstraction](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1132r8.html)
 - [P1642R11 Freestanding Library: Easy `[utilities]`, `[ranges]`, and `[iterators]`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1642r11.html)
     - C++23で、このヘッダの多くの機能がフリースタンディング処理系で使用可能になった（`shared_ptr`や`make_unique`などを除く）
+- [LWG Issue 3814. Add freestanding items requested by NB comments](https://cplusplus.github.io/LWG/issue3814)
+    - C++23で、`start_lifetime_as`・`start_lifetime_as_array`がフリースタンディング処理系で使用可能であることが追加で規定された
 - [P2976R1 Freestanding Library: algorithm, numeric, and random](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2976r1.html)
     - C++26で、未初期化メモリアルゴリズムの実行ポリシー版がフリースタンディング処理系で削除されるなど、`<memory>`のフリースタンディング対応が進められた

--- a/reference/ranges.md
+++ b/reference/ranges.md
@@ -488,3 +488,5 @@ range | adaptor(args...)
 - [P2278R4 `cbegin` should always return a constant iterator](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2278r4.html)
 - [P1642R11 Freestanding Library: Easy `[utilities]`, `[ranges]`, and `[iterators]`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1642r11.html)
     - C++23で、このヘッダのほとんどの機能がフリースタンディング処理系で使用可能になった（`istream_view`などを除く）
+- [LWG Issue 3814. Add freestanding items requested by NB comments](https://cplusplus.github.io/LWG/issue3814)
+    - C++23で、`repeat_view`／`views::repeat`・`stride_view`／`views::stride`・`cartesian_product_view`／`views::cartesian_product`がフリースタンディング処理系で使用可能であることが追加で規定された

--- a/reference/ranges/common_view/end.md
+++ b/reference/ranges/common_view/end.md
@@ -22,7 +22,7 @@ constexpr auto end() const
 - (1) :
     ```cpp
     if constexpr (random_access_range<V> && sized_range<V>)
-      return ranges::begin(base_) + ranges::size(base_);
+      return ranges::begin(base_) + ranges::distance(base_);
     else
       return common_iterator<iterator_t<V>, sentinel_t<V>>(ranges::end(base_));
     ```
@@ -30,7 +30,7 @@ constexpr auto end() const
 - (2) :
     ```cpp
     if constexpr (random_access_range<const V> && sized_range<const V>)
-      return ranges::begin(base_) + ranges::size(base_);
+      return ranges::begin(base_) + ranges::distance(base_);
     else
       return common_iterator<iterator_t<const V>, sentinel_t<const V>>(ranges::end(base_));
     ```
@@ -86,5 +86,7 @@ int main() {
 
 ## 参照
 - [N4861 24.7.5.1 Overview](https://timsong-cpp.github.io/cppwp/n4861/range.common.view)
+- [LWG Issue 3717. `common_view::end` should improve `random_access_range` case](https://cplusplus.github.io/LWG/issue3717)
+    - C++23で、`random_access_range`かつ`sized_range`の場合の戻り値が、符号なしを返す`ranges::size`ではなく符号付きの差分型を返す`ranges::distance`を用いる形に修正された
 - [LWG Issue 4012. `common_view::begin`/`end` are missing the *simple-view* check](https://cplusplus.github.io/LWG/issue4012)
     - C++26で、非`const`版に`requires (!simple-view<V>)`制約が追加され、`simple-view`である場合に`const`版と曖昧にならないよう修正された

--- a/reference/ranges/take_view/begin.md
+++ b/reference/ranges/take_view/begin.md
@@ -36,6 +36,16 @@ constexpr auto begin() const
     * range_difference_t[link /reference/ranges/range_difference_t.md]
     * counted_iterator[link /reference/iterator/counted_iterator.md]
 
+入力が[`sized_range`](../sized_range.md)ではないが、[`sized_sentinel_for`](/reference/iterator/sized_sentinel_for.md)`<`[`sentinel_t`](../sentinel_t.md)`<V>,` [`iterator_t`](../iterator_t.md)`<V>>`を満たす場合：
+- (1), (2) : 以下と等価：
+    ```cpp
+    auto it = ranges::begin(base_);
+    auto sz = std::min(count_, ranges::end(base_) - it);
+    return counted_iterator(std::move(it), sz);
+    ```
+    * counted_iterator[link /reference/iterator/counted_iterator.md]
+    * std::min[link /reference/algorithm/min.md]
+
 それ以外の場合：
 - (1), (2) : 以下と等価：
     ```cpp
@@ -81,3 +91,5 @@ int main() {
 
 ## 参照
 - [P2393R1 Cleaning up integer-class types](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2393r1.html)
+- [LWG Issue 3737. `take_view::sentinel` should provide `operator-`](https://cplusplus.github.io/LWG/issue3737)
+    - C++23で、`sized_range`ではないが`sized_sentinel_for<sentinel_t<V>, iterator_t<V>>`を満たす場合の分岐が追加された

--- a/reference/ranges/take_view/end.md
+++ b/reference/ranges/take_view/end.md
@@ -30,6 +30,9 @@ constexpr auto end() const
 入力が[`sized_range`](../sized_range.md)だが[`random_access_range`](../random_access_range.md)ではない場合：
 - (1), (2) : [`default_sentinel`](/reference/iterator/default_sentinel_t.md)を返す。
 
+入力が[`sized_range`](../sized_range.md)ではないが、[`sized_sentinel_for`](/reference/iterator/sized_sentinel_for.md)`<`[`sentinel_t`](../sentinel_t.md)`<V>,` [`iterator_t`](../iterator_t.md)`<V>>`を満たす場合：
+- (1), (2) : [`default_sentinel`](/reference/iterator/default_sentinel_t.md)を返す。
+
 それ以外の場合：
 - (1) : `sentinel<false>{ranges::end(base_)}`を返す。
 - (2) : `sentinel<true>{ranges::end(base_)}`を返す。
@@ -79,3 +82,5 @@ int main() {
 
 ## 参照
 - [P2393R1 Cleaning up integer-class types](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2393r1.html)
+- [LWG Issue 3737. `take_view::sentinel` should provide `operator-`](https://cplusplus.github.io/LWG/issue3737)
+    - C++23で、`sized_range`ではないが`sized_sentinel_for<sentinel_t<V>, iterator_t<V>>`を満たす場合の分岐が追加された

--- a/reference/ranges/view_interface/cbegin.md
+++ b/reference/ranges/view_interface/cbegin.md
@@ -42,3 +42,5 @@ return ranges::cbegin(derived());
 ## 参照
 
 - [P2278R4 `cbegin` should always return a constant iterator](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2278r4.html)
+- [LWG Issue 3766. `view_interface::cbegin` is underconstrained](https://cplusplus.github.io/LWG/issue3766)
+    - C++23で、非`const`版に`input_range<D>`制約が追加され、`const`版の制約が`range<const D>`から`input_range<const D>`に変更された

--- a/reference/ranges/view_interface/cend.md
+++ b/reference/ranges/view_interface/cend.md
@@ -42,3 +42,5 @@ return ranges::cend(derived());
 ## 参照
 
 - [P2278R4 `cbegin` should always return a constant iterator](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2278r4.html)
+- [LWG Issue 3766. `view_interface::cbegin` is underconstrained](https://cplusplus.github.io/LWG/issue3766)
+    - C++23で、非`const`版に`input_range<D>`制約が追加され、`const`版の制約が`range<const D>`から`input_range<const D>`に変更された

--- a/reference/stacktrace/basic_stacktrace/op_ostream.md
+++ b/reference/stacktrace/basic_stacktrace/op_ostream.md
@@ -7,10 +7,8 @@
 
 ```cpp
 namespace std {
-  template <class charT, class traits, class Allocator>
-  basic_ostream<charT, traits>&
-    operator<<(basic_ostream<charT, traits>& os,
-               const basic_stacktrace<Allocator>& st);
+  template <class Allocator>
+  ostream& operator<<(ostream& os, const basic_stacktrace<Allocator>& st);
 }
 ```
 
@@ -66,3 +64,8 @@ int main() {
 - [Clang](/implementation.md#clang): ??
 - [GCC](/implementation.md#gcc): 12 [mark verified]
 - [Visual C++](/implementation.md#visual_cpp): ??
+
+
+## 参照
+- [LWG Issue 3515. `[stacktrace.basic.nonmem]`: `operator<<` should be less templatized](https://cplusplus.github.io/LWG/issue3515)
+    - C++23で、`operator<<`が`charT`/`traits`でテンプレート化された`basic_ostream<charT, traits>`ではなく、非テンプレートの`ostream`を受け取り返すよう変更された

--- a/reference/stacktrace/stacktrace_entry/op_ostream.md
+++ b/reference/stacktrace/stacktrace_entry/op_ostream.md
@@ -7,10 +7,7 @@
 
 ```cpp
 namespace std {
-  template <class charT, class traits>
-  basic_ostream<charT, traits>&
-    operator<<(basic_ostream<charT, traits>& os,
-               const stacktrace_entry& f);
+  ostream& operator<<(ostream& os, const stacktrace_entry& f);
 }
 ```
 
@@ -61,3 +58,8 @@ int main() {
 - [Clang](/implementation.md#clang): ??
 - [GCC](/implementation.md#gcc): 12 [mark verified]
 - [Visual C++](/implementation.md#visual_cpp): ??
+
+
+## 参照
+- [LWG Issue 3515. `[stacktrace.basic.nonmem]`: `operator<<` should be less templatized](https://cplusplus.github.io/LWG/issue3515)
+    - C++23で、`operator<<`が`charT`/`traits`でテンプレート化された`basic_ostream<charT, traits>`ではなく、非テンプレートの`ostream`を受け取り返すよう変更された

--- a/reference/type_traits/is_aggregate.md
+++ b/reference/type_traits/is_aggregate.md
@@ -42,7 +42,7 @@ Point ar[] = { // 配列の初期化子リストで、要素ごとの初期化�
 
 
 ## 要件
-[`remove_all_extents_t`](remove_all_extents.md)`<T>`した結果の型が、完全型であるか、`const/volatile`修飾された (あるいはされていない) `void`でなければならない。
+型`T`が、配列型であるか、完全型であるか、`const/volatile`修飾された (あるいはされていない) `void`でなければならない。
 
 
 ## 効果
@@ -84,3 +84,5 @@ int main()
 
 ## 参照
 - [LWG Issue 2911. An `is_aggregate` type trait is needed](https://wg21.cmeerw.net/lwg/issue2911)
+- [LWG Issue 3823. Unnecessary precondition for `is_aggregate`](https://cplusplus.github.io/LWG/issue3823)
+    - C++23で、事前条件が`remove_all_extents_t<T>`ではなく`T`を主語とする形に整理され、配列型が明示的に許可された（要素が不完全型の配列型に対しても問い合わせできるようになった）


### PR DESCRIPTION
- [P2704R0 C++ Standard Library Immediate Issues to be moved in Kona, Nov. 2022](https://wg21.link/p2704r0)

これに対応しました。