### PR TITLE
C++23のLWG Issue対応第5弾

### DIFF
--- a/reference/atomic/atomic_flag_init.md
+++ b/reference/atomic/atomic_flag_init.md
@@ -55,4 +55,6 @@ false
 
 ## 参照
 - [P0883R2 Fixing Atomic Initialization, Rev2](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p0883r2.pdf)
-- [LWG Issue 3659. Consider `ATOMIC_FLAG_INIT` undeprecation](http://www.open-std.org/jtc1/sc22/wg21/docs/lwg-defects.html#3659)
+    - C++20で、デフォルトコンストラクタが値初期化を行うようになり、あわせてこのマクロが非推奨とされた
+- [LWG Issue 3659. Consider `ATOMIC_FLAG_INIT` undeprecation](https://cplusplus.github.io/LWG/issue3659)
+    - C++23で、一部のプラットフォームでは静的初期化のために必要であることから、このマクロの非推奨が解除された

--- a/reference/expected/expected.md
+++ b/reference/expected/expected.md
@@ -212,3 +212,5 @@ int main()
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
 - [P2505R5 Monadic Functions for `std::expected`](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2505r5.html)
+- [LWG Issue 3703. Missing requirements for `expected<T, E>` requires `is_void<T>`](https://cplusplus.github.io/LWG/issue3703)
+    - C++23で、`expected<void, E>`部分特殊化にも型`E`に対する適格要件が明記された

--- a/reference/expected/expected.void/op_assign.md
+++ b/reference/expected/expected.void/op_assign.md
@@ -178,6 +178,8 @@ int main()
 
 ## 参照
 - [P0323R12 std::expected](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p0323r12.html)
+- [LWG Issue 3687. `expected<cv void, E>` move constructor should move](https://cplusplus.github.io/LWG/issue3687)
+    - C++23で、ムーブ代入演算子(2)で両者がエラー値を保持する場合に、エラー値がコピーではなくムーブされるよう修正された
 - [LWG Issue 4025. Move assignment operator of `std::expected<cv void, E>` should not be conditionally deleted](https://cplusplus.github.io/LWG/issue4025)
     - C++26で、ムーブ代入演算子(2)が条件付きでdelete定義されるのではなく、テンプレートパラメータ制約によってオーバーロード解決から除外されるよう修正された
 - [LWG Issue 4026. Assignment operators of `std::expected` should propagate triviality](https://cplusplus.github.io/LWG/issue4026)

--- a/reference/exposition-only/decay-copy.md
+++ b/reference/exposition-only/decay-copy.md
@@ -6,13 +6,15 @@
 
 ```cpp
 template<class T>
-constexpr decay_t<T> decay-copy(T&& v) noexcept(is_nothrow_convertible_v<T, decay_t<T>>)
-{
-  return std::forward<T>(v);
-}
+constexpr decay_t<T> decay-copy(T&& v)
+  noexcept(is_nothrow_convertible_v<T, decay_t<T>>);            // (1) C++20
+template<class T>
+  requires convertible_to<T, decay_t<T>>
+constexpr decay_t<T> decay-copy(T&& v)
+  noexcept(is_nothrow_convertible_v<T, decay_t<T>>);            // (1) C++23
 ```
 * decay-copy[italic]
-* forward[link /reference/utility/forward.md]
+* convertible_to[link /reference/concepts/convertible_to.md]
 * is_nothrow_convertible_v[link /reference/type_traits/is_nothrow_convertible.md]
 
 ## 概要
@@ -32,6 +34,15 @@ int g = 0;
 int f(){ return g; }
 ```
 
+## 効果
+以下と等価である：
+
+```cpp
+return std::forward<T>(v);
+```
+* forward[link /reference/utility/forward.md]
+
+
 ## 戻り値
 式`decay-copy(v)`の値は次のようになる。
 
@@ -47,3 +58,5 @@ int f(){ return g; }
 ## 参照
 - [N4861 16.4.2.1 Exposition-only functions](https://timsong-cpp.github.io/cppwp/n4861/expos.only.func)
 - [N3255 C++ Decay Copy](http://www.open-std.org/JTC1/SC22/WG21/docs/papers/2011/n3255.html) 実際の関数として提案しているが、採用には至っていない。
+- [LWG Issue 3724. decay-copy should be constrained](https://cplusplus.github.io/LWG/issue3724)
+    - C++23で、`decay-copy`に`convertible_to<T, decay_t<T>>`制約が追加され、変換できない型に対してSFINAEフレンドリー（ill-formed）になった

--- a/reference/filesystem/directory_iterator/op_equal.md
+++ b/reference/filesystem/directory_iterator/op_equal.md
@@ -6,16 +6,26 @@
 
 ```cpp
 namespace std::filesystem {
-  bool operator==(const directory_iterator& a, const directory_iterator& b) noexcept;
+  bool operator==(const directory_iterator& a, const directory_iterator& b) noexcept; // (1) C++17
+
+  class directory_iterator {
+  public:
+    bool operator==(default_sentinel_t) const noexcept; // (2) C++23
+  };
 }
 ```
+* default_sentinel_t[link /reference/iterator/default_sentinel_t.md]
 
 ## 概要
-2つの`directory_iterator`オブジェクトが等値かを判定する。
+`directory_iterator`オブジェクトが等値かを判定する。
+
+- (1) : 2つの`directory_iterator`オブジェクトを等値比較する。
+- (2) : `directory_iterator`オブジェクトが終端（ディレクトリの末尾）に到達しているかを判定する。
 
 
 ## 戻り値
-2つの`directory_iterator`オブジェクトが等値である場合は`true`、そうでなければ`false`を返す。
+- (1) : 2つの`directory_iterator`オブジェクトが等値である場合は`true`、そうでなければ`false`を返す。
+- (2) : `*this == directory_iterator()`と等価。すなわち、イテレータが終端を指していれば`true`、そうでなければ`false`を返す。
 
 
 ## 例
@@ -23,6 +33,7 @@ namespace std::filesystem {
 #include <cassert>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 
 namespace fs = std::filesystem;
 
@@ -33,14 +44,22 @@ int main()
 
   fs::directory_iterator a{"dir"};
   fs::directory_iterator b = a;
+
+  // (1) 2つのイテレータの等値比較
   assert(a == b);
 
   ++b;
+
+  // (1) デフォルト構築したイテレータ（終端）との比較
   fs::directory_iterator end{};
   assert(b == end);
+
+  // (2) default_sentinelとの比較で終端を判定する (C++23)
+  assert(b == std::default_sentinel);
 }
 ```
 * fs::create_directory[link /reference/filesystem/create_directory.md]
+* std::default_sentinel[link /reference/iterator/default_sentinel.md.nolink]
 
 ### 出力
 ```
@@ -54,3 +73,8 @@ int main()
 - [Clang](/implementation.md#clang): 7.0 [mark verified]
 - [GCC](/implementation.md#gcc): 8.1 [mark verified]
 - [Visual C++](/implementation.md#visual_cpp):
+
+
+## 参照
+- [LWG Issue 3719. Directory iterators should be usable with default sentinel](https://cplusplus.github.io/LWG/issue3719)
+    - C++23で、`default_sentinel_t`との等値比較演算子(2)が追加された

--- a/reference/filesystem/recursive_directory_iterator/op_equal.md
+++ b/reference/filesystem/recursive_directory_iterator/op_equal.md
@@ -7,16 +7,26 @@
 ```cpp
 namespace std::filesystem {
   bool operator==(const recursive_directory_iterator& a,
-                  const recursive_directory_iterator& b) noexcept;
+                  const recursive_directory_iterator& b) noexcept; // (1) C++17
+
+  class recursive_directory_iterator {
+  public:
+    bool operator==(default_sentinel_t) const noexcept; // (2) C++23
+  };
 }
 ```
+* default_sentinel_t[link /reference/iterator/default_sentinel_t.md]
 
 ## 概要
-2つの`recursive_directory_iterator`オブジェクトが等値かを判定する。
+`recursive_directory_iterator`オブジェクトが等値かを判定する。
+
+- (1) : 2つの`recursive_directory_iterator`オブジェクトを等値比較する。
+- (2) : `recursive_directory_iterator`オブジェクトが終端（ディレクトリの末尾）に到達しているかを判定する。
 
 
 ## 戻り値
-2つの`recursive_directory_iterator`オブジェクトが等値である場合は`true`、そうでなければ`false`を返す。
+- (1) : 2つの`recursive_directory_iterator`オブジェクトが等値である場合は`true`、そうでなければ`false`を返す。
+- (2) : `*this == recursive_directory_iterator()`と等価。すなわち、イテレータが終端を指していれば`true`、そうでなければ`false`を返す。
 
 
 ## 例
@@ -24,6 +34,7 @@ namespace std::filesystem {
 #include <cassert>
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 
 namespace fs = std::filesystem;
 
@@ -34,14 +45,22 @@ int main()
 
   fs::recursive_directory_iterator a{"dir"};
   fs::recursive_directory_iterator b = a;
+
+  // (1) 2つのイテレータの等値比較
   assert(a == b);
 
   ++b;
+
+  // (1) デフォルト構築したイテレータ（終端）との比較
   fs::recursive_directory_iterator end{};
   assert(b == end);
+
+  // (2) default_sentinelとの比較で終端を判定する (C++23)
+  assert(b == std::default_sentinel);
 }
 ```
 * fs::create_directory[link /reference/filesystem/create_directory.md]
+* std::default_sentinel[link /reference/iterator/default_sentinel.md.nolink]
 
 ### 出力
 ```
@@ -55,3 +74,8 @@ int main()
 - [Clang](/implementation.md#clang): 7.0 [mark verified]
 - [GCC](/implementation.md#gcc): 8.1 [mark verified]
 - [Visual C++](/implementation.md#visual_cpp):
+
+
+## 参照
+- [LWG Issue 3719. Directory iterators should be usable with default sentinel](https://cplusplus.github.io/LWG/issue3719)
+    - C++23で、`default_sentinel_t`との等値比較演算子(2)が追加された

--- a/reference/format/format.md
+++ b/reference/format/format.md
@@ -752,6 +752,8 @@ wstring format(const locale& loc, wformat_string<Args...> fmt, const Args&... ar
     - C++26から非ロケール版が`constexpr`に対応した
 - [LWG Issue 3720. Restrict the valid types of _arg-id_ for _width_ and _precision_ in _std-format-spec_](https://cplusplus.github.io/LWG/issue3720)
     - C++23で、幅・精度を動的引数で指定する場合、その引数の型が標準の符号付き/符号なし整数型に制限された（`bool`や文字型は指定できなくなった）
+- [LWG Issue 3721. Allow an _arg-id_ with a value of zero for _width_ in _std-format-spec_](https://cplusplus.github.io/LWG/issue3721)
+    - C++23で、幅を動的引数で指定する場合に値0を許可するようになった（精度と要件を統一し、負値のみ例外となる）
 - [LWG Issue 4090. Underspecified use of locale facets for locale-dependent `std::format`](https://cplusplus.github.io/LWG/issue4090)
     - C++26で、`L`オプション指定時にロケール依存の置換で使用されるファセットが`numpunct`（`grouping`/`thousands_sep`/`decimal_point`/`truename`/`falsename`）であることが明確化された
 - [LWG Issue 4522. Clarify that `std::format` transcodes for `std::wformat_strings`](https://cplusplus.github.io/LWG/issue4522)

--- a/reference/format/formatter.md
+++ b/reference/format/formatter.md
@@ -284,6 +284,8 @@ int main()
 - [P2286R8 Formatting Ranges](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2286r8.html)
 - [P2585R1 Improve default container formatting](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2585r1.html)
     - C++23から、Range・コンテナ、`pair`、`tuple`のフォーマット出力、および文字・文字列のデバッグ指定 (`"?"`) が追加された
+- [LWG Issue 3701. Make `formatter<remove_cvref_t<const charT[N]>, charT>` requirement explicit](https://cplusplus.github.io/LWG/issue3701)
+    - C++23で、有効な標準特殊化の一覧に`formatter<charT[N], charT>`が明示的に追加された
 - [LWG Issue 3833. Remove specialization `template<size_t N> struct formatter<const charT[N], charT>`](https://cplusplus.github.io/LWG/issue3833)
     - C++23で、`formatter`がCV修飾のないオブジェクト型に対してのみ特殊化される設計と矛盾するため、`formatter<const charT[N], charT>`の特殊化が有効な標準特殊化の一覧から削除された
 - [LWG Issue 3944. Formatters converting sequences of `char` to sequences of `wchar_t`](https://cplusplus.github.io/LWG/issue3944)

--- a/reference/functional/function/op_deduction_guide.md
+++ b/reference/functional/function/op_deduction_guide.md
@@ -25,10 +25,12 @@ namespace std {
 - (2) :
     - `&F::operator()`は評価されないオペランドとして扱われ、以下のいずれかの場合に適格である：
         - C++17 :
-            - `decltype(&F::operator())`は、型`G`があるとして、`R(G::*)(A...) cv &(opt) noexcept(opt)`形式もしくは`R(*)(G cv ref(opt), A...) noexcept(opt)`形式であること
+            - `decltype(&F::operator())`は、型`G`があるとして、`R(G::*)(A...) cv &(opt) noexcept(opt)`形式であること
+        - C++23 :
+            - `decltype(&F::operator())`は、型`G`があるとして、`R(G::*)(A...) cv &(opt) noexcept(opt)`形式もしくは`R(*)(G, A...) noexcept(opt)`形式であること
         - C++26 :
-            - `F::operator()`が非静的メンバ関数であり、`decltype(&F::operator())`は、型`G`があるとして、`R(G::*)(A...) cv &(opt) noexcept(opt)`形式もしくは`R(*)(G cv ref(opt), A...) noexcept(opt)`形式であること
-            - `F::operator()`静的メンバ関数であり、`decltype(&F::operator())`は`R(*)(A...) noexcept(opt)`形式であること
+            - `F::operator()`が非静的メンバ関数であり、`decltype(&F::operator())`は、型`G`があるとして、`R(G::*)(A...) cv &(opt) noexcept(opt)`形式もしくは`R(*)(G, A...) noexcept(opt)`形式であること
+            - `F::operator()`が静的メンバ関数であり、`decltype(&F::operator())`は`R(*)(A...) noexcept(opt)`形式であること
 
 
 ## 例
@@ -94,3 +96,5 @@ int main()
 
 ## 参照
 - [LWG issue 3117. Missing `packaged_task` deduction guides](https://wg21.cmeerw.net/lwg/issue3117)
+- [LWG Issue 3617. `function`/`packaged_task` deduction guides and deducing `this`](https://cplusplus.github.io/LWG/issue3617)
+    - C++23で、明示的オブジェクトパラメータ（deducing this）をもつ関数呼び出し演算子に対応するため、推論補助の制約に`R(*)(G, A...) noexcept(opt)`形式が追加された

--- a/reference/future/packaged_task/op_deduction_guide.md
+++ b/reference/future/packaged_task/op_deduction_guide.md
@@ -26,11 +26,13 @@ namespace std {
 ## テンプレートパラメータ制約
 - (2) :
     - `&F::operator()`は評価されないオペランドとして扱われ、以下のいずれかの場合に適格である：
-        - C++17 :
+        - C++20 :
             - `decltype(&F::operator())`は、型`G`があるとして、`R(G::*)(A...) cv &(opt) noexcept(opt)`形式であること
+        - C++23 :
+            - `decltype(&F::operator())`は、型`G`があるとして、`R(G::*)(A...) cv &(opt) noexcept(opt)`形式もしくは`R(*)(G, A...) noexcept(opt)`形式であること
         - C++26 :
-            - `F::operator()`が非静的メンバ関数であり、`decltype(&F::operator())`は、型`G`があるとして、`R(G::*)(A...) cv &(opt) noexcept(opt)`形式もしくは`R(*)(G cv ref(opt), A...) noexcept(opt)`形式であること
-            - `F::operator()`静的メンバ関数であり、`decltype(&F::operator())`は`R(*)(A...) noexcept(opt)`形式であること
+            - `F::operator()`が非静的メンバ関数であり、`decltype(&F::operator())`は、型`G`があるとして、`R(G::*)(A...) cv &(opt) noexcept(opt)`形式もしくは`R(*)(G, A...) noexcept(opt)`形式であること
+            - `F::operator()`が静的メンバ関数であり、`decltype(&F::operator())`は`R(*)(A...) noexcept(opt)`形式であること
 
 
 ## 例
@@ -93,3 +95,5 @@ int main()
 
 ## 参照
 - [P0433R2 Toward a resolution of US7 and US14: Integrating template deduction for class templates into the standard library](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0433r2.html)
+- [LWG Issue 3617. `function`/`packaged_task` deduction guides and deducing `this`](https://cplusplus.github.io/LWG/issue3617)
+    - C++23で、明示的オブジェクトパラメータ（deducing this）をもつ関数呼び出し演算子に対応するため、推論補助の制約に`R(*)(G, A...) noexcept(opt)`形式が追加された

--- a/reference/iterator/common_iterator/op_arrow.md
+++ b/reference/iterator/common_iterator/op_arrow.md
@@ -6,7 +6,7 @@
 * cpp20[meta cpp]
 
 ```cpp
-decltype(auto) operator->() const requires see below;
+auto operator->() const requires see below;
 ```
 
 ## 概要
@@ -68,5 +68,7 @@ indirectly_readable<const I> &&
 
 ## 参照
 - [P0896R4 The One Ranges Proposal (was Merging the Ranges TS)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0896r4.pdf)
+- [LWG Issue 3672. `common_iterator::operator->()` should return by value](https://cplusplus.github.io/LWG/issue3672)
+    - C++23で、戻り値の型が`decltype(auto)`から`auto`（値返し）に変更された
 - [P3697R1 Minor additions to C++26 standard library hardening](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3697r1.html)
 - [P3878R1 Standard library hardening should not use the 'observe' semantic](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3878r1.html)

--- a/reference/memory_resource/polymorphic_allocator/op_equal.md
+++ b/reference/memory_resource/polymorphic_allocator/op_equal.md
@@ -98,3 +98,4 @@ true
 ## 参照
 
 - [LWG Issue 3683. `operator==` for `polymorphic_allocator` cannot deduce template argument in common cases](https://cplusplus.github.io/LWG/issue3683)
+    - C++23で、hidden friendとして同次の`operator==`(1)が追加され、`memory_resource*`等からの変換を伴う比較ができるようになった

--- a/reference/ranges/chunk_view/end.md
+++ b/reference/ranges/chunk_view/end.md
@@ -77,3 +77,5 @@ int main() {
 
 ## 参照
 - [N4950 26.7.29 Chunk view](https://timsong-cpp.github.io/cppwp/n4950/range.chunk)
+- [LWG Issue 3710. The end of `chunk_view` for input ranges can be const](https://cplusplus.github.io/LWG/issue3710)
+    - C++23で、input rangeに対する`end()`(1)に`const`修飾が付き、const object からも番兵を取得できるようになった

--- a/reference/ranges/chunk_view/op_constructor.md
+++ b/reference/ranges/chunk_view/op_constructor.md
@@ -6,30 +6,25 @@
 * cpp23[meta cpp]
 
 ```cpp
-chunk_view()
-  requires default_initializable<V> = default; // (1) C++23
-
 constexpr explicit
-chunk_view(V base, range_difference_t<V> n);   // (2) C++23
+chunk_view(V base, range_difference_t<V> n);   // (1) C++23
 ```
 
 ## 概要
 
 `chunk_view`オブジェクトを構築する。
 
-- (1) : デフォルトコンストラクタ。元となるRangeを値初期化する。
-- (2) : 元となるRangeと分割数を受け取るコンストラクタ。
+- (1) : 元となるRangeと分割数を受け取るコンストラクタ。
 
 ## 効果
 
-- (1) : `base_`と`n_`を値初期化する。
-- (2) : `base_(std::move(base))`、`n_(n)`で初期化する。
+- (1) : `base_(std::move(base))`、`n_(n)`で初期化する。
 
 ここで、`base_`は元となるRangeを保持するメンバ変数、`n_`は分割する要素数を保持するメンバ変数である。
 
 ## 事前条件
 
-- (2) : `n > 0`
+- (1) : `n > 0`
 
 ## 例
 ```cpp example
@@ -39,14 +34,11 @@ chunk_view(V base, range_difference_t<V> n);   // (2) C++23
 
 int main() {
   std::vector<int> v = {1, 2, 3, 4, 5, 6, 7, 8};
-  
-  // デフォルトコンストラクタ
-  std::ranges::chunk_view<std::views::all_t<std::vector<int>>> cv1{};
-  
+
   // 元となるRangeと分割数を指定
-  std::ranges::chunk_view cv2{v, 3};
-  
-  std::println("{}", cv2);
+  std::ranges::chunk_view cv{v, 3};
+
+  std::println("{}", cv);
 }
 ```
 * std::ranges::chunk_view[color ff0000]
@@ -67,3 +59,5 @@ int main() {
 
 ## 参照
 - [N4950 26.7.29 Chunk view](https://timsong-cpp.github.io/cppwp/n4950/range.chunk)
+- [LWG Issue 3712. chunk_view and slide_view should not be default_initializable](https://cplusplus.github.io/LWG/issue3712)
+    - C++23で、事前条件`n > 0`を満たせないデフォルトコンストラクタが削除された

--- a/reference/ranges/iota_view/iterator.md
+++ b/reference/ranges/iota_view/iterator.md
@@ -205,5 +205,7 @@ namespace std::ranges {
 ## 参照
 - [N4861 24 Ranges library](https://timsong-cpp.github.io/cppwp/n4861/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
+- [LWG Issue 3670. Cpp17InputIterators don't have integer-class difference types](https://cplusplus.github.io/LWG/issue3670)
+    - C++23で、`iterator_category`は`iota_diff_t<W>`が整数型のときにのみ`input_iterator_tag`として定義されるよう条件が追加された
 - [P3059R2 Making user-defined constructors of view iterators/sentinels private](https://open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3059r2.html)
     - C++26で、ユーザー定義のコンストラクタを`public`から`private`に移動

--- a/reference/ranges/slide_view/op_constructor.md
+++ b/reference/ranges/slide_view/op_constructor.md
@@ -6,30 +6,25 @@
 * cpp23[meta cpp]
 
 ```cpp
-slide_view()
-  requires default_initializable<V> = default; // (1) C++23
-
 constexpr explicit
-slide_view(V base, range_difference_t<V> n);   // (2) C++23
+slide_view(V base, range_difference_t<V> n);   // (1) C++23
 ```
 
 ## 概要
 
 `slide_view`オブジェクトを構築する。
 
-- (1) : デフォルトコンストラクタ。元となるRangeを値初期化する。
-- (2) : 元となるRangeとスライドサイズを受け取るコンストラクタ。
+- (1) : 元となるRangeとスライドサイズを受け取るコンストラクタ。
 
 ## 効果
 
-- (1) : `base_`と`n_`を値初期化する。
-- (2) : `base_(std::move(base))`、`n_(n)`で初期化する。
+- (1) : `base_(std::move(base))`、`n_(n)`で初期化する。
 
 ここで、`base_`は元となるRangeを保持するメンバ変数、`n_`はスライドサイズを保持するメンバ変数である。
 
 ## 事前条件
 
-- (2) : `n > 0`
+- (1) : `n > 0`
 
 ## 例
 ```cpp example
@@ -39,14 +34,11 @@ slide_view(V base, range_difference_t<V> n);   // (2) C++23
 
 int main() {
   std::vector<int> v = {1, 2, 3, 4, 5, 6};
-  
-  // デフォルトコンストラクタ
-  std::ranges::slide_view<std::views::all_t<std::vector<int>>> sv1{};
-  
+
   // 元となるRangeとスライドサイズを指定
-  std::ranges::slide_view sv2{v, 3};
-  
-  std::println("{}", sv2);
+  std::ranges::slide_view sv{v, 3};
+
+  std::println("{}", sv);
 }
 ```
 
@@ -66,3 +58,7 @@ int main() {
 
 ## 参照
 - [N4950 26.7.31 Slide view](https://timsong-cpp.github.io/cppwp/n4950/range.slide)
+- [LWG Issue 3711. Missing preconditions for slide_view constructor](https://cplusplus.github.io/LWG/issue3711)
+    - C++23で、コンストラクタ(1)に事前条件`n > 0`が追加された
+- [LWG Issue 3712. chunk_view and slide_view should not be default_initializable](https://cplusplus.github.io/LWG/issue3712)
+    - C++23で、事前条件`n > 0`を満たせないデフォルトコンストラクタが削除された

--- a/reference/set/multiset/erase.md
+++ b/reference/set/multiset/erase.md
@@ -176,6 +176,8 @@ int main()
     - C++11では、「`a.erase(q1, q2)`の結果として`q2`が返る」という仕様だったが、`const_iterator`型が渡された場合に`iterator`型を返せない問題があった。そのためC++14では、`q2`が指す要素を指すイテレータが返る、ということが明記された
 - [LWG Issue 2059. C++0x ambiguity problem with `map::erase`](https://cplusplus.github.io/LWG/issue2059)
     - C++17で、`erase(iterator)`を再追加
+- [LWG Issue 3704. LWG 2059 added overloads that might be ill-formed for sets](https://cplusplus.github.io/LWG/issue3704)
+    - C++23で、`iterator`と`const_iterator`が同一型のときにオーバーロード(1)と(2)が曖昧になる問題を避けるため、`erase(iterator)`(1)に`!same_as<iterator, const_iterator>`の制約が追加された
 - [P2077R3 Heterogeneous erasure overloads for associative containers](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2077r3.html)
     - C++23で、`template <class K> erase(K&& x)`のオーバーロードが追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/set/set/erase.md
+++ b/reference/set/set/erase.md
@@ -177,6 +177,8 @@ int main()
     - C++11では、「`a.erase(q1, q2)`の結果として`q2`が返る」という仕様だったが、`const_iterator`型が渡された場合に`iterator`型を返せない問題があった。そのためC++14では、`q2`が指す要素を指すイテレータが返る、ということが明記された
 - [LWG Issue 2059. C++0x ambiguity problem with `map::erase`](https://cplusplus.github.io/LWG/issue2059)
     - C++17で、`erase(iterator)`を再追加
+- [LWG Issue 3704. LWG 2059 added overloads that might be ill-formed for sets](https://cplusplus.github.io/LWG/issue3704)
+    - C++23で、`iterator`と`const_iterator`が同一型のときにオーバーロード(1)と(2)が曖昧になる問題を避けるため、`erase(iterator)`(1)に`!same_as<iterator, const_iterator>`の制約が追加された
 - [P2077R3 Heterogeneous erasure overloads for associative containers](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2077r3.html)
     - C++23で、`template <class K> erase(K&& x)`のオーバーロードが追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/stdatomic.h.md
+++ b/reference/stdatomic.h.md
@@ -21,5 +21,7 @@
 
 ## 参照
 - [P0943R6 Support C atomics in C++](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2020/p0943r6.html)
+- [LWG Issue 3671. `atomic_fetch_xor` missing from `stdatomic.h`](https://cplusplus.github.io/LWG/issue3671)
+    - C++23で、`<stdatomic.h>`のシノプシスに`atomic_fetch_xor`/`atomic_fetch_xor_explicit`のusing宣言が追加された（C23・`<atomic>`との整合をとるための欠落補完）
 - [LWG Issue 4480. `<stdatomic.h>` should provide `ATOMIC_CHAR8_T_LOCK_FREE`](https://cplusplus.github.io/LWG/issue4480)
     - C++26で、`atomic_char8_t`に対応するロックフリー判定マクロ[`ATOMIC_CHAR8_T_LOCK_FREE`](atomic/lock_free_property.md)が`<stdatomic.h>`のシノプシスに追加された（C23の`<stdatomic.h>`との整合をとるための欠落補完）

--- a/reference/string.md
+++ b/reference/string.md
@@ -53,23 +53,6 @@
 | [`to_wstring`](string/to_wstring.md) | 数値から`wstring`への変換(function)                | C++11 |
 
 
-## ハッシュサポート
-
-| 名前 | 説明 | 対応バージョン |
-|-------------------|-----------------------------------|-------|
-| `hash`            | 先行宣言(class template)          | C++11 |
-| `hash<string>`    | `hash`の`string`に対する特殊化    | C++11 |
-| `hash<u8string>`  | `hash`の`u8string`に対する特殊化  | C++20 |
-| `hash<u16string>` | `hash`の`u16string`に対する特殊化 | C++11 |
-| `hash<u32string>` | `hash`の`u32string`に対する特殊化 | C++11 |
-| `hash<wstring>`   | `hash`の`wstring`に対する特殊化   | C++11 |
-| `hash<pmr::string>`    | `hash`の`pmr::string`に対する特殊化    | C++17 |
-| `hash<pmr::u8string>`  | `hash`の`pmr::u8string`に対する特殊化  | C++20 |
-| `hash<pmr::u16string>` | `hash`の`pmr::u16string`に対する特殊化 | C++17 |
-| `hash<pmr::u32string>` | `hash`の`pmr::u32string`に対する特殊化 | C++17 |
-| `hash<pmr::wstring>`   | `hash`の`pmr::wstring`に対する特殊化   | C++17 |
-
-
 ## 関連項目
 - [`<string_view>`](string_view.md)
 - [`<charconv>`](charconv.md)

--- a/reference/string/basic_string.md
+++ b/reference/string/basic_string.md
@@ -237,6 +237,13 @@ namespace std {
 | [`(deduction_guide)`](basic_string/op_deduction_guide.md) | クラステンプレートの推論補助 | C++17 |
 
 
+## ハッシュサポート
+
+| 名前 | 説明 | 対応バージョン |
+|------|------|----------------|
+| [`hash`](basic_string/hash.md) | `hash`クラスの特殊化 | C++11 |
+
+
 ## 例
 ### 基本的な使い方 (C++03)
 ```cpp example

--- a/reference/string/basic_string/hash.md
+++ b/reference/string/basic_string/hash.md
@@ -1,0 +1,103 @@
+# hash
+* string[meta header]
+* std[meta namespace]
+* class template[meta id-type]
+* cpp11[meta cpp]
+
+```cpp
+namespace std {
+  // 標準のallocatorを使用するbasic_stringに対する明示的特殊化
+  template <> struct hash<string>;    // (1) C++11からC++20まで
+  template <> struct hash<u8string>;  // (2) C++20からC++20まで
+  template <> struct hash<u16string>; // (3) C++11からC++20まで
+  template <> struct hash<u32string>; // (4) C++11からC++20まで
+  template <> struct hash<wstring>;   // (5) C++11からC++20まで
+
+  // pmr::polymorphic_allocatorを使用するbasic_stringに対する明示的特殊化
+  template <> struct hash<pmr::string>;    // (6) C++17からC++20まで
+  template <> struct hash<pmr::u8string>;  // (7) C++20からC++20まで
+  template <> struct hash<pmr::u16string>; // (8) C++17からC++20まで
+  template <> struct hash<pmr::u32string>; // (9) C++17からC++20まで
+  template <> struct hash<pmr::wstring>;   // (10) C++17からC++20まで
+
+  // 任意のアロケータを許す部分特殊化（(1)〜(10)を統合）
+  template <class Allocator>
+  struct hash<basic_string<char, char_traits<char>, Allocator>>;         // (11) C++23
+  template <class Allocator>
+  struct hash<basic_string<char8_t, char_traits<char8_t>, Allocator>>;   // (12) C++23
+  template <class Allocator>
+  struct hash<basic_string<char16_t, char_traits<char16_t>, Allocator>>; // (13) C++23
+  template <class Allocator>
+  struct hash<basic_string<char32_t, char_traits<char32_t>, Allocator>>; // (14) C++23
+  template <class Allocator>
+  struct hash<basic_string<wchar_t, char_traits<wchar_t>, Allocator>>;   // (15) C++23
+}
+```
+* hash[link /reference/functional/hash.md]
+* string[link ../basic_string.md]
+* u8string[link ../basic_string.md]
+* u16string[link ../basic_string.md]
+* u32string[link ../basic_string.md]
+* wstring[link ../basic_string.md]
+* pmr::string[link ../basic_string.md]
+* pmr::u8string[link ../basic_string.md]
+* pmr::u16string[link ../basic_string.md]
+* pmr::u32string[link ../basic_string.md]
+* pmr::wstring[link ../basic_string.md]
+* basic_string[link ../basic_string.md]
+* char_traits[link /reference/string/char_traits.md]
+
+## 概要
+[`std::hash`](/reference/functional/hash.md)クラスの、[`basic_string`](../basic_string.md)に対する特殊化。文字列の内容からハッシュ値を計算し、`basic_string`を[`unordered_map`](/reference/unordered_map/unordered_map.md)や[`unordered_set`](/reference/unordered_set/unordered_set.md)のキーとして使用できるようにする。
+
+各文字型に対する特殊化が提供される。定義の形式は、C++のバージョンによって以下のように変遷している。
+
+- (1)-(5) : 標準の[`allocator`](/reference/memory/allocator.md)を使用する`basic_string`（[`string`](../basic_string.md)等）に対する明示的特殊化。`char`・`char16_t`・`char32_t`・`wchar_t`版がC++11で、`char8_t`版 (2) がC++20で追加された。
+- (6)-(10) : [`pmr::polymorphic_allocator`](/reference/memory_resource/polymorphic_allocator.md)を使用する`basic_string`（`pmr::string`等）に対する明示的特殊化。`char`・`char16_t`・`char32_t`・`wchar_t`版がC++17で、`char8_t`版 (7) がC++20で追加された。
+- (11)-(15) : C++23で、(1)〜(10)を統合した、任意のアロケータ`Allocator`を許す部分特殊化。ハッシュ値は文字列の内容にのみ依存しアロケータには依存しないため、標準以外のアロケータを使用する`basic_string`もハッシュ可能となった。
+
+
+## 効果
+`S`を対象の文字列型、`SV`を対応する文字列ビュー型（例えば`S`が[`string`](../basic_string.md)なら`SV`は[`string_view`](/reference/string_view/basic_string_view.md)）、`s`を型`S`のオブジェクトとするとき、`hash<S>()(s)`は`hash<SV>()(SV(s))`と等しい。
+
+つまり、同じ文字列内容を表すオブジェクト同士は、文字列型・文字列ビュー型・アロケータの違いにかかわらず、同じハッシュ値を持つ。
+
+
+## 例
+```cpp example
+#include <cassert>
+#include <functional>
+#include <string>
+#include <string_view>
+
+int main()
+{
+  std::string s = "hello";
+
+  // 文字列の内容からハッシュ値を計算する
+  std::size_t h = std::hash<std::string>{}(s);
+
+  // 対応するstring_viewのハッシュ値と一致する
+  assert(h == std::hash<std::string_view>{}(std::string_view{s}));
+}
+```
+* std::hash[color ff0000]
+
+### 出力
+```
+```
+
+
+## バージョン
+### 言語
+- C++11
+
+
+## 関連項目
+- [`std::hash`](/reference/functional/hash.md)
+- [`std::basic_string`](../basic_string.md)
+
+
+## 参照
+- [LWG Issue 3705. Hashability shouldn't depend on `basic_string`'s allocator](https://cplusplus.github.io/LWG/issue3705)
+    - C++23で、`hash`の`basic_string`特殊化が、アロケータ固定の明示的特殊化から任意のアロケータを許す部分特殊化に変更された

--- a/reference/unordered_set/unordered_multiset/erase.md
+++ b/reference/unordered_set/unordered_multiset/erase.md
@@ -207,4 +207,6 @@ int main()
     - 安定性の保証が規定された経緯のレポート
 - [LWG Issue 2059. C++0x ambiguity problem with `map::erase`](https://cplusplus.github.io/LWG/issue2059)
     - C++17で、`erase(iterator)`を追加
+- [LWG Issue 3704. LWG 2059 added overloads that might be ill-formed for sets](https://cplusplus.github.io/LWG/issue3704)
+    - C++23で、`iterator`と`const_iterator`が同一型のときにオーバーロード(1)と(2)が曖昧になる問題を避けるため、`erase(iterator)`(1)に`!same_as<iterator, const_iterator>`の制約が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/unordered_set/unordered_set/erase.md
+++ b/reference/unordered_set/unordered_set/erase.md
@@ -205,4 +205,6 @@ int main()
 - [N2350 Container insert/erase and iterator constness (Revision 1)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2007/n2350.pdf)
 - [LWG Issue 2059. C++0x ambiguity problem with `map::erase`](https://cplusplus.github.io/LWG/issue2059)
     - C++17で、`erase(iterator)`を追加
+- [LWG Issue 3704. LWG 2059 added overloads that might be ill-formed for sets](https://cplusplus.github.io/LWG/issue3704)
+    - C++23で、`iterator`と`const_iterator`が同一型のときにオーバーロード(1)と(2)が曖昧になる問題を避けるため、`erase(iterator)`(1)に`!same_as<iterator, const_iterator>`の制約が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)


### PR DESCRIPTION
- [P2618R0 C++ Standard Library Issues to be moved in Virtual Plenary, Jul. 2022](https://wg21.link/p2618r0)

これに対応しました。