### PR TITLE
C++23 LWG Issueへの対応第7弾

### DIFF
--- a/reference/cstdlib.md
+++ b/reference/cstdlib.md
@@ -80,7 +80,7 @@
 | 名前 | 説明 | 対応バージョン |
 |------|------|----------------|
 | [`bsearch`](cstdlib/bsearch.md) | 二分探索を行う (function) | C++26で`const`版オーバーロードを追加 |
-| `qsort`   | 範囲の並べ替えを行う (function) | |
+| [`qsort`](cstdlib/qsort.md)   | 範囲の並べ替えを行う (function) | |
 
 
 ## 整数に対する算術関数

--- a/reference/cstdlib/bsearch.md
+++ b/reference/cstdlib/bsearch.md
@@ -44,6 +44,13 @@ namespace std {
 説明用の型`c-compare-pred`・`compare-pred`は、それぞれ`extern "C"`・`extern "C++"`の言語リンケージを持つ比較関数`int(const void*, const void*)`へのポインタ型である。これにより、いずれの言語リンケージの比較関数も渡せる。
 
 
+## 事前条件
+- 配列は、比較関数`compar`が定める順序に従って昇順にソートされていること。
+- 配列の要素型について：
+    - C++20まで : トリビアルな型であること
+    - C++23 : 要素型に対する要件は削除された（この要件は[`qsort`](qsort.md)にのみ残り、トリビアルにコピー可能な型に緩和された）
+
+
 ## 戻り値
 一致する要素が見つかった場合、その要素へのポインタを返す。一致する要素が複数ある場合、いずれが返されるかは未規定である。
 
@@ -59,8 +66,6 @@ namespace std {
 - `key`が要素より小さい場合 : 負の値
 - `key`が要素と等しい場合 : `0`
 - `key`が要素より大きい場合 : 正の値
-
-配列は、この比較関数の順序に従って昇順にソートされていなければならない。
 
 
 ## 備考
@@ -113,10 +118,12 @@ found: 5
 
 
 ## 関連項目
-- `qsort`: 範囲の並べ替えを行う
+- [`qsort`](qsort.md): 範囲の並べ替えを行う
 - [`std::lower_bound`](/reference/algorithm/lower_bound.md): ソート済み範囲から二分探索を行う
 
 
 ## 参照
+- [LWG Issue 3521. Overly strict requirements on `qsort` and `bsearch`](https://cplusplus.github.io/LWG/issue3521)
+    - C++23で、配列の要素型に対する「トリビアルな型であること」という事前条件が`bsearch`から削除された（この要件は`qsort`にのみ残った）
 - [P3348R4 C++26 should refer to C23 not C17](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3348r4.pdf)
     - C++26で`const`を保持するオーバーロードが追加された

--- a/reference/cstdlib/qsort.md
+++ b/reference/cstdlib/qsort.md
@@ -1,0 +1,111 @@
+# qsort
+* cstdlib[meta header]
+* std[meta namespace]
+* function[meta id-type]
+
+```cpp
+namespace std {
+  void qsort(void* base,
+             size_t nmemb,
+             size_t size,
+             c-compare-pred* compar); // (1)
+  void qsort(void* base,
+             size_t nmemb,
+             size_t size,
+             compare-pred* compar);   // (2)
+}
+```
+* size_t[link /reference/cstddef/size_t.md]
+* c-compare-pred[italic]
+* compare-pred[italic]
+
+## 概要
+配列を、比較関数`compar`が定める順序に従って昇順にソートする。
+
+`base`が指す`nmemb`個の要素 (各要素のサイズは`size`バイト) からなる配列を、その場でソートする。
+
+説明用の型`c-compare-pred`・`compare-pred`は、それぞれ`extern "C"`・`extern "C++"`の言語リンケージを持つ比較関数`int(const void*, const void*)`へのポインタ型である。これにより、いずれの言語リンケージの比較関数も渡せる。
+
+
+## 事前条件
+`base`が指す配列の要素は、トリビアルにコピー可能 ([`is_trivially_copyable`](/reference/type_traits/is_trivially_copyable.md)) な型であること。
+
+- C++20まで : トリビアルな型であること
+- C++23 : トリビアルにコピー可能な型に緩和された
+
+
+## 効果
+`base`が指す配列の`nmemb`個の要素を、比較関数`compar`が定める順序に従って昇順にソートする。ソートは配列をその場で書き換えることによって行われる。
+
+`compar`は任意の2要素`x`、`y`について、`x`が`y`より前に位置すべき場合に負の値を返すように、全順序と整合する必要がある。同じ配列に対する`compar`の呼び出しは、比較される要素の値のみによって一貫した結果を返さなければならない。
+
+比較関数`compar`が同順とした（`0`を返した）要素どうしの、ソート後の相対順序は規定されない（安定ソートではない）。
+
+
+## 戻り値
+なし
+
+
+## 比較関数
+`compar`は、配列の2つの要素へのポインタを引数に取り、以下を返す関数である。
+
+- 第1引数が第2引数より小さい場合 : 負の値
+- 第1引数が第2引数と等しい場合 : `0`
+- 第1引数が第2引数より大きい場合 : 正の値
+
+
+## 例外
+比較関数`compar`が送出した例外を送出する。
+
+
+## 備考
+この関数は、フリースタンディング処理系でも使用できる。
+
+
+## 例
+```cpp example
+#include <cstdlib>
+#include <iostream>
+#include <iterator>
+
+int compare(const void* a, const void* b)
+{
+  int x = *static_cast<const int*>(a);
+  int y = *static_cast<const int*>(b);
+  return x - y;
+}
+
+int main()
+{
+  int data[] = {5, 3, 9, 1, 7};
+
+  std::qsort(data, std::size(data), sizeof(int), compare);
+
+  for (int x : data) {
+    std::cout << x << ' ';
+  }
+  std::cout << std::endl;
+}
+```
+* std::qsort[color ff0000]
+* std::size[link /reference/iterator/size.md]
+
+### 出力
+```
+1 3 5 7 9 
+```
+
+
+## バージョン
+### 言語
+- C++98
+
+
+## 関連項目
+- [`bsearch`](bsearch.md): ソート済み範囲から二分探索を行う
+- [`std::sort`](/reference/algorithm/sort.md): 範囲の並べ替えを行う
+
+
+## 参照
+- [LWG Issue 3521. Overly strict requirements on `qsort` and `bsearch`](https://cplusplus.github.io/LWG/issue3521)
+    - C++23で、配列の要素型の事前条件がトリビアルな型からトリビアルにコピー可能な型へ緩和された

--- a/reference/format/formatter.md
+++ b/reference/format/formatter.md
@@ -75,11 +75,11 @@ namespace std {
 2. 式 `cf.format(t, fc)` が有効であり、
     - 戻り値の型が`FC::iterator`である
     - フォーマット結果を`fc.out()`へ出力し、出力後のイテレータを返す
-    - 出力は`t`、`fc.locale()`、最後に呼び出された`f.parse(pc)`のイテレータ範囲`[pc.begin(), pc.end())`以外に依存しない
+    - 出力は`t`、`fc.locale()`、`fc.arg(n)`（任意の`n`について）、最後に呼び出された`f.parse(pc)`のイテレータ範囲`[pc.begin(), pc.end())`以外に依存しない
 3. 式 `cf.format(u, fc)` が有効であり、
     - 戻り値が`FC::iterator`である
     - フォーマット結果を`fc.out()`へ出力し、出力後のイテレータを返す
-    - 出力は`u`、`fc.locale()`、最後に呼び出された`f.parse(pc)`のイテレータ範囲`[pc.begin(), pc.end())`以外に依存しない
+    - 出力は`u`、`fc.locale()`、`fc.arg(n)`（任意の`n`について）、最後に呼び出された`f.parse(pc)`のイテレータ範囲`[pc.begin(), pc.end())`以外に依存しない
     - `u`を変更しない
 
 条件内の各要素を、以下のように定義する。
@@ -284,6 +284,8 @@ int main()
 - [P2286R8 Formatting Ranges](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2286r8.html)
 - [P2585R1 Improve default container formatting](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2585r1.html)
     - C++23から、Range・コンテナ、`pair`、`tuple`のフォーマット出力、および文字・文字列のデバッグ指定 (`"?"`) が追加された
+- [LWG Issue 3462. §[formatter.requirements]: Formatter requirements forbid use of `fc.arg()`](https://cplusplus.github.io/LWG/issue3462)
+    - C++23で、`format`の出力が依存してよい対象に`fc.arg(n)`が追加され、動的な幅・精度指定などをフォーマッターから実装できるようになった
 - [LWG Issue 3701. Make `formatter<remove_cvref_t<const charT[N]>, charT>` requirement explicit](https://cplusplus.github.io/LWG/issue3701)
     - C++23で、有効な標準特殊化の一覧に`formatter<charT[N], charT>`が明示的に追加された
 - [LWG Issue 3833. Remove specialization `template<size_t N> struct formatter<const charT[N], charT>`](https://cplusplus.github.io/LWG/issue3833)

--- a/reference/forward_list/forward_list/unique.md
+++ b/reference/forward_list/forward_list/unique.md
@@ -26,8 +26,13 @@ constexpr size_type unique(BinaryPredicate pred); // (2) C++26
 コンテナがソート済みであること。ソート済みでない場合、この関数の動作は未規定。
 
 
+## 事前条件
+- (2) :
+    - C++23 : `pred`は同値関係であること。
+
+
 ## 効果
-イテレータ範囲`[first + 1, last)`の全てのイテレータ`i`について、
+連続する等価な要素のグループごとに、先頭の要素以外を削除する。すなわち、イテレータ範囲`[first + 1, last)`の全てのイテレータ`i`について、
 
 - (1) : `*i == *(i - 1)`
 - (2) : `pred(*i, *(i - 1))`
@@ -48,7 +53,7 @@ constexpr size_type unique(BinaryPredicate pred); // (2) C++26
 
 
 ## 計算量
-ちょうど`(last - first) - 1`回の等値比較、もしくは述語の適用を行う。
+コンテナが空でない場合、ちょうど`(last - first) - 1`回の等値比較、もしくは述語の適用を行う。空の場合、等値比較・述語の適用は行わない。
 
 
 ## 例
@@ -91,4 +96,6 @@ int main()
 
 ## 参照
 - [P0646R1 Improving the Return Value of Erase-Like Algorithms I: list/forward list](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0646r1.pdf)
+- [LWG Issue 2997. LWG 491 and the specification of `{forward_,}list::unique`](https://cplusplus.github.io/LWG/issue2997)
+    - C++23で、`pred`が同値関係であるという事前条件が追加され、効果・計算量の記述が整理された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/fstream/basic_filebuf/open.md
+++ b/reference/fstream/basic_filebuf/open.md
@@ -10,6 +10,8 @@ basic_filebuf* open(const filesystem::path::value_type* s,
                     ios_base::openmode mode); // (2) C++17
 basic_filebuf* open(const string& s, ios_base::openmode mode); // (3)
 basic_filebuf* open(const filesystem::path& s, ios_base::openmode mode); // (4) C++17
+template <class T>
+basic_filebuf* open(const T& s, ios_base::openmode mode); // (4) C++23
 ```
 
 ## 概要
@@ -17,7 +19,10 @@ basic_filebuf* open(const filesystem::path& s, ios_base::openmode mode); // (4) 
 - (1): `s`で指定されたファイルを開く。`s`はヌル終端文字列。
 - (2): [`std::filesystem::path::value_type`](/reference/filesystem/path.md)の型が`char`ではないときのみ定義される。効果は(1)と同じ。
 - (3): ファイルを指定する引数の型が`std::string`である点を除き、(1)と同じ。
-- (4): ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(1)と同じ。
+- (4): ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(1)と同じ。C++23では、`path`へ暗黙変換可能な型（[`std::string_view`](/reference/string_view/basic_string_view.md)など）が渡されたときの高コストな暗黙変換を防ぐため、`filesystem::path`とまったく同じ型のみを受け取る制約付きテンプレートとして定義される。
+
+## テンプレートパラメータ制約
+- (4) C++23 : [`is_same_v`](/reference/type_traits/is_same.md)`<T, filesystem::path>`が`true`であること
 
 ## 効果
 
@@ -85,4 +90,6 @@ int main()
 ## 参照
 
 - [LGW issue 2676. Provide filesystem::path overloads for File-based streams](https://wg21.cmeerw.net/lwg/issue2676)
+- [LWG Issue 3430. `std::fstream` & co. should be constructible from `string_view`](https://cplusplus.github.io/LWG/issue3430)
+    - C++23で、`filesystem::path`を受け取る`open`(4)が、`path`へ暗黙変換可能な型による高コストな変換を防ぐため、`is_same_v<T, filesystem::path>`を制約とする制約付きテンプレートに変更された
 - [LGW issue 2943. Problematic specification of the wide version of basic_filebuf::open](https://wg21.cmeerw.net/lwg/issue2943)

--- a/reference/fstream/basic_fstream/op_constructor.md
+++ b/reference/fstream/basic_fstream/op_constructor.md
@@ -12,12 +12,18 @@ explicit basic_fstream(const filesystem::path::value_type* s,
                        ios_base::openmode mode = ios_base::in|ios_base::out); // (4) C++17
 explicit basic_fstream(const filesystem::path& s,
                        ios_base::openmode mode = ios_base::in | ios_base::out); // (5) C++17
+template <class T>
+explicit basic_fstream(const T& s,
+                       ios_base::openmode mode = ios_base::in | ios_base::out); // (5) C++23
 basic_fstream(const basic_fstream& rhs) = delete; // (6) C++11
 basic_fstream(basic_fstream&& rhs); // (7) C++11
 ```
 
 ## 概要
 オブジェクトを構築する。一部のオーバーロードでは、ファイルを開く機能を持っている。
+
+## テンプレートパラメータ制約
+- (5) C++23 : [`is_same_v`](/reference/type_traits/is_same.md)`<T, filesystem::path>`が`true`であること
 
 ## 効果
 
@@ -26,7 +32,7 @@ basic_fstream(basic_fstream&& rhs); // (7) C++11
     - [`rdbuf()->open(s, mode)`](/reference/fstream/basic_filebuf/open.md)を呼び出す。その結果が失敗だった（戻り値がヌルポインタだった）場合、[`setstate(failbit)`](/reference/ios/basic_ios/setstate.md)を呼び出す。
 - (3) : ファイルを指定する引数の型が`std::string`である点を除き、(2)と同じ。
 - (4) : [`std::filesystem::path::value_type`](/reference/filesystem/path.md)の型が`char`ではないときのみ定義される。効果は(2)と同じ。
-- (5) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(2)と同じ。
+- (5) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(2)と同じ。C++23では、`path`へ暗黙変換可能な型（[`std::string_view`](/reference/string_view/basic_string_view.md)など）が渡されたときの高コストな暗黙変換を防ぐため、`filesystem::path`とまったく同じ型のみを受け取る制約付きテンプレートとして定義される。
 - (6) : コピーコンストラクタ。コピー不可。
 - (7) : ムーブコンストラクタ。ファイルストリームの所有権を移動する。
 
@@ -109,3 +115,5 @@ basic_fstream<CharT, Traits>::basic_fstream(basic_fstream&& rhs)
 
 - [LGW issue 2676. Provide filesystem::path overloads for File-based streams](https://wg21.cmeerw.net/lwg/issue2676)
 - [LWG Issue 3130. §[input.output] needs many `addressof`](https://wg21.cmeerw.net/lwg/issue3130)
+- [LWG Issue 3430. `std::fstream` & co. should be constructible from `string_view`](https://cplusplus.github.io/LWG/issue3430)
+    - C++23で、`filesystem::path`を受け取るコンストラクタ(5)が、`path`へ暗黙変換可能な型による高コストな変換を防ぐため、`is_same_v<T, filesystem::path>`を制約とする制約付きテンプレートに変更された

--- a/reference/fstream/basic_fstream/open.md
+++ b/reference/fstream/basic_fstream/open.md
@@ -17,11 +17,18 @@ void open(
 void open(
   const filesystem::path& s,
   ios_base::openmode mode = ios_base::in | ios_base::out); // (4) C++17
+template <class T>
+void open(
+  const T& s,
+  ios_base::openmode mode = ios_base::in | ios_base::out); // (4) C++23
 ```
 
 ## 概要
 
 ファイルを開く
+
+## テンプレートパラメータ制約
+- (4) C++23 : [`is_same_v`](/reference/type_traits/is_same.md)`<T, filesystem::path>`が`true`であること
 
 ## 効果
 
@@ -29,7 +36,7 @@ void open(
     - [`rdbuf()->open(s, mode)`](/reference/fstream/basic_filebuf/open.md)を呼び出す。その結果が成功だった（戻り値がヌルポインタではなかった）場合、[`clear()`](/reference/ios/basic_ios/clear.md)を呼び出す。その結果が失敗だった（戻り値がヌルポインタだった）場合、[`setstate(failbit)`](/reference/ios/basic_ios/setstate.md)を呼び出す。
 - (2) : [`std::filesystem::path::value_type`](/reference/filesystem/path.md)の型が`char`ではないときのみ定義される。効果は(1)と同じ。
 - (3) : ファイルを指定する引数の型が`std::string`である点を除き、(1)と同じ。
-- (4) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(1)と同じ。
+- (4) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(1)と同じ。C++23では、`path`へ暗黙変換可能な型（[`std::string_view`](/reference/string_view/basic_string_view.md)など）が渡されたときの高コストな暗黙変換を防ぐため、`filesystem::path`とまったく同じ型のみを受け取る制約付きテンプレートとして定義される。
 
 ## 例
 
@@ -73,3 +80,5 @@ int main()
 ## 参照
 
 - [LGW issue 2676. Provide filesystem::path overloads for File-based streams](https://wg21.cmeerw.net/lwg/issue2676)
+- [LWG Issue 3430. `std::fstream` & co. should be constructible from `string_view`](https://cplusplus.github.io/LWG/issue3430)
+    - C++23で、`filesystem::path`を受け取る`open`(4)が、`path`へ暗黙変換可能な型による高コストな変換を防ぐため、`is_same_v<T, filesystem::path>`を制約とする制約付きテンプレートに変更された

--- a/reference/fstream/basic_ifstream/op_constructor.md
+++ b/reference/fstream/basic_ifstream/op_constructor.md
@@ -12,12 +12,18 @@ explicit basic_ifstream(const filesystem::path::value_type* s,
                        ios_base::openmode mode = ios_base::in); // (4) C++17
 explicit basic_ifstream(const filesystem::path& s,
                        ios_base::openmode mode = ios_base::in); // (5) C++17
+template <class T>
+explicit basic_ifstream(const T& s,
+                       ios_base::openmode mode = ios_base::in); // (5) C++23
 basic_ifstream(const basic_ifstream& rhs) = delete; // (6) C++11
 basic_ifstream(basic_ifstream&& rhs); // (7) C++11
 ```
 
 ## 概要
 オブジェクトを構築する。一部のオーバーロードでは、ファイルを開く機能を持っている。
+
+## テンプレートパラメータ制約
+- (5) C++23 : [`is_same_v`](/reference/type_traits/is_same.md)`<T, filesystem::path>`が`true`であること
 
 ## 効果
 
@@ -26,7 +32,7 @@ basic_ifstream(basic_ifstream&& rhs); // (7) C++11
     - [`rdbuf()->open(s, mode | std::ios_base::in)`](/reference/fstream/basic_filebuf/open.md)を呼び出す(少なくとも読み取り操作ができる)。その結果が失敗だった（戻り値がヌルポインタだった）場合、[`setstate(failbit)`](/reference/ios/basic_ios/setstate.md)を呼び出す。
 - (3) : ファイルを指定する引数の型が`std::string`である点を除き、(2)と同じ。
 - (4) : [`std::filesystem::path::value_type`](/reference/filesystem/path.md)の型が`char`ではないときのみ定義される。効果は(2)と同じ。
-- (5) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(2)と同じ。
+- (5) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(2)と同じ。C++23では、`path`へ暗黙変換可能な型（[`std::string_view`](/reference/string_view/basic_string_view.md)など）が渡されたときの高コストな暗黙変換を防ぐため、`filesystem::path`とまったく同じ型のみを受け取る制約付きテンプレートとして定義される。
 - (6) : コピーコンストラクタ。コピー不可。
 - (7) : ムーブコンストラクタ。ファイルストリームの所有権を移動する。
 
@@ -109,3 +115,5 @@ basic_ifstream<CharT, Traits>::basic_ifstream(basic_ifstream&& rhs)
 
 - [LGW issue 2676. Provide filesystem::path overloads for File-based streams](https://wg21.cmeerw.net/lwg/issue2676)
 - [LWG Issue 3130. §[input.output] needs many `addressof`](https://wg21.cmeerw.net/lwg/issue3130)
+- [LWG Issue 3430. `std::fstream` & co. should be constructible from `string_view`](https://cplusplus.github.io/LWG/issue3430)
+    - C++23で、`filesystem::path`を受け取るコンストラクタ(5)が、`path`へ暗黙変換可能な型による高コストな変換を防ぐため、`is_same_v<T, filesystem::path>`を制約とする制約付きテンプレートに変更された

--- a/reference/fstream/basic_ifstream/open.md
+++ b/reference/fstream/basic_ifstream/open.md
@@ -17,11 +17,18 @@ void open(
 void open(
   const filesystem::path& s,
   ios_base::openmode mode = ios_base::in); // (4) C++17
+template <class T>
+void open(
+  const T& s,
+  ios_base::openmode mode = ios_base::in); // (4) C++23
 ```
 
 ## 概要
 
 ファイルを開く
+
+## テンプレートパラメータ制約
+- (4) C++23 : [`is_same_v`](/reference/type_traits/is_same.md)`<T, filesystem::path>`が`true`であること
 
 ## 効果
 
@@ -29,7 +36,7 @@ void open(
     - [`rdbuf()->open(s, mode | std::ios_base::in)`](/reference/fstream/basic_filebuf/open.md)を呼び出す(少なくとも読み取り操作ができる)。その結果が成功だった（戻り値がヌルポインタではなかった）場合、[`clear()`](/reference/ios/basic_ios/clear.md)を呼び出す。その結果が失敗だった（戻り値がヌルポインタだった）場合、[`setstate(failbit)`](/reference/ios/basic_ios/setstate.md)を呼び出す。
 - (2) : [`std::filesystem::path::value_type`](/reference/filesystem/path.md)の型が`char`ではないときのみ定義される。効果は(1)と同じ。
 - (3) : ファイルを指定する引数の型が`std::string`である点を除き、(1)と同じ。
-- (4) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(1)と同じ。
+- (4) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(1)と同じ。C++23では、`path`へ暗黙変換可能な型（[`std::string_view`](/reference/string_view/basic_string_view.md)など）が渡されたときの高コストな暗黙変換を防ぐため、`filesystem::path`とまったく同じ型のみを受け取る制約付きテンプレートとして定義される。
 
 ## 例
 
@@ -73,3 +80,5 @@ int main()
 ## 参照
 
 - [LGW issue 2676. Provide filesystem::path overloads for File-based streams](https://wg21.cmeerw.net/lwg/issue2676)
+- [LWG Issue 3430. `std::fstream` & co. should be constructible from `string_view`](https://cplusplus.github.io/LWG/issue3430)
+    - C++23で、`filesystem::path`を受け取る`open`(4)が、`path`へ暗黙変換可能な型による高コストな変換を防ぐため、`is_same_v<T, filesystem::path>`を制約とする制約付きテンプレートに変更された

--- a/reference/fstream/basic_ofstream/op_constructor.md
+++ b/reference/fstream/basic_ofstream/op_constructor.md
@@ -12,12 +12,18 @@ explicit basic_ofstream(const filesystem::path::value_type* s,
                        ios_base::openmode mode = ios_base::out); // (4) C++17
 explicit basic_ofstream(const filesystem::path& s,
                        ios_base::openmode mode = ios_base::out); // (5) C++17
+template <class T>
+explicit basic_ofstream(const T& s,
+                       ios_base::openmode mode = ios_base::out); // (5) C++23
 basic_ofstream(const basic_ofstream& rhs) = delete; // (6) C++11
 basic_ofstream(basic_ofstream&& rhs); // (7) C++11
 ```
 
 ## 概要
 オブジェクトを構築する。一部のオーバーロードでは、ファイルを開く機能を持っている。
+
+## テンプレートパラメータ制約
+- (5) C++23 : [`is_same_v`](/reference/type_traits/is_same.md)`<T, filesystem::path>`が`true`であること
 
 ## 効果
 
@@ -26,7 +32,7 @@ basic_ofstream(basic_ofstream&& rhs); // (7) C++11
     - [`rdbuf()->open(s, mode | std::ios_base::out)`](/reference/fstream/basic_filebuf/open.md)を呼び出す(少なくとも書き込み操作ができる)。その結果が失敗だった（戻り値がヌルポインタだった）場合、[`setstate(failbit)`](/reference/ios/basic_ios/setstate.md)を呼び出す。
 - (3) : ファイルを指定する引数の型が`std::string`である点を除き、(2)と同じ。
 - (4) : [`std::filesystem::path::value_type`](/reference/filesystem/path.md)の型が`char`ではないときのみ定義される。効果は(2)と同じ。
-- (5) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(2)と同じ。
+- (5) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(2)と同じ。C++23では、`path`へ暗黙変換可能な型（[`std::string_view`](/reference/string_view/basic_string_view.md)など）が渡されたときの高コストな暗黙変換を防ぐため、`filesystem::path`とまったく同じ型のみを受け取る制約付きテンプレートとして定義される。
 - (6) : コピーコンストラクタ。コピー不可。
 - (7) : ムーブコンストラクタ。ファイルストリームの所有権を移動する。
 
@@ -108,3 +114,5 @@ basic_ofstream<CharT, Traits>::basic_ofstream(basic_ofstream&& rhs)
 
 - [LGW issue 2676. Provide filesystem::path overloads for File-based streams](https://wg21.cmeerw.net/lwg/issue2676)
 - [LWG Issue 3130. §[input.output] needs many `addressof`](https://wg21.cmeerw.net/lwg/issue3130)
+- [LWG Issue 3430. `std::fstream` & co. should be constructible from `string_view`](https://cplusplus.github.io/LWG/issue3430)
+    - C++23で、`filesystem::path`を受け取るコンストラクタ(5)が、`path`へ暗黙変換可能な型による高コストな変換を防ぐため、`is_same_v<T, filesystem::path>`を制約とする制約付きテンプレートに変更された

--- a/reference/fstream/basic_ofstream/open.md
+++ b/reference/fstream/basic_ofstream/open.md
@@ -17,11 +17,18 @@ void open(
 void open(
   const filesystem::path& s,
   ios_base::openmode mode = ios_base::out); // (4) C++17
+template <class T>
+void open(
+  const T& s,
+  ios_base::openmode mode = ios_base::out); // (4) C++23
 ```
 
 ## 概要
 
 ファイルを開く
+
+## テンプレートパラメータ制約
+- (4) C++23 : [`is_same_v`](/reference/type_traits/is_same.md)`<T, filesystem::path>`が`true`であること
 
 ## 効果
 
@@ -29,7 +36,7 @@ void open(
     - [`rdbuf()->open(s, mode | std::ios_base::out)`](/reference/fstream/basic_filebuf/open.md)を呼び出す(少なくとも書き込み操作ができる)。その結果が成功だった（戻り値がヌルポインタではなかった）場合、[`clear()`](/reference/ios/basic_ios/clear.md)を呼び出す。その結果が失敗だった（戻り値がヌルポインタだった）場合、[`setstate(failbit)`](/reference/ios/basic_ios/setstate.md)を呼び出す。
 - (2) : [`std::filesystem::path::value_type`](/reference/filesystem/path.md)の型が`char`ではないときのみ定義される。効果は(1)と同じ。
 - (3) : ファイルを指定する引数の型が`std::string`である点を除き、(1)と同じ。
-- (4) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(1)と同じ。
+- (4) : ファイルを指定する引数の型が[`std::filesystem::path`](/reference/filesystem/path.md)である点を除き、(1)と同じ。C++23では、`path`へ暗黙変換可能な型（[`std::string_view`](/reference/string_view/basic_string_view.md)など）が渡されたときの高コストな暗黙変換を防ぐため、`filesystem::path`とまったく同じ型のみを受け取る制約付きテンプレートとして定義される。
 
 ## 例
 
@@ -72,3 +79,5 @@ int main()
 ## 参照
 
 - [LGW issue 2676. Provide filesystem::path overloads for File-based streams](https://wg21.cmeerw.net/lwg/issue2676)
+- [LWG Issue 3430. `std::fstream` & co. should be constructible from `string_view`](https://cplusplus.github.io/LWG/issue3430)
+    - C++23で、`filesystem::path`を受け取る`open`(4)が、`path`へ暗黙変換可能な型による高コストな変換を防ぐため、`is_same_v<T, filesystem::path>`を制約とする制約付きテンプレートに変更された

--- a/reference/list/list/unique.md
+++ b/reference/list/list/unique.md
@@ -25,8 +25,13 @@ constexpr size_type unique(BinaryPredicate pred); // (2) C++26
 コンテナがソート済みであること。ソート済みでない場合、この関数の動作は未規定。
 
 
+## 事前条件
+- (2) :
+    - C++23 : `pred`は同値関係であること。
+
+
 ## 効果
-イテレータ範囲`[first + 1, last)`の全てのイテレータ`i`について、オーバーロードごとに、以下の条件が`true`となる要素を削除する。
+連続する等価な要素のグループごとに、先頭の要素以外を削除する。すなわち、イテレータ範囲`[first + 1, last)`の全てのイテレータ`i`について、オーバーロードごとに、以下の条件が`true`となる要素を削除する。
 
 - (1) : `*i == *(i - 1)`
 - (2) : `pred(*i, *(i - 1))`
@@ -46,7 +51,7 @@ constexpr size_type unique(BinaryPredicate pred); // (2) C++26
 
 
 ## 計算量
-ちょうど`(last - first) - 1`回の等値比較、もしくは述語の適用を行う。
+コンテナが空でない場合、ちょうど`(last - first) - 1`回の等値比較、もしくは述語の適用を行う。空の場合、等値比較・述語の適用は行わない。
 
 
 ## 例
@@ -79,4 +84,6 @@ int main()
 
 ## 参照
 - [P0646R1 Improving the Return Value of Erase-Like Algorithms I: list/forward list](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0646r1.pdf)
+- [LWG Issue 2997. LWG 491 and the specification of `{forward_,}list::unique`](https://cplusplus.github.io/LWG/issue2997)
+    - C++23で、`pred`が同値関係であるという事前条件が追加され、効果・計算量の記述が整理された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/queue/priority_queue/op_constructor.md
+++ b/reference/queue/priority_queue/op_constructor.md
@@ -208,6 +208,11 @@ constexpr
 `Compare`型パラメータ`x`が、[狭義の弱順序](/reference/algorithm.md#strict-weak-ordering)で定義されていること。
 
 
+## テンプレートパラメータ制約
+- (5), (6), (7), (15), (16), (17) :
+    - C++23 : `InputIterator`が入力イテレータの要件を満たすこと。
+
+
 ## 効果
 - (1) :
     - C++03
@@ -363,4 +368,8 @@ que5 : 5 4 3 2 1
 ## 参照
 
 - [P0935R0 Eradicating unnecessarily explicit default constructors from the standard library](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p0935r0.html)
+- [LWG Issue 3506. Missing allocator-extended constructors for `priority_queue`](https://cplusplus.github.io/LWG/issue3506)
+    - C++23で、イテレータ範囲を受け取るアロケータ拡張コンストラクタ(15)〜(17)が追加された
+- [LWG Issue 3522. Missing requirement on `InputIterator` template parameter for `priority_queue` constructors](https://cplusplus.github.io/LWG/issue3522)
+    - C++23で、イテレータ範囲を受け取るコンストラクタが、入力イテレータでない型が推論された場合にオーバーロード解決に参加しないという制約が追加された
 - [P3372R3 constexpr containers and adaptors](https://open-std.org/jtc1/sc22/wg21/docs/papers/2025/p3372r3.html)

--- a/reference/queue/priority_queue/op_deduction_guide.md
+++ b/reference/queue/priority_queue/op_deduction_guide.md
@@ -133,3 +133,5 @@ int main()
 - [P0433R2 Toward a resolution of US7 and US14: Integrating template deduction for class templates into the standard library](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/p0433r2.html)
 - [P1518R2 Stop Overconstraining Allocators in Container Deduction Guides](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p1518r2.html)
     - C++23での推論補助の制約についての変更
+- [LWG Issue 3506. Missing allocator-extended constructors for `priority_queue`](https://cplusplus.github.io/LWG/issue3506)
+    - C++23で、アロケータ拡張コンストラクタの追加に対応する推論補助が追加された

--- a/reference/ranges/iota_view/op_constructor.md
+++ b/reference/ranges/iota_view/op_constructor.md
@@ -16,20 +16,26 @@ constexpr explicit iota_view(W value);
 constexpr iota_view(type_identity_t<W> value, type_identity_t<Bound> bound);
 
 // (4)
-constexpr iota_view(iterator first, sentinel last);
+constexpr iota_view(iterator first, see-below last);
 ```
 * iota_view[link ../iota_view.md]
 * type_identity_t[link /reference/type_traits/type_identity.md]
 * iterator[link iterator.md]
-* sentinel[link sentinel.md]
+* see-below[italic]
 
 ## 概要
 - (1) : `[W(), Bound())` を範囲とする`iota_view`を構築する
 - (2) : `[value, Bound())` を範囲とする`iota_view`を構築する
 - (3) : `[value, bound)` を範囲とする`iota_view`を構築する
-- (4) : イテレータ `[first, last)` が指す値を範囲とする`iota_view`を構築する((3)に委譲)
+- (4) : イテレータ `[first, last)` が指す値を範囲とする`iota_view`を構築する
 
 `Bound`が[`unreachable_sentinel_t`](/reference/iterator/unreachable_sentinel_t.md)のとき、無限長の`iota_view`となる。
+
+(4)の第2引数`last`の型は、以下のように決まる：
+
+- [`same_as`](/reference/concepts/same_as.md)`<W, Bound>`が`true`の場合、[`iterator`](iterator.md)
+- `Bound`が[`unreachable_sentinel_t`](/reference/iterator/unreachable_sentinel_t.md)の場合、`Bound`
+- それ以外の場合、[`sentinel`](sentinel.md)
 
 ## 事前条件
 
@@ -40,7 +46,11 @@ constexpr iota_view(iterator first, sentinel last);
 
 ## 効果
 
-`iota_view`が内部で保持する先頭と終端の値を引数で初期化する。
+- (1), (2), (3) : `iota_view`が内部で保持する先頭と終端の値を引数で初期化する。
+- (4) : 以下と等価。
+    - [`same_as`](/reference/concepts/same_as.md)`<W, Bound>`が`true`の場合、`iota_view(first.value_, last.value_)`
+    - `Bound`が[`unreachable_sentinel_t`](/reference/iterator/unreachable_sentinel_t.md)の場合、`iota_view(first.value_, last)`
+    - それ以外の場合、`iota_view(first.value_, last.bound_)`
 
 ## 例
 ```cpp example
@@ -81,5 +91,7 @@ int main()
 ## 参照
 - [N4861 24 Ranges library](https://timsong-cpp.github.io/cppwp/n4861/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
+- [LWG Issue 3523. `iota_view::sentinel` is not always `iota_view`'s sentinel](https://cplusplus.github.io/LWG/issue3523)
+    - C++23で、イテレータ対を取るコンストラクタ(4)の第2引数の型が、常に`sentinel`ではなく実際の終端型（`iterator`・`Bound`・`sentinel`）に応じて決まるよう修正され、効果も場合分けされた
 - [LWG Issue 3597. Unsigned integer types don't model `advanceable`](https://cplusplus.github.io/LWG/issue3597)
     - C++23で、1引数コンストラクタ(2)の事前条件に、2引数版と同様の`totally_ordered_with<W, Bound>`ならば`bool(value <= Bound())`が`true`という条件が追加された（符号なし整数のラップアラウンドで到達不能になる問題への対処）

--- a/reference/ranges/viewable_range.md
+++ b/reference/ranges/viewable_range.md
@@ -24,9 +24,12 @@ namespace std::ranges {
 Rangeアダプタを適用するには、`viewable_range`である必要がある。
 
 ## モデル
-型`T`が`viewable_range`のモデルとなるのは、`T`が[`range`](range.md)のモデルであり、かつ`T`が[`borrowed_range`](borrowed_range.md)のモデルであるか、[`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<T>`が[`view`](view.md)のモデルである場合である。
+型`T`が`viewable_range`のモデルとなるのは、`T`が[`range`](range.md)のモデルであり、かつ以下のいずれかを満たす場合である。
 
-[`borrowed_range`](borrowed_range.md)または[`view`](view.md)ではない[`range`](range.md)の右辺値は、`viewable_range`のモデルにはならない。
+- [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<T>`が[`view`](view.md)のモデルであり、かつ`T`から[`constructible_from`](/reference/concepts/constructible_from.md)`<remove_cvref_t<T>, T>`である（ムーブ専用の`view`の左辺値も安全に扱えるようにするための条件）
+- [`remove_cvref_t`](/reference/type_traits/remove_cvref.md)`<T>`が[`view`](view.md)のモデルではなく、`T`が左辺値参照であるか、または[`remove_reference_t`](/reference/type_traits/remove_reference.md)`<T>`が[`movable`](/reference/concepts/movable.md)でありかつ[`initializer_list`](/reference/initializer_list/initializer_list.md)の特殊化ではない
+
+[`view`](view.md)でも左辺値でもない[`range`](range.md)の右辺値のうち、ムーブできないものは`viewable_range`のモデルにはならない。
 
 ## 例
 (執筆中)
@@ -48,4 +51,5 @@ Rangeアダプタを適用するには、`viewable_range`である必要があ�
 - [N4861 24 Ranges library](https://timsong-cpp.github.io/cppwp/n4861/ranges)
 - [C++20 ranges](https://techbookfest.org/product/5134506308665344)
 - [LWG Issue 3481 `viewable_range` mishandles lvalue move-only views](https://cplusplus.github.io/LWG/lwg-defects.html#3481)
+    - C++23で、`view`の場合に`constructible_from<remove_cvref_t<T>, T>`を要求するようコンセプト定義が変更され、ムーブ専用の`view`の左辺値も`views::all`で扱えるようになった
 - [P2415R2 What is a `view`?](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2021/p2415r2.html) (本提案文書はC++20に遡って適用されている)

--- a/reference/string/char_traits.md
+++ b/reference/string/char_traits.md
@@ -114,7 +114,23 @@ namespace std {
 
 
 ## 備考
-このクラスは、フリースタンディング処理系でも使用できる。
+- このクラスは、フリースタンディング処理系でも使用できる。
+- `char_traits`（およびユーザー定義の同等クラス）が備えるべき静的メンバ関数の呼び出しは、例外を送出してはならない。この要件の対象範囲は、バージョンによって以下のように規定されている。
+    - C++20まで : 「`char_traits`型に対する操作は例外を投げてはならない」と規定されていた。この「操作」の範囲は明確でなかった
+    - C++23 : 例外を送出してはならない対象が、上記の「静的メンバ関数」に挙げた以下の各関数の呼び出しに限定されることが明確化された
+        - [`assign()`](char_traits/assign.md)
+        - [`eq()`](char_traits/eq.md)
+        - [`lt()`](char_traits/lt.md)
+        - [`compare()`](char_traits/compare.md)
+        - [`length()`](char_traits/length.md)
+        - [`find()`](char_traits/find.md)
+        - [`move()`](char_traits/move.md)
+        - [`copy()`](char_traits/copy.md)
+        - [`not_eof()`](char_traits/not_eof.md)
+        - [`to_char_type()`](char_traits/to_char_type.md)
+        - [`to_int_type()`](char_traits/to_int_type.md)
+        - [`eq_int_type()`](char_traits/eq_int_type.md)
+        - [`eof()`](char_traits/eof.md)
 
 ## 例
 ### 基本的な使い方
@@ -237,3 +253,5 @@ equal
 ## 参照
 - [P1614R2 The Mothership has Landed](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2019/p1614r2.html)
     - C++20での三方比較演算子の追加と、関連する演算子の自動導出
+- [LWG Issue 3518. Exception requirements on char trait operations unclear](https://cplusplus.github.io/LWG/issue3518)
+    - C++23で、例外を送出してはならない対象が、character traits要件で規定された式に限定されることが明確化された


### PR DESCRIPTION
- [P2385R0 C++ Standard Library Issues to be moved in Virtual Plenary, June 2021](https://wg21.link/p2385r0)

これに対応しました。