### PR TITLE
C++23のLWG Issue対応第4弾

### DIFF
--- a/lang/cpp20/feature_test_macros.md
+++ b/lang/cpp20/feature_test_macros.md
@@ -58,7 +58,7 @@
 |`__cpp_lib_char8_t`|`201811L`<br/>`201907L`|`char8_t`に対する特殊化の追加|[`<atomic>`](/reference/atomic.md)<br/>[`<filesystem>`](/reference/filesystem.md)<br/>[`<iosfwd>`](/reference/iosfwd.md)<br/>[`<istream>`](/reference/istream.md)<br/>[`<limits>`](/reference/limits.md)<br/>[`<locale>`](/reference/locale.md)<br/>[`<ostream>`](/reference/ostream.md)<br/>[`<string>`](/reference/string.md)<br/>[`<string_view>`](/reference/string_view.md)|
 |`__cpp_lib_chrono`|`201907L`|カレンダーとタイムゾーン|[`<chrono>`](/reference/chrono.md)|
 |`__cpp_lib_concepts`|`202002L`|[`<concepts>`](/reference/concepts.md)の追加|[`<concepts>`](/reference/concepts.md)|
-|`__cpp_lib_constexpr_algorithms`|`201806L`|多くのアルゴリズムに`constexpr`を追加|[`<algorithm>`](/reference/algorithm.md)|
+|`__cpp_lib_constexpr_algorithms`|`201806L`|多くのアルゴリズムに`constexpr`を追加|[`<algorithm>`](/reference/algorithm.md)<br/>[`<utility>`](/reference/utility.md)|
 |`__cpp_lib_constexpr_complex`|`201711L`|[`std::complex`](/reference/complex/complex.md)の`constexpr`対応|[`<complex>`](/reference/complex.md)|
 |`__cpp_lib_constexpr_dynamic_alloc`|`201907L`|[`std::destroy_at`](/reference/memory/destroy_at.md)ファミリと[`std::allocator`](/reference/memory/allocator.md)/[`std::allocator_traits`](/reference/memory/allocator_traits.md)の`constexpr`対応<br/>[`std::construct_at`](/reference/memory/construct_at.md)|[`<memory>`](/reference/memory.md)|
 |`__cpp_lib_constexpr_functional`|`201907L`|[`std::invoke`](/reference/functional/invoke.md)、[`std::reference_wrapper`](/reference/functional/reference_wrapper.md)、[`std::not_fn`](/reference/functional/not_fn.md)、[`std::bind_front`](/reference/functional/bind_front.md)、[`std::bind`](/reference/functional/bind.md)、[`std::mem_fn`](/reference/functional/mem_fn.md)の`constexpr`対応|[`<functional>`](/reference/functional.md)|
@@ -110,5 +110,7 @@
 ## 参照
 
 - [SD-FeatureTest: Feature-Test Macros and Policies - isocpp](https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations)
+- [LWG Issue 3792. `__cpp_lib_constexpr_algorithms` should also be defined in `<utility>`](https://cplusplus.github.io/LWG/issue3792)
+    - C++23で、`__cpp_lib_constexpr_algorithms`の定義ヘッダに[`<utility>`](/reference/utility.md)が追加された（値`201806L`は不変。C++20へ遡及適用される）
 - [LWG Issue 4440. Forward declarations of entities need also in entries](https://cplusplus.github.io/LWG/issue4440)
     - C++26で、`__cpp_lib_char8_t`と`__cpp_lib_syncbuf`の定義ヘッダに[`<iosfwd>`](/reference/iosfwd.md)が追加された（`<iosfwd>`が関連エンティティの先行宣言を含むため）

--- a/lang/cpp23/feature_test_macros.md
+++ b/lang/cpp23/feature_test_macros.md
@@ -102,5 +102,9 @@
 ## 参照
 
 - [SD-FeatureTest: Feature-Test Macros and Policies - isocpp](https://isocpp.org/std/standing-documents/sd-6-sg10-feature-test-recommendations)
+- [LWG Issue 3750. Too many papers bump `__cpp_lib_format`](https://cplusplus.github.io/LWG/issue3750)
+    - C++23で、フォーマットRange系（P2286/P2585）用に`__cpp_lib_format_ranges`（値`202207L`）が追加され、`__cpp_lib_format`とマクロが分離された
+- [LWG Issue 3751. Missing feature macro for `flat_set`](https://cplusplus.github.io/LWG/issue3751)
+    - C++23で、`flat_set`/`flat_multiset`用の機能テストマクロ`__cpp_lib_flat_set`（値`202207L`）が追加された
 - [LWG Issue 4440. Forward declarations of entities need also in entries](https://cplusplus.github.io/LWG/issue4440)
     - C++26で、`__cpp_lib_spanstream`の定義ヘッダに[`<iosfwd>`](/reference/iosfwd.md)が追加された（`<iosfwd>`が`<spanstream>`のエンティティの先行宣言を含むため）

--- a/reference/algorithm/ranges_rotate_copy.md
+++ b/reference/algorithm/ranges_rotate_copy.md
@@ -169,5 +169,7 @@ int main() {
 - [N4861 25 Algorithms library](https://timsong-cpp.github.io/cppwp/n4861/algorithms)
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
 - [P3709R2 Reconsider parallel `ranges::rotate_copy` and `ranges::reverse_copy`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3709r2.html)
+- [LWG Issue 3759. `ranges::rotate_copy` should use `std::move`](https://cplusplus.github.io/LWG/issue3759)
+    - C++23で、範囲版がイテレータ版へ`result`を渡す際、`result`が`weakly_incrementable`のみでコピー不可の可能性があるため`std::move(result)`で渡すよう修正された
 - [LWG Issue 4441. `ranges::rotate` do not handle sized-but-not-sized-sentinel ranges correctly](https://cplusplus.github.io/LWG/issue4441)
     - C++26で、実行ポリシーをとる範囲版の効果を規定する等価コードで、末尾イテレータの算出が`ranges::end(r)`から`ranges::begin(r) + ranges::distance(r)`へ変更された。サイズは判るがsized sentinelを持たない範囲を正しく扱うため

--- a/reference/atomic/atomic_notify_all.md
+++ b/reference/atomic/atomic_notify_all.md
@@ -8,14 +8,14 @@
 namespace std {
   template <class T>
   void
-    atomic_notify_all(volatile atomic<T>* object); // (1) C++20
+    atomic_notify_all(volatile atomic<T>* object) noexcept; // (1) C++20
 
   template <class T>
   void
-    atomic_notify_all(atomic<T>* object);          // (2) C++20
+    atomic_notify_all(atomic<T>* object) noexcept;          // (2) C++20
   template <class T>
   constexpr void
-    atomic_notify_all(atomic<T>* object);          // (2) C++26
+    atomic_notify_all(atomic<T>* object) noexcept;          // (2) C++26
 }
 ```
 
@@ -102,3 +102,5 @@ int main()
     - C++20での、`volatile`版への制約追加
 - [P3309R3 `constexpr atomic` and `atomic_ref`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3309r3.html)
     - C++26で`constexpr`に対応した
+- [LWG Issue 3745. `std::atomic_wait` and its friends lack `noexcept`](https://cplusplus.github.io/LWG/issue3745)
+    - C++23で、対応するメンバ関数や他の`atomic_*`フリー関数と一貫させるため、`noexcept`が付加された

--- a/reference/atomic/atomic_notify_one.md
+++ b/reference/atomic/atomic_notify_one.md
@@ -8,14 +8,14 @@
 namespace std {
   template <class T>
   void
-    atomic_notify_one(volatile atomic<T>* object); // (1) C++20
+    atomic_notify_one(volatile atomic<T>* object) noexcept; // (1) C++20
 
   template <class T>
   void
-    atomic_notify_one(atomic<T>* object);          // (2) C++20
+    atomic_notify_one(atomic<T>* object) noexcept;          // (2) C++20
   template <class T>
   constexpr void
-    atomic_notify_one(atomic<T>* object);          // (2) C++26
+    atomic_notify_one(atomic<T>* object) noexcept;          // (2) C++26
 }
 ```
 
@@ -128,3 +128,5 @@ int main()
     - C++20での、`volatile`版への制約追加
 - [P3309R3 `constexpr atomic` and `atomic_ref`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3309r3.html)
     - C++26で`constexpr`に対応した
+- [LWG Issue 3745. `std::atomic_wait` and its friends lack `noexcept`](https://cplusplus.github.io/LWG/issue3745)
+    - C++23で、対応するメンバ関数や他の`atomic_*`フリー関数と一貫させるため、`noexcept`が付加された

--- a/reference/atomic/atomic_wait.md
+++ b/reference/atomic/atomic_wait.md
@@ -9,16 +9,16 @@ namespace std {
   template<class T>
   void
     atomic_wait(const volatile atomic<T>* object,
-                typename atomic<T>::value_type old); // (1) C++20
+                typename atomic<T>::value_type old) noexcept; // (1) C++20
 
   template<class T>
   void
     atomic_wait(const atomic<T>* object,
-                typename atomic<T>::value_type old); // (2) C++20
+                typename atomic<T>::value_type old) noexcept; // (2) C++20
   template<class T>
   constexpr void
     atomic_wait(const atomic<T>* object,
-                typename atomic<T>::value_type old); // (2) C++26
+                typename atomic<T>::value_type old) noexcept; // (2) C++26
 }
 ```
 
@@ -140,3 +140,5 @@ int main()
     - C++20での、`volatile`版への制約追加
 - [P3309R3 `constexpr atomic` and `atomic_ref`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3309r3.html)
     - C++26で`constexpr`に対応した
+- [LWG Issue 3745. `std::atomic_wait` and its friends lack `noexcept`](https://cplusplus.github.io/LWG/issue3745)
+    - C++23で、対応するメンバ関数や他の`atomic_*`フリー関数と一貫させるため、`noexcept`が付加された

--- a/reference/atomic/atomic_wait_explicit.md
+++ b/reference/atomic/atomic_wait_explicit.md
@@ -10,18 +10,18 @@ namespace std {
   void
     atomic_wait_explicit(const volatile atomic<T>* object,
                 typename atomic<T>::value_type old,
-                memory_order order);                 // (1) C++20
+                memory_order order) noexcept;                 // (1) C++20
 
   template<class T>
   void
     atomic_wait_explicit(const atomic<T>* object,
                 typename atomic<T>::value_type old,
-                memory_order order);                 // (2) C++20
+                memory_order order) noexcept;                 // (2) C++20
   template<class T>
   constexpr void
     atomic_wait_explicit(const atomic<T>* object,
                 typename atomic<T>::value_type old,
-                memory_order order);                 // (2) C++26
+                memory_order order) noexcept;                 // (2) C++26
 }
 ```
 
@@ -151,3 +151,5 @@ int main()
     - C++20での、`volatile`版への制約追加
 - [P3309R3 `constexpr atomic` and `atomic_ref`](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3309r3.html)
     - C++26で`constexpr`に対応した
+- [LWG Issue 3745. `std::atomic_wait` and its friends lack `noexcept`](https://cplusplus.github.io/LWG/issue3745)
+    - C++23で、対応するメンバ関数や他の`atomic_*`フリー関数と一貫させるため、`noexcept`が付加された

--- a/reference/chrono/zoned_time/formatter/format.md
+++ b/reference/chrono/zoned_time/formatter/format.md
@@ -9,7 +9,7 @@
 template <class FormatContext>
 typename FormatContext::iterator
 format(const chrono::zoned_time<Duration, TimeZonePtr>& tp,
-       FormatContext& ctx);                                 // (1) C++20
+       FormatContext& ctx) const;                           // (1) C++20
 ```
 
 ## 概要
@@ -45,3 +45,8 @@ return formatter<chrono::local-time-format-t<Duration>, charT>::format(
 - [Clang](/implementation.md#clang): 9.0 [mark noimpl]
 - [GCC](/implementation.md#gcc): 9.2 [mark noimpl]
 - [Visual C++](/implementation.md#visual_cpp): 2019 Update 3 [mark noimpl]
+
+
+## 参照
+- [LWG Issue 3636. `formatter<T>::format` should be `const`-qualified](https://cplusplus.github.io/LWG/issue3636)
+    - C++23で、`formatter`の`format`メンバ関数が`const`修飾された

--- a/reference/flat_set.md
+++ b/reference/flat_set.md
@@ -34,3 +34,5 @@
     - C++23で`flat_set`が導入された経緯・動機・設計について記載されている
 - [P1222R4 A Standard `flat_set`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p1222r4.pdf)
     - C++23で導入された`flat_set`の仕様
+- [LWG Issue 3774. `<flat_set>` should include `<compare>`](https://cplusplus.github.io/LWG/issue3774)
+    - C++23で、`flat_set`/`flat_multiset`が`operator<=>`を持つため、`<flat_set>`が`<compare>`をインクルードすることが規定された

--- a/reference/functional/reference_wrapper/op_call.md
+++ b/reference/functional/reference_wrapper/op_call.md
@@ -13,8 +13,11 @@ template <class... ArgTypes>
 invoke_result_t<T&, ArgTypes...> operator ()(ArgTypes&&... args) const;            //C++17
 
 template <class... ArgTypes>
-constexpr invoke_result_t<T&, ArgTypes...> operator ()(ArgTypes&&... args) const;  //C++20
+constexpr invoke_result_t<T&, ArgTypes...>
+  operator ()(ArgTypes&&... args) const
+    noexcept(is_nothrow_invocable_v<T&, ArgTypes...>);                             //C++20
 ```
+* is_nothrow_invocable_v[link /reference/type_traits/is_nothrow_invocable.md]
 
 ## 概要
 保持している参照に対して関数呼び出しを行う
@@ -77,3 +80,5 @@ int main()
 ## 参照
 - [P0357R3 reference_wrapper for incomplete types](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0357r3.html)
     - テンプレートパラメータ`T`が完全型であるという要件が追加された経緯
+- [LWG Issue 3764. `reference_wrapper::operator()` should propagate `noexcept`](https://cplusplus.github.io/LWG/issue3764)
+    - C++23で、`operator()`に`noexcept(is_nothrow_invocable_v<T&, ArgTypes...>)`が付加され、被参照の呼び出し可能物の`noexcept`性が伝播するようになった

--- a/reference/future/future/op_assign.md
+++ b/reference/future/future/op_assign.md
@@ -16,7 +16,7 @@ future& operator=(future&& rhs) noexcept;      // (2)
 
 
 ## 効果
-- (2) : 共有状態を解放し、`rhs`の共有状態を含むコンテンツを`*this`にムーブ代入する。
+- (2) : [`addressof`](/reference/memory/addressof.md)`(rhs) == this`（自己代入）の場合、効果はない。それ以外の場合、共有状態を解放し、`rhs`の共有状態を含むコンテンツを`*this`にムーブ代入する。
 
 
 ## 戻り値
@@ -24,7 +24,7 @@ future& operator=(future&& rhs) noexcept;      // (2)
 
 
 ## 事後条件
-- (2) : [`valid()`](valid.md)の戻り値が、この関数を呼び出す前の`rhs.`[`valid()`](valid.md)と等価になること。`rhs.`[`valid()`](valid.md) `== false`になること。
+- (2) : [`valid()`](valid.md)の戻り値が、この関数を呼び出す前の`rhs.`[`valid()`](valid.md)と等価になること。[`addressof`](/reference/memory/addressof.md)`(rhs) != this`（自己代入でない）の場合、`rhs.`[`valid()`](valid.md) `== false`になること。
 
 
 ## 例外
@@ -61,3 +61,5 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3795. Self-move-assignment of `std::future` and `std::shared_future` have unimplementable postconditions](https://cplusplus.github.io/LWG/issue3795)
+    - C++23で、自己代入(`addressof(rhs) == this`)の場合は効果がないことが効果に明記され、事後条件の`rhs.valid() == false`が「自己代入でない場合」に条件付けられた

--- a/reference/future/shared_future/op_assign.md
+++ b/reference/future/shared_future/op_assign.md
@@ -16,12 +16,13 @@ shared_future& operator=(shared_future&& rhs) noexcept; // (2)
 
 
 ## 効果
-- (1) : 共有状態を解放し、`rhs`の共有状態を含むコンテンツを`*this`にコピー代入する。`rhs`と`*this`が同じ共有状態を参照するようになる。
+- (1) : [`addressof`](/reference/memory/addressof.md)`(rhs) == this`（自己代入）の場合、効果はない。それ以外の場合、共有状態を解放し、`rhs`の共有状態を含むコンテンツを`*this`にコピー代入する。`rhs`と`*this`が同じ共有状態を参照するようになる。
+- (2) : [`addressof`](/reference/memory/addressof.md)`(rhs) == this`（自己代入）の場合、効果はない。それ以外の場合、共有状態を解放し、`rhs`の共有状態を含むコンテンツを`*this`にムーブ代入する。
 
 
 ## 事後条件
 - (1) : `valid() == rhs.valid()`
-- (2) : `valid()`の戻り値が、この関数を呼び出す前の`rhs.valid()`と等価になること。`rhs.valid() == false`になること。
+- (2) : `valid()`の戻り値が、この関数を呼び出す前の`rhs.valid()`と等価になること。[`addressof`](/reference/memory/addressof.md)`(rhs) != this`（自己代入でない）の場合、`rhs.valid() == false`になること。
 
 
 ## 例外
@@ -96,3 +97,5 @@ int main()
 
 
 ## 参照
+- [LWG Issue 3795. Self-move-assignment of `std::future` and `std::shared_future` have unimplementable postconditions](https://cplusplus.github.io/LWG/issue3795)
+    - C++23で、自己代入(`addressof(rhs) == this`)の場合は効果がないことが効果に明記され、(2)の事後条件の`rhs.valid() == false`が「自己代入でない場合」に条件付けられた

--- a/reference/generator/generator/iterator/op_equal.md
+++ b/reference/generator/generator/iterator/op_equal.md
@@ -38,3 +38,8 @@ return i.coroutine_.done();
 
 ## 関連項目
 - [`generator::end()`](../end.md)
+
+
+## 参照
+- [LWG Issue 3762. `generator::iterator::operator==` should pass by reference](https://cplusplus.github.io/LWG/issue3762)
+    - C++23で、`operator==`のイテレータ引数がコピー渡しから`const iterator&`（参照渡し）に変更された

--- a/reference/ios/fpos.md
+++ b/reference/ios/fpos.md
@@ -43,8 +43,8 @@ using u32streampos = fpos<char_traits<char32_t>::state_type>;
 | `P p = i;`      | 〃                                         | 〃                             |
 | `P(o)`          | オフセットからの（一時）オブジェクトの生成 |                                |
 | `O(p)`          | オフセットへの変換                         | `P(O(p)) == p`                 |
-| `p == q`        | 比較                                       | 結果の型はboolに変換可能である |
-| `p != q`        | 〃                                         | 〃                             |
+| `p == q`        | 比較                                       | C++03 : 結果の型は`bool`に変換可能である<br/>C++23 : 戻り値の型は`bool`。`p`, `q`をそれぞれ値`o`, `o2`から得たとき、`o == o2`のとき、かつそのときに限り`true` |
+| `p != q`        | 〃                                         | C++03 : 結果の型は`bool`に変換可能である<br/>C++23 : 戻り値の型は`bool`。`!(p == q)` |
 | `q = p + o`     | 正値のオフセット                           | `q - o == p`                   |
 | `p += o`        | 〃                                         | 〃                             |
 | `q = p - o`     |                                            | `q + o == p`                   |
@@ -64,3 +64,8 @@ using u32streampos = fpos<char_traits<char32_t>::state_type>;
 
 - 戻り値としてこの値が返されれば、操作の失敗を表す。
 - 引数としてこの値が渡された場合、未定義動作を引き起こす。
+
+
+## 参照
+- [LWG Issue 3118. `fpos` equality comparison unspecified](https://cplusplus.github.io/LWG/issue3118)
+    - C++23で、`operator==`/`operator!=`の戻り値の型が「boolに変換可能」から`bool`に修正され、等値比較の意味論（同じオフセット値から得た`fpos`のとき、かつそのときに限り等しい）が規定された

--- a/reference/iterator/const_sentinel.md
+++ b/reference/iterator/const_sentinel.md
@@ -59,3 +59,5 @@ int main() {
 ## 参照
 
 - [P2278R4 `cbegin` should always return a constant iterator](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2278r4.html)
+- [LWG Issue 3765. `const_sentinel` should be constrained](https://cplusplus.github.io/LWG/issue3765)
+    - C++23で、テンプレートパラメータ制約が無制約の`class S`から`semiregular S`に強化された

--- a/reference/iterator/disable_sized_sentinel_for.md
+++ b/reference/iterator/disable_sized_sentinel_for.md
@@ -14,8 +14,15 @@ namespace std {
     requires (!sized_sentinel_for<Iterator1, Iterator2>)
   inline constexpr bool disable_sized_sentinel_for<reverse_iterator<Iterator1>,
                                                    reverse_iterator<Iterator2>> = true;
+
+  // move_iteratorに対する特殊化 (C++23)
+  template<class Iterator1, class Iterator2>
+    requires (!sized_sentinel_for<Iterator1, Iterator2>)
+  inline constexpr bool disable_sized_sentinel_for<move_iterator<Iterator1>,
+                                                   move_iterator<Iterator2>> = true;
 }
 ```
+* move_iterator[link move_iterator.md]
 * sized_sentinel_for[link /reference/iterator/sized_sentinel_for.md]
 * reverse_iterator[link /reference/iterator/reverse_iterator.md]
 
@@ -53,3 +60,5 @@ namespace std {
 - [P1871R0 Should concepts be enabled or disabled?](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1871r0.html)
 - [P1871R1 Concept traits should be named after concepts](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1871r1.html)
 - [microsoft/STL P1871R1 disable_sized_sentinel_for #607 - Github](https://github.com/microsoft/STL/pull/607/files#r392700693)
+- [LWG Issue 3736. `move_iterator` missing `disable_sized_sentinel_for` specialization](https://cplusplus.github.io/LWG/issue3736)
+    - C++23で、`move_iterator`に対する`disable_sized_sentinel_for`の特殊化が追加され、`move_iterator`が意味論的に`sized_sentinel_for`を満たさない場合に誤ってそれを満たすと判定される問題が解消された

--- a/reference/iterator/istream_iterator/op_constructor.md
+++ b/reference/iterator/istream_iterator/op_constructor.md
@@ -14,13 +14,25 @@ istream_iterator(istream_type& s);                     // (3)
 
 istream_iterator(const istream_iterator& x);           // (4) C++03
 istream_iterator(const istream_iterator& x) = default; // (4) C++11
+constexpr istream_iterator(const istream_iterator& x)
+  noexcept(see below);                                 // (4) C++23
 ```
+* see below[italic]
 
 ## 概要
 - (1) : デフォルトコンストラクタ。メンバ変数として保持する入力ストリームへのポインタをヌル初期化する。デフォルトコンストラクタで構築された`istream_iterator`オブジェクトは、イテレータの終端値として使用できる。
 - (2) : [`default_sentinel`](/reference/iterator/default_sentinel_t.md)を受け取り、(1)と同等の構築をより明示的に行う。
 - (3) : 入力ストリームオブジェクトへの参照を受け取り、メンバ変数にそのオブジェクトへのポインタを保持する。`operator*()`で現在参照している値を返すために、この段階で入力ストリームから値を読み取り、メンバ変数に値を保持する。
 - (4) : コピーコンストラクタ
+
+
+## 例外
+- (4) :
+    - C++23 : `noexcept(see below)`の例外指定は、[`is_nothrow_copy_constructible_v`](/reference/type_traits/is_nothrow_copy_constructible.md)`<T>`と等価である。
+
+
+## 備考
+- (4) : C++23では、メンバ変数（入力ストリームへのポインタと保持値）をコピー初期化する明示的な定義に変更された。値型`T`がトリビアルにコピー構築可能であってもコピーコンストラクタはトリビアルにならない（ABI互換性のための変更）。
 
 
 ## 例
@@ -56,3 +68,5 @@ int main()
 
 ## 参照
 - [LWG Issue 2576. `istream_iterator` and `ostream_iterator` should use `std::addressof`](https://wg21.cmeerw.net/lwg/issue2576)
+- [LWG Issue 3600. Making `istream_iterator` copy constructor trivial is an ABI break](https://cplusplus.github.io/LWG/issue3600)
+    - C++23で、コピーコンストラクタが`= default`から明示的に定義された非トリビアルなコンストラクタ（`constexpr`・`noexcept`指定付き）に変更された。既存実装とのABI互換性を保つため、トリビアル化が見送られた

--- a/reference/iterator/make_const_sentinel.md
+++ b/reference/iterator/make_const_sentinel.md
@@ -68,3 +68,5 @@ int main() {
 ## 参照
 
 - [P2278R4 `cbegin` should always return a constant iterator](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2278r4.html)
+- [LWG Issue 3765. `const_sentinel` should be constrained](https://cplusplus.github.io/LWG/issue3765)
+    - C++23で、テンプレートパラメータ制約が無制約の`class S`から`semiregular S`に強化された

--- a/reference/memory/inout_ptr_t/op_destructor.md
+++ b/reference/memory/inout_ptr_t/op_destructor.md
@@ -42,9 +42,9 @@ constexpr ~inout_ptr_t(); // (1) C++26
 - 式 `s.reset(static_cast<SP>(p),` [`std::forward`](/reference/utility/forward.md)`<Args>(args)...)` が適格ならば、
 
     ```cpp
+    release-statement;
     if (p) {
       apply([&](auto&&... args) {
-        release-statement;
         s.reset(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
     }
     ```
@@ -53,9 +53,9 @@ constexpr ~inout_ptr_t(); // (1) C++26
 - [`is_constructible_v`](/reference/type_traits/is_constructible.md)`<Smart, SP, Args...>`が`true`ならば、
 
     ```cpp
+    release-statement;
     if (p) {
       apply([&](auto&&... args) {
-        release-statement;
         s = Smart(static_cast<SP>(p), std::forward<Args>(args)...); }, std::move(a));
     }
     ```
@@ -84,5 +84,7 @@ constexpr ~inout_ptr_t(); // (1) C++26
 
 ## 参照
 - [P1132R8 out_ptr - a scalable output pointer abstraction](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1132r8.html)
+- [LWG Issue 3594. `inout_ptr` — inconsistent `release()` in destructor](https://cplusplus.github.io/LWG/issue3594)
+    - C++23で、`release-statement`が`if (p)`ブロックの内側から外側へ移され、取得ポインタ`p`がヌルの場合でも`release()`が呼ばれるよう修正された
 - [LWG Issue 3897. `inout_ptr` will not update raw pointer to 0](https://cplusplus.github.io/LWG/issue3897)
 - [P3037R6 `constexpr std::shared_ptr` and friends](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3037r6.pdf)

--- a/reference/memory/pointer_traits.md
+++ b/reference/memory/pointer_traits.md
@@ -30,7 +30,7 @@ namespace std {
 | 名前 | 説明 | 対応バージョン |
 |----------------|----------------------------------------------|-------|
 | `pointer`      | ポインタと見なせる型 `Ptr` | C++11 |
-| `element_type` | ポインタが指す要素型。<br/> 型`Ptr`が`element_type`型を持っていればそれを使用する。型`Ptr`が要素型`T`と0個以上の他のパラメータをとるクラステンプレートであれば`T`を使用する。そうでなければ不適格となる。 | C++11 |
+| `element_type` | ポインタが指す要素型。<br/> 型`Ptr`が`element_type`型を持っていればそれを使用する。型`Ptr`が要素型`T`と0個以上の他のパラメータをとるクラステンプレートであれば`T`を使用する。どちらでもなく要素型を決定できない場合、<br/>・C++11 : 不適格となる<br/>・C++23 : `pointer_traits<Ptr>`はメンバを一切持たない (SFINAEフレンドリ) | C++11 |
 | `difference_type` | ポインタの差を表す符号付き整数型。<br/> 型`Ptr`が`difference_type`型を持っていればそれを使用し、そうでなければ[`ptrdiff_t`](/reference/cstddef/ptrdiff_t.md)型を使用する。 | C++11 |
 | `rebind<U>`    | 型の再束縛。<br/> 型`Ptr`が`rebind<U>`を持っていればそれを使用する。型`Ptr`が型`T`と0個以上の他のパラメータをとるクラステンプレートであれば、型`U`で再束縛した`Ptr`型を使用する。どちらもなければ、`rebind<U>`のインスタンス化は不適格となる。 | C++11 |
 
@@ -81,3 +81,5 @@ int main()
 ## 参照
 - [N2982 Allocators post Removal of C++ Concepts (Rev 1)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2009/n2982.pdf)
 - [Why `pointer_traits` was introduced in C++11 - Doug Judd's Blog](https://web.archive.org/web/20190228022724/http://blog.nuggetwheat.org/index.php/2015/09/01/why-pointer_traits-was-introduced-in-c11/)
+- [LWG Issue 3545. `std::pointer_traits` should be SFINAE-friendly](https://cplusplus.github.io/LWG/issue3545)
+    - C++23で、要素型を決定できない`Ptr`に対して`pointer_traits<Ptr>`が不適格となるのではなく、メンバを一切持たない（SFINAEで除外される）よう変更された

--- a/reference/memory/ranges_destroy_n.md
+++ b/reference/memory/ranges_destroy_n.md
@@ -40,10 +40,11 @@ namespace std::ranges {
 以下と等価：
 
 ```cpp
-return destroy(counted_iterator(first, n), default_sentinel).base();
+return destroy(counted_iterator(std::move(first), n), default_sentinel).base();
 ```
 * destroy[link ranges_destroy.md]
 * counted_iterator[link /reference/iterator/counted_iterator.md]
+* std::move[link /reference/utility/move.md]
 * base()[link /reference/iterator/counted_iterator/base.md]
 
 
@@ -136,5 +137,7 @@ done
 ## 参照
 - [P0896R4 The One Ranges Proposal](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0896r4.pdf)
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 3747. `ranges::uninitialized_copy_n`, `ranges::uninitialized_move_n`, and `ranges::destroy_n` should use `std::move`](https://cplusplus.github.io/LWG/issue3747)
+    - C++23で、入力イテレータが`input_iterator`（コピー可能とは限らない）であるため、`counted_iterator`へ渡す際に`std::move`するよう効果が修正された
 - [LWG Issue 4431. Parallel `std::ranges::destroy` should allow exceptions](https://cplusplus.github.io/LWG/issue4431)
     - C++26で、実行ポリシーをとる並列オーバーロードから`noexcept`が除去された。並列アルゴリズムの処理系定義の実行ポリシーがどの例外を送出しうるかは、その実行ポリシーに委ねられるため

--- a/reference/memory/ranges_uninitialized_copy_n.md
+++ b/reference/memory/ranges_uninitialized_copy_n.md
@@ -79,7 +79,7 @@ namespace std::ranges {
 以下と等価である：
 
 ```cpp
-auto t = uninitialized_copy(counted_iterator(ifirst, n),
+auto t = uninitialized_copy(counted_iterator(std::move(ifirst), n),
                             default_sentinel, ofirst, olast);
 return {std::move(t.in).base(), t.out};
 ```
@@ -192,3 +192,5 @@ int main() {
 - [P3508R0 Wording for "constexpr for specialized memory algorithms"](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3508r0.html)
     - C++26から`constexpr`がついた
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 3747. `ranges::uninitialized_copy_n`, `ranges::uninitialized_move_n`, and `ranges::destroy_n` should use `std::move`](https://cplusplus.github.io/LWG/issue3747)
+    - C++23で、入力イテレータが`input_iterator`（コピー可能とは限らない）であるため、`counted_iterator`へ渡す際に`std::move`するよう効果が修正された

--- a/reference/memory/ranges_uninitialized_move_n.md
+++ b/reference/memory/ranges_uninitialized_move_n.md
@@ -78,7 +78,7 @@ namespace std::ranges {
 以下と等価である：
 
 ```cpp
-auto t = uninitialized_move(counted_iterator(ifirst, n),
+auto t = uninitialized_move(counted_iterator(std::move(ifirst), n),
                             default_sentinel, ofirst, olast);
 return {std::move(t.in).base(), t.out};
 ```
@@ -193,3 +193,5 @@ hello world test
 - [P3508R0 Wording for "constexpr for specialized memory algorithms"](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3508r0.html)
     - C++26から`constexpr`がついた
 - [P3179R9 C++ parallel range algorithms](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3179r9.html)
+- [LWG Issue 3747. `ranges::uninitialized_copy_n`, `ranges::uninitialized_move_n`, and `ranges::destroy_n` should use `std::move`](https://cplusplus.github.io/LWG/issue3747)
+    - C++23で、入力イテレータが`input_iterator`（コピー可能とは限らない）であるため、`counted_iterator`へ渡す際に`std::move`するよう効果が修正された

--- a/reference/optional/optional/op_compare_3way.md
+++ b/reference/optional/optional/op_compare_3way.md
@@ -30,7 +30,7 @@ namespace std {
 
 
 ## テンプレートパラメータ制約
-- (3) : 比較する相手の型`U`が`optional`の特殊化でないこと
+- (3) : 比較する相手の型`U`が`optional`の特殊化、またはそれから公開かつ非曖昧に派生した型でないこと
 
 
 ## 戻り値
@@ -124,5 +124,5 @@ int main()
 ## 参照
 - [P1614R2 The Mothership has Landed](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1614r2.html)
     - C++20での三方比較演算子の追加と、関連する演算子の自動導出
-- [LWG Issue 4072. `std::optional` comparisons: constrain harder](https://cplusplus.github.io/LWG/issue4072)
-    - C++26で、(3)の制約に、相手の型が`optional`の特殊化でないことが追加された
+- [LWG Issue 3746. `optional`'s spaceship with `U` with a type derived from `optional` causes infinite constraint recursion](https://cplusplus.github.io/LWG/issue3746)
+    - C++23で、(3)の制約が説明専用の`is-optional`から`is-derived-from-optional`に変更され、`U`が`optional`の特殊化から派生した型の場合も候補から除外することで、制約チェックの無限再帰を防ぐようになった

--- a/reference/ranges/cartesian_product_view/begin.md
+++ b/reference/ranges/cartesian_product_view/begin.md
@@ -63,3 +63,5 @@ first element: (1, 'a')
 
 ## 参照
 - [N4950 26.7.33 Cartesian product view](https://timsong-cpp.github.io/cppwp/n4950/range.cartesian)
+- [LWG Issue 3760. `cartesian_product_view::iterator`'s `parent_` is never valid](https://cplusplus.github.io/LWG/issue3760)
+    - C++23で、`begin`/`end`が`iterator`を構築する際に`*this`（親ビュー）を渡すよう修正され、`iterator`の`parent_`が常に無効であった問題が解消された

--- a/reference/ranges/cartesian_product_view/end.md
+++ b/reference/ranges/cartesian_product_view/end.md
@@ -81,3 +81,5 @@ int main() {
 
 ## 参照
 - [N4950 26.7.33 Cartesian product view](https://timsong-cpp.github.io/cppwp/n4950/range.cartesian)
+- [LWG Issue 3760. `cartesian_product_view::iterator`'s `parent_` is never valid](https://cplusplus.github.io/LWG/issue3760)
+    - C++23で、`begin`/`end`が`iterator`を構築する際に`*this`（親ビュー）を渡すよう修正され、`iterator`の`parent_`が常に無効であった問題が解消された

--- a/reference/ranges/iota_view/op_constructor.md
+++ b/reference/ranges/iota_view/op_constructor.md
@@ -35,7 +35,7 @@ constexpr iota_view(iterator first, sentinel last);
 
 `e`が`b`から到達できるとは、`b`をn回インクリメントしたとき、`e == b`が真となるようなnが存在することをいう。
 
-- (2): `Bound`は[`unreachable_sentinel_t`](/reference/iterator/unreachable_sentinel_t.md)である。または、`Bound()`は`value`から到達できる
+- (2): `Bound`は[`unreachable_sentinel_t`](/reference/iterator/unreachable_sentinel_t.md)である。または、`Bound()`は`value`から到達できる。[`totally_ordered_with`](/reference/concepts/totally_ordered.md)`<W, Bound>`ならば、`bool(value <= Bound())`が`true`である
 - (3): `Bound`は[`unreachable_sentinel_t`](/reference/iterator/unreachable_sentinel_t.md)である。または、`bound`は`value`から到達できる。[`totally_ordered_with`](/reference/concepts/totally_ordered.md)`<W, Bound>`ならば、`bool(value <= bound)`が`true`である
 
 ## 効果
@@ -81,3 +81,5 @@ int main()
 ## 参照
 - [N4861 24 Ranges library](https://timsong-cpp.github.io/cppwp/n4861/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
+- [LWG Issue 3597. Unsigned integer types don't model `advanceable`](https://cplusplus.github.io/LWG/issue3597)
+    - C++23で、1引数コンストラクタ(2)の事前条件に、2引数版と同様の`totally_ordered_with<W, Bound>`ならば`bool(value <= Bound())`が`true`という条件が追加された（符号なし整数のラップアラウンドで到達不能になる問題への対処）

--- a/reference/ranges/take_view/op_constructor.md
+++ b/reference/ranges/take_view/op_constructor.md
@@ -20,6 +20,10 @@ constexpr explicit
 - (1) : デフォルト構築
 - (2) : 元となるviewと取得する要素数を指定して構築
 
+## 事前条件
+- (2) : `count >= 0`であること。
+
+
 ## 効果
 
 - (1) : `base_`と`count_`をデフォルト構築する
@@ -61,3 +65,5 @@ int main() {
 ## 参照
 - [N4861 24.7.10 Take view](https://timsong-cpp.github.io/cppwp/n4861/range.take)
 - [N4950 26.7.14 Take view](https://timsong-cpp.github.io/cppwp/n4950/range.take)
+- [LWG Issue 3738. Missing preconditions for `take_view` constructor](https://cplusplus.github.io/LWG/issue3738)
+    - C++23で、(2)のコンストラクタに事前条件`count >= 0`が追加された（`counted_iterator`の事前条件と一貫させ、`drop_view`と揃えるため）

--- a/reference/ranges/to.md
+++ b/reference/ranges/to.md
@@ -234,6 +234,10 @@ int main() {
     - C++26で要素数の事前確保に[`ranges::size`](size.md)の代わりに[`ranges::reserve_hint`](reserve_hint.md)を使用するよう変更
 - [LWG Issue 3733. `ranges::to` misuses *cpp17-input-iterator*](https://cplusplus.github.io/LWG/issue3733)
     - C++23で、Cpp17InputIterator判定に説明専用コンセプト`cpp17-input-iterator`を使用するのをやめ、`iterator_traits<iterator_t<R>>::iterator_category`が`input_iterator_tag`から派生する有効な型であることを判定するよう修正された（[`common_iterator`](/reference/iterator/common_iterator.md)のように`iterator_traits`の特殊化を持つイテレータで正しく判定されるようにするため）
+- [LWG Issue 3743. `ranges::to`'s `reserve` may be ill-formed](https://cplusplus.github.io/LWG/issue3743)
+    - C++23で、`reserve`に渡す値を`static_cast<range_size_t<C>>(ranges::size(r))`と明示キャストするよう修正され、整数クラス型を返す`ranges::size`が暗黙変換できず不適格になる問題が解消された
+- [LWG Issue 3785. `ranges::to` is over-constrained on the destination type being a range](https://cplusplus.github.io/LWG/issue3785)
+    - C++23で、変換先`C`が`input_range`でない場合の分岐条件が加えられ、`range_value_t<C>`が不適格になる問題が回避された
 - [LWG Issue 3847. `ranges::to` can still return views](https://cplusplus.github.io/LWG/issue3847)
     - C++23で、(1)(3)に`C`がcv非修飾のクラス型であることの適格要件が追加され、`view`が返される問題が解消された
 - [LWG Issue 3984. `ranges::to`'s recursion branch may be ill-formed](https://cplusplus.github.io/LWG/issue3984)

--- a/reference/ranges/tuple-for-each.md
+++ b/reference/ranges/tuple-for-each.md
@@ -25,3 +25,5 @@ namespace std::ranges {
 
 ## 参照
 - [N4950 26 Ranges library](https://timsong-cpp.github.io/cppwp/n4950/ranges)
+- [LWG Issue 3755. *tuple-for-each* can call user-defined `operator,`](https://cplusplus.github.io/LWG/issue3755)
+    - C++23で、`invoke`の呼び出しを`static_cast<void>(...)`で包み、ユーザー定義の`operator,`が呼ばれないよう修正された

--- a/reference/ranges/view_interface/size.md
+++ b/reference/ranges/view_interface/size.md
@@ -27,9 +27,12 @@ Rangeの大きさを取得する。
 (1), (2)共に、以下と等価：
 
 ```cpp
-ranges::end(derived()) - ranges::begin(derived());
+to-unsigned-like(ranges::end(derived()) - ranges::begin(derived()));
 ```
 * derived[link derived.md]
+* to-unsigned-like[italic]
+
+ここで`to-unsigned-like`は、引数を対応する符号なし整数型（相当の型）に変換する説明専用の関数である。
 
 ## 計算量
 償却定数時間
@@ -47,3 +50,5 @@ ranges::end(derived()) - ranges::begin(derived());
 ## 参照
 - [N4861 24 Ranges library](https://timsong-cpp.github.io/cppwp/n4861/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
+- [LWG Issue 3646. `std::ranges::view_interface::size` returns a signed type](https://cplusplus.github.io/LWG/issue3646)
+    - C++23で、戻り値が符号付きの差分型ではなく、`to-unsigned-like`で符号なし整数型に変換した値を返すよう修正された

--- a/reference/ranges/zip_transform_view.md
+++ b/reference/ranges/zip_transform_view.md
@@ -113,3 +113,5 @@ int main() {
 ## 参照
 - [N4950 26 Ranges library](https://timsong-cpp.github.io/cppwp/n4950/ranges)
 - [P2321R2 zip](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2321r2.html)
+- [LWG Issue 3773. `views::zip_transform` still requires `F` to be `copy_constructible` when empty pack](https://cplusplus.github.io/LWG/issue3773)
+    - C++23で、空パック時の制約で`F`に要求する要件が`copy_constructible`から`move_constructible`に緩和された

--- a/reference/system_error/error_code/op_constructor.md
+++ b/reference/system_error/error_code/op_constructor.md
@@ -193,3 +193,8 @@ not found
 - [GCC](/implementation.md#gcc): 4.6.1 [mark verified]
 - [ICC](/implementation.md#icc): ??
 - [Visual C++](/implementation.md#visual_cpp): 2010 (enum class未対応のため、ErrorCodeEnumのコンストラクタは動作しない) [mark verified]
+
+
+## 参照
+- [LWG Issue 3629. `make_error_code` and `make_error_condition` are customization points](https://cplusplus.github.io/LWG/issue3629)
+    - C++23で、`make_error_code`/`make_error_condition`がADLによって探索されるカスタマイゼーションポイントであることが明記された

--- a/reference/thread/jthread/op_assign.md
+++ b/reference/thread/jthread/op_assign.md
@@ -18,14 +18,15 @@ jthread& operator=(jthread&& x) noexcept;    // (2) C++20
 
 
 ## 効果
-- [`joinable()`](joinable.md)が`true`を返す場合、[`request_stop()`](request_stop.md)と[`join()`](join.md)を呼び出す
-- `x`の状態を`*this`に代入し、`x`をデフォルト構築された状態に設定する
+- `&x == this`（自己代入）の場合、効果はない
+- それ以外の場合、以下を行う
+    - [`joinable()`](joinable.md)が`true`を返す場合、[`request_stop()`](request_stop.md)と[`join()`](join.md)を呼び出す
+    - `x`の状態を`*this`に代入し、`x`をデフォルト構築された状態に設定する
 
 
 ## 事後条件
-- `x.`[`get_id()`](get_id.md) `==` [`id`](id.md)`()`であること
 - [`get_id()`](get_id.md)の呼び出しでは、代入前の`x.`[`get_id()`](get_id.md)が返されるようになること
-- メンバ変数として保持している[`std::stop_source`](/reference/stop_token/stop_source.md)型オブジェクト`ssource`は、代入前の`x.ssource`の値を持ち、`x.ssource.`[`stop_possible()`](/reference/stop_token/stop_source/stop_possible.md)は`false`となること
+- メンバ変数として保持している[`std::stop_source`](/reference/stop_token/stop_source.md)型オブジェクト`ssource`は、代入前の`x.ssource`の値を持つこと
 
 
 ## 戻り値
@@ -66,3 +67,8 @@ int main()
 - [Clang](/implementation.md#clang):
 - [GCC](/implementation.md#gcc): 10.2.0 [mark verified]
 - [Visual C++](/implementation.md#visual_cpp): ??
+
+
+## 参照
+- [LWG Issue 3788. `jthread::operator=(jthread&&)` postconditions are unimplementable under self-assignment](https://cplusplus.github.io/LWG/issue3788)
+    - C++23で、自己代入(`&x == this`)の場合は効果がないことが効果に明記され、自己代入時に成立しない事後条件（`x.get_id() == id()`、`x.ssource.stop_possible()`が`false`）が削除された

--- a/reference/utility/forward_like.md
+++ b/reference/utility/forward_like.md
@@ -19,6 +19,9 @@ constexpr auto forward_like(U&& x) noexcept -> see below; // (1) C++26
 
 この関数は主に、クラスオブジェクトの`const`性と参照修飾を用いてメンバ変数を転送する目的で使用される。
 
+## 適格要件
+テンプレート引数`T`が参照可能型 (referenceable type) であること。（`void`など参照を作れない型に対して`forward_like<void>(x)`のように使用すると、プログラムは不適格となる。）
+
 ## 効果
 - `COPY_CONST(A, B)`を`A`が`const`修飾されているとき`const B`、そうでないとき`B`とする
 - `OVERRIDE_REF(A, B)`を`A`が右辺値参照のとき`remove_reference_t<B>&&`、そうでないとき`B&`とする
@@ -133,5 +136,7 @@ template <class T, class U>
 
 ## 参照
 - [P2445R1 `std::forward_like`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2445r1.pdf)
+- [LWG Issue 3757. What's the effect of `std::forward_like<void>(x)`?](https://cplusplus.github.io/LWG/issue3757)
+    - C++23で、テンプレート引数`T`が参照可能型でなければならないという適格要件が追加され、`forward_like<void>`のような非参照可能型に対する呼び出しが不適格であることが明確化された
 - [P2422R1 Remove `nodiscard` annotations from the standard library specification](https://open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2422r1.html)
     - C++26で`[[nodiscard]]`指定が削除された


### PR DESCRIPTION
- [P2703R0 C++ Standard Library Issues to be moved in Kona, Nov. 2022](https://wg21.link/p2703r0)

これに対応しました。